### PR TITLE
Requeue multiple jobs

### DIFF
--- a/scale/docs/interface/rest/job.rst
+++ b/scale/docs/interface/rest/job.rst
@@ -37,6 +37,9 @@ These services provide access to information about "all", "currently running" an
 | status             | String            | Optional | Return only jobs with a status matching this string.                |
 |                    |                   |          | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].            |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_id             | Integer           | Optional | Return only jobs with a given identifier.                           |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
 | job_type_id        | Integer           | Optional | Return only jobs with a given job type identifier.                  |
 |                    |                   |          | Duplicate it to filter by multiple values.                          |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
@@ -581,6 +584,10 @@ These services provide access to information about "all", "currently running" an
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .job_type          | JSON Object       | The job type that is associated with the job.                                  |
 |                    |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .job_type_rev      | JSON Object       | The job type revision that is associated with the job.                         |
+|                    |                   | This represents the definition at the time the job was scheduled.              |
+|                    |                   | (See :ref:`Job Type Revision Details <rest_job_type_rev_details>`)             |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .event             | JSON Object       | The trigger event that is associated with the job.                             |
 |                    |                   | (See :ref:`Trigger Event Details <rest_trigger_event_details>`)                |

--- a/scale/docs/interface/rest/queue.rst
+++ b/scale/docs/interface/rest/queue.rst
@@ -695,257 +695,104 @@ place jobs and recipes on the queue for processing.
 +-------------------------------------------------------------------------------------------------------------------------+
 
 +-------------------------------------------------------------------------------------------------------------------------+
-| **Requeue Existing Job**                                                                                                |
+| **Requeue Jobs**                                                                                                        |
 +=========================================================================================================================+
-| Increases the maximum failure allowance for an existing failed or canceled job and puts it back on the queue.           |
+| Increases the maximum failure allowance for existing jobs and puts them back on the queue.                              |
 +-------------------------------------------------------------------------------------------------------------------------+
-| **POST** /queue/requeue-job/                                                                                            |
-+--------------------+----------------------------------------------------------------------------------------------------+
-| **Location**       | URL pointing to the details for the newly queued job execution                                     |
+| **POST** /queue/requeue-jobs/                                                                                           |
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **Content Type**   | *application/json*                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **JSON Fields**                                                                                                         |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| job_id             | Integer           | The ID of the job to be requeued.                                              |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| started            | ISO-8601 Datetime | Optional | The start of the time range to query.                               |
+|                    |                   |          | Supports the ISO-8601 date/time format, (ex: 2015-01-01T00:00:00Z). |
+|                    |                   |          | Supports the ISO-8601 duration format, (ex: PT3H0M0S).              |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| ended              | ISO-8601 Datetime | Optional | End of the time range to query, defaults to the current time.       |
+|                    |                   |          | Supports the ISO-8601 date/time format, (ex: 2015-01-01T00:00:00Z). |
+|                    |                   |          | Supports the ISO-8601 duration format, (ex: PT3H0M0S).              |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| status             | String            | Optional | Queue only jobs with a status matching these strings.               |
+|                    |                   |          | Choices: [CANCELED, FAILED].                                        |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_ids            | Array[Integer]    | Optional | Queue only jobs with a given identifier.                            |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_type_ids       | Array[Integer]    | Optional | Queue only jobs with a given job type identifier.                   |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_type_names     | Array[String]     | Optional | Queue only jobs with a given job type name.                         |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_type_categories| Array[String]     | Optional | Queue only jobs with a given job type category.                     |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| priority           | Integer           | Optional | Change the priority of matching jobs when adding them to the queue. |
+|                    |                   |          | Defaults to jobs current priority, lower number is higher priority. |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **Status**         | 200 OK                                                                                             |
 +--------------------+----------------------------------------------------------------------------------------------------+
-| **Location**       | URL pointing to the details for the newly queued job execution                                     |
-+--------------------+----------------------------------------------------------------------------------------------------+
 | **Content Type**   | *application/json*                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **JSON Fields**                                                                                                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-|                    | JSON Object       | All fields are the same as the job details model.                              |
+|                    | JSON Object       | All fields are the same as the jobs model.                                     |
 |                    |                   | The status will be PENDING or BLOCKED if the job has never been queued.        |
 |                    |                   | The status will be QUEUED if the job has been previously queued.               |
-|                    |                   | There will be an additional job_exe if the job was immediately queued.         |
-|                    |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
+|                    |                   | (See :ref:`Job List <rest_job_list>`)                                          |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .. code-block:: javascript                                                                                              |
 |                                                                                                                         |
 |    {                                                                                                                    |
-|        "id": 15096,                                                                                                     |
-|        "job_type": {                                                                                                    |
-|            "id": 8,                                                                                                     |
-|            "name": "kml-footprint",                                                                                     |
-|            "version": "1.0.0",                                                                                          |
-|            "title": "KML Footprint",                                                                                    |
-|            "description": "Creates a KML representation of the data",                                                   |
-|            "is_system": false,                                                                                          |
-|            "is_long_running": false,                                                                                    |
-|            "is_active": true,                                                                                           |
-|            "is_operational": true,                                                                                      |
-|            "is_paused": false,                                                                                          |
-|            "icon_code": "f0ac",                                                                                         |
-|            "uses_docker": false,                                                                                        |
-|            "docker_privileged": false,                                                                                  |
-|            "docker_image": null,                                                                                        |
-|            "priority": 2,                                                                                               |
-|            "timeout": 600,                                                                                              |
-|            "max_tries": 1,                                                                                              |
-|            "cpus_required": 0.5,                                                                                        |
-|            "mem_required": 128.0,                                                                                       |
-|            "disk_out_const_required": 0.0,                                                                              |
-|            "disk_out_mult_required": 0.0,                                                                               |
-|            "created": "2015-06-01T00:00:00Z",                                                                           |
-|            "archived": null,                                                                                            |
-|            "paused": null,                                                                                              |
-|            "last_modified": "2015-06-01T00:00:00Z"                                                                      |
-|        },                                                                                                               |
-|        "job_type_rev": {                                                                                                |
-|            "id": 5,                                                                                                     |
-|            "job_type": {                                                                                                |
-|                "id": 8                                                                                                  |
-|            },                                                                                                           |
-|            "revision_num": 1,                                                                                           |
-|            "interface": {                                                                                               |
-|                "input_data": [                                                                                          |
-|                    {                                                                                                    |
-|                        "type": "file",                                                                                  |
-|                        "name": "input_file"                                                                             |
-|                    }                                                                                                    |
-|                ],                                                                                                       |
-|                "output_data": [                                                                                         |
-|                    {                                                                                                    |
-|                        "media_type": "application/vnd.google-earth.kml+xml",                                            |
-|                        "type": "file",                                                                                  |
-|                        "name": "output_file"                                                                            |
-|                    }                                                                                                    |
-|                ],                                                                                                       |
-|                "version": "1.0",                                                                                        |
-|                "command": "/usr/local/bin/python2.7 /app/parser/manage.py create_footprint_kml",                        |
-|                "command_arguments": "${input_file} ${job_output_dir}"                                                   |
-|            },                                                                                                           |
-|            "created": "2015-11-06T00:00:00Z"                                                                            |
-|        },                                                                                                               |
-|        "event": {                                                                                                       |
-|            "id": 10278,                                                                                                 |
-|            "type": "PARSE",                                                                                             |
-|            "rule": {                                                                                                    |
-|                "id": 8,                                                                                                 |
-|                "type": "PARSE",                                                                                         |
-|                "is_active": true,                                                                                       |
-|                "created": "2015-08-28T18:31:29.282Z",                                                                   |
-|                "archived": null,                                                                                        |
-|                "last_modified": "2015-08-28T18:31:29.282Z"                                                              |
-|            },                                                                                                           |
-|            "occurred": "2015-09-01T17:27:31.467Z"                                                                       |
-|        },                                                                                                               |
-|        "error": null,                                                                                                   |
-|        "status": "COMPLETED",                                                                                           |
-|        "priority": 210,                                                                                                 |
-|        "num_exes": 1,                                                                                                   | 
-|        "timeout": 1800,                                                                                                 |
-|        "max_tries": 3,                                                                                                  |
-|        "cpus_required": 1.0,                                                                                            |
-|        "mem_required": 15360.0,                                                                                         |
-|        "disk_in_required": 2.0,                                                                                         |
-|        "disk_out_required": 16.0,                                                                                       |
-|        "created": "2015-08-28T17:55:41.005Z",                                                                           |
-|        "queued": "2015-08-28T17:56:41.005Z",                                                                            |
-|        "started": "2015-08-28T17:57:41.005Z",                                                                           |
-|        "ended": "2015-08-28T17:58:41.005Z",                                                                             |
-|        "last_status_change": "2015-08-28T17:58:45.906Z",                                                                |
-|        "last_modified": "2015-08-28T17:58:46.001Z",                                                                     |
-|        "data": {                                                                                                        |
-|            "input_data": [                                                                                              |
-|                {                                                                                                        |
-|                    "name": "input_file",                                                                                |
-|                    "file_id": 8480                                                                                      |
-|                }                                                                                                        |
-|            ],                                                                                                           |
-|            "version": "1.0",                                                                                            |
-|            "output_data": [                                                                                             |
-|                {                                                                                                        |
-|                    "name": "output_file",                                                                               |
-|                    "workspace_id": 2                                                                                    |
-|                }                                                                                                        |
-|            ]                                                                                                            |
-|        },                                                                                                               |
-|        "results": {                                                                                                     |
-|            "output_data": [                                                                                             |
-|                {                                                                                                        |
-|                    "name": "output_file",                                                                               |
-|                    "file_id": 8484                                                                                      |
-|                }                                                                                                        |
-|            ],                                                                                                           |
-|            "version": "1.0"                                                                                             |
-|        },                                                                                                               |
-|        "input_files": [                                                                                                 |
+|        "count": 68,                                                                                                     |
+|        "next": null,                                                                                                    |
+|        "previous": null,                                                                                                |
+|        "results": [                                                                                                     |
 |            {                                                                                                            |
-|                "id": 2,                                                                                                 |
-|                "workspace": {                                                                                           |
+|                "id": 3,                                                                                                 |
+|                "job_type": {                                                                                            |
 |                    "id": 1,                                                                                             |
-|                    "name": "Raw Source"                                                                                 |
+|                    "name": "scale-ingest",                                                                              |
+|                    "version": "1.0",                                                                                    |
+|                    "title": "Scale Ingest",                                                                             |
+|                    "description": "Ingests a source file into a workspace",                                             |
+|                    "is_system": true,                                                                                   |
+|                    "is_long_running": false,                                                                            |
+|                    "is_active": true,                                                                                   |
+|                    "is_operational": true,                                                                              |
+|                    "is_paused": false,                                                                                  |
+|                    "icon_code": "f013"                                                                                  |
 |                },                                                                                                       |
-|                "file_name": "input_file.txt",                                                                           | 
-|                "media_type": "text/plain",                                                                              |
-|                "file_size": 1234,                                                                                       |
-|                "data_type": [],                                                                                         | 
-|                "is_deleted": false,                                                                                     |
-|                "uuid": "c8928d9183fc99122948e7840ec9a0fd",                                                              |
-|                "url": "http://host.com/input_file.txt",                                                                 |
-|                "created": "2015-09-10T15:24:53.962Z",                                                                   |
-|                "deleted": null,                                                                                         |
-|                "data_started": "2015-09-10T14:50:49Z",                                                                  |
-|                "data_ended": "2015-09-10T14:51:05Z",                                                                    |
-|                "geometry": null,                                                                                        |
-|                "center_point": null,                                                                                    |
-|                "meta_data": {...}                                                                                       |
-|                "last_modified": "2015-09-10T15:25:02.808Z"                                                              |
-|            }                                                                                                            |
-|        ],                                                                                                               |
-|        "recipes": [                                                                                                     |
-|            {                                                                                                            |
-|                "id": 4832,                                                                                              |
-|                "recipe_type": {                                                                                         |
-|                    "id": 6,                                                                                             |
-|                    "name": "Recipe",                                                                                    |
-|                    "version": "1.0.0",                                                                                  |
-|                    "description": "Recipe description"                                                                  |
+|                "job_type_rev": {                                                                                        |
+|                    "id": 5,                                                                                             |
+|                    "job_type": {                                                                                        |
+|                        "id": 1                                                                                          |
+|                    },                                                                                                   |
+|                    "revision_num": 1                                                                                    |
 |                },                                                                                                       |
 |                "event": {                                                                                               |
-|                    "id": 7,                                                                                             |
-|                    "type": "PARSE",                                                                                     |
-|                    "rule": {                                                                                            |
-|                        "id": 2                                                                                          |
-|                    },                                                                                                   |
-|                    "occurred": "2015-08-28T17:58:45.280Z"                                                               |
+|                    "id": 3,                                                                                             |
+|                    "type": "STRIKE_TRANSFER",                                                                           |
+|                    "rule": null,                                                                                        |
+|                    "occurred": "2015-08-28T17:57:24.261Z"                                                               |
 |                },                                                                                                       |
-|                "created": "2015-09-01T20:32:20.912Z",                                                                   |
-|                "completed": "2015-09-01T20:35:20.912Z",                                                                 |
-|                "last_modified": "2015-09-01T20:35:20.912Z"                                                              |
-|            }                                                                                                            |
-|        ],                                                                                                               |
-|        "job_exes": [                                                                                                    |
-|            {                                                                                                            |
-|                "id": 14552,                                                                                             |
-|                "status": "COMPLETED",                                                                                   |
-|                "command_arguments": "${input_file} ${job_output_dir}",                                                  |
+|                "error": null,                                                                                           |
+|                "status": "QUEUED",                                                                                      |
+|                "priority": 10,                                                                                          |
+|                "num_exes": 1,                                                                                           |
 |                "timeout": 1800,                                                                                         |
-|                "pre_started": "2015-09-01T17:27:32.435Z",                                                               |
-|                "pre_completed": "2015-09-01T17:27:34.346Z",                                                             |
-|                "pre_exit_code": null,                                                                                   |
-|                "job_started": "2015-09-01T17:27:42.437Z",                                                               |
-|                "job_completed": "2015-09-01T17:27:46.762Z",                                                             |
-|                "job_exit_code": null,                                                                                   |
-|                "post_started": "2015-09-01T17:27:47.246Z",                                                              |
-|                "post_completed": "2015-09-01T17:27:49.461Z",                                                            |
-|                "post_exit_code": null,                                                                                  |
-|                "created": "2015-09-01T17:27:31.753Z",                                                                   |
-|                "queued": "2015-09-01T17:27:31.716Z",                                                                    |
-|                "started": "2015-09-01T17:27:32.022Z",                                                                   |
-|                "ended": "2015-09-01T17:27:49.461Z",                                                                     |
-|                "last_modified": "2015-09-01T17:27:49.606Z",                                                             |
-|                "job": {                                                                                                 |
-|                    "id": 15586                                                                                          |
-|                },                                                                                                       |
-|                "node": {                                                                                                |
-|                    "id": 1                                                                                              |
-|                },                                                                                                       |
-|                "error": null                                                                                            |
-|            }                                                                                                            |
-|        ],                                                                                                               |
-|        "products": [                                                                                                    |
-|            {                                                                                                            |
-|                "id": 8484,                                                                                              |
-|                "workspace": {                                                                                           |
-|                    "id": 2,                                                                                             | 
-|                    "name": "Products"                                                                                   | 
-|                },                                                                                                       |
-|                "file_name": "file.kml",                                                                                 |
-|                "media_type": "application/vnd.google-earth.kml+xml",                                                    |
-|                "file_size": 1234,                                                                                       |
-|                "data_type": [],                                                                                         |
-|                "is_deleted": false,                                                                                     |
-|                "uuid": "c8928d9183fc99122948e7840ec9a0fd",                                                              |
-|                "url": "http://host.com/file/path/my_file.kml",                                                          | 
-|                "created": "2015-09-01T17:27:48.477Z",                                                                   | 
-|                "deleted": null,                                                                                         |
-|                "data_started": null,                                                                                    |
-|                "data_ended": null,                                                                                      |
-|                "geometry": null,                                                                                        |
-|                "center_point": null,                                                                                    | 
-|                "meta_data": {},                                                                                         |
-|                "last_modified": "2015-09-01T17:27:49.639Z",                                                             |
-|                "is_operational": true,                                                                                  |
-|                "is_published": true,                                                                                    |
-|                "published": "2015-09-01T17:27:49.461Z",                                                                 |
-|                "unpublished": null,                                                                                     |
-|                "job_type": {                                                                                            |
-|                    "id": 8                                                                                              |
-|                },                                                                                                       |
-|                "job": {                                                                                                 |
-|                    "id": 35                                                                                             |
-|                },                                                                                                       |
-|                "job_exe": {                                                                                             |
-|                    "id": 19                                                                                             |
-|                }                                                                                                        |
-|            }                                                                                                            |
+|                "max_tries": 3,                                                                                          |
+|                "cpus_required": 1.0,                                                                                    |
+|                "mem_required": 64.0,                                                                                    |
+|                "disk_in_required": 0.0,                                                                                 |
+|                "disk_out_required": 64.0,                                                                               |
+|                "created": "2015-08-28T17:55:41.005Z",                                                                   |
+|                "queued": "2015-08-28T17:56:41.005Z",                                                                    |
+|                "started": "2015-08-28T17:57:41.005Z",                                                                   |
+|                "ended": "2015-08-28T17:58:41.005Z",                                                                     |
+|                "last_status_change": "2015-08-28T17:58:45.906Z",                                                        |
+|                "last_modified": "2015-08-28T17:58:46.001Z"                                                              |
+|            },                                                                                                           |
+|            ...                                                                                                          |
 |        ]                                                                                                                |
 |    }                                                                                                                    |
 +-------------------------------------------------------------------------------------------------------------------------+

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -92,7 +92,7 @@ class JobManager(models.Manager):
 
         return job
 
-    def get_jobs(self, started=None, ended=None, status=None, job_type_ids=None, job_type_names=None,
+    def get_jobs(self, started=None, ended=None, status=None, job_ids=None, job_type_ids=None, job_type_names=None,
                  job_type_categories=None, order=None):
         """Returns a list of jobs within the given time range.
 
@@ -102,6 +102,8 @@ class JobManager(models.Manager):
         :type ended: :class:`datetime.datetime`
         :param status: Query jobs with the a specific execution status.
         :type status: str
+        :param job_ids: Query jobs associated with the identifier.
+        :type job_ids: list[int]
         :param job_type_ids: Query jobs of the type associated with the identifier.
         :type job_type_ids: list[int]
         :param job_type_names: Query jobs of the type associated with the name.
@@ -126,6 +128,8 @@ class JobManager(models.Manager):
 
         if status:
             jobs = jobs.filter(status=status)
+        if job_ids:
+            jobs = jobs.filter(id__in=job_ids)
         if job_type_ids:
             jobs = jobs.filter(job_type_id__in=job_type_ids)
         if job_type_names:
@@ -181,8 +185,8 @@ class JobManager(models.Manager):
         self.populate_input_files([job])
         return job
 
-    def get_job_updates(self, started=None, ended=None, status=None, job_type_ids=None, job_type_names=None,
-                        job_type_categories=None, order=None):
+    def get_job_updates(self, started=None, ended=None, status=None, job_type_ids=None,
+                        job_type_names=None, job_type_categories=None, order=None):
         """Returns a list of jobs that changed status within the given time range.
 
         :param started: Query jobs updated after this amount of time.
@@ -204,7 +208,8 @@ class JobManager(models.Manager):
         """
         if not order:
             order = ['last_status_change']
-        return self.get_jobs(started, ended, status, job_type_ids, job_type_names, job_type_categories, order)
+        return self.get_jobs(started=started, ended=ended, status=status, job_type_ids=job_type_ids,
+                             job_type_names=job_type_names, job_type_categories=job_type_categories, order=order)
 
     def get_locked_job(self, job_id):
         """Gets the job model with the given ID with a model lock obtained and related job_type and job_type_rev models

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -1,4 +1,3 @@
-#@PydevCodeAnalysisIgnore
 from __future__ import unicode_literals
 
 import datetime
@@ -30,7 +29,7 @@ class TestJobsView(TestCase):
         self.job2 = job_test_utils.create_job(job_type=self.job_type2, status='PENDING')
 
     def test_successful(self):
-        '''Tests successfully calling the jobs view.'''
+        """Tests successfully calling the jobs view."""
 
         url = '/jobs/'
         response = self.client.generic('GET', url)
@@ -50,7 +49,7 @@ class TestJobsView(TestCase):
             self.assertEqual(entry['job_type_rev']['job_type']['id'], expected.job_type.id)
 
     def test_status(self):
-        '''Tests successfully calling the jobs view filtered by status.'''
+        """Tests successfully calling the jobs view filtered by status."""
 
         url = '/jobs/?status=RUNNING'
         response = self.client.generic('GET', url)
@@ -60,8 +59,19 @@ class TestJobsView(TestCase):
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['job_type']['id'], self.job1.job_type.id)
 
+    def test_job_id(self):
+        """Tests successfully calling the jobs view filtered by job identifier."""
+
+        url = '/jobs/?job_id=%s' % self.job1.id
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['id'], self.job1.id)
+
     def test_job_type_id(self):
-        '''Tests successfully calling the jobs view filtered by job type identifier.'''
+        """Tests successfully calling the jobs view filtered by job type identifier."""
 
         url = '/jobs/?job_type_id=%s' % self.job1.job_type.id
         response = self.client.generic('GET', url)
@@ -72,7 +82,7 @@ class TestJobsView(TestCase):
         self.assertEqual(result['results'][0]['job_type']['id'], self.job1.job_type.id)
 
     def test_job_type_name(self):
-        '''Tests successfully calling the jobs view filtered by job type name.'''
+        """Tests successfully calling the jobs view filtered by job type name."""
 
         url = '/jobs/?job_type_name=%s' % self.job1.job_type.name
         response = self.client.generic('GET', url)
@@ -83,7 +93,7 @@ class TestJobsView(TestCase):
         self.assertEqual(result['results'][0]['job_type']['name'], self.job1.job_type.name)
 
     def test_job_type_category(self):
-        '''Tests successfully calling the jobs view filtered by job type category.'''
+        """Tests successfully calling the jobs view filtered by job type category."""
 
         url = '/jobs/?job_type_category=%s' % self.job1.job_type.category
         response = self.client.generic('GET', url)
@@ -94,7 +104,7 @@ class TestJobsView(TestCase):
         self.assertEqual(result['results'][0]['job_type']['category'], self.job1.job_type.category)
 
     def test_order_by(self):
-        '''Tests successfully calling the jobs view with sorting.'''
+        """Tests successfully calling the jobs view with sorting."""
 
         job_type1b = job_test_utils.create_job_type(name='test1', version='2.0', category='test-1')
         job_test_utils.create_job(job_type=job_type1b, status='RUNNING')
@@ -142,7 +152,7 @@ class TestJobDetailsView(TestCase):
             self.product = None
 
     def test_successful(self):
-        '''Tests successfully calling the jobs view.'''
+        """Tests successfully calling the jobs view."""
 
         url = '/jobs/%i/' % self.job.id
         response = self.client.generic('GET', url)
@@ -170,7 +180,7 @@ class TestJobDetailsView(TestCase):
             self.assertEqual(len(result['products']), 0)
 
     def test_cancel_successful(self):
-        '''Tests successfully cancelling a job.'''
+        """Tests successfully cancelling a job."""
 
         url = '/jobs/%i/' % self.job.id
         data = {'status': 'CANCELED'}
@@ -180,7 +190,7 @@ class TestJobDetailsView(TestCase):
         self.assertEqual(result['status'], 'CANCELED')
 
     def test_cancel_bad_param(self):
-        '''Tests successfully cancelling a job.'''
+        """Tests successfully cancelling a job."""
 
         url = '/jobs/%i/' % self.job.id
         data = {'foo': 'bar'}
@@ -188,7 +198,7 @@ class TestJobDetailsView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_cancel_bad_value(self):
-        '''Tests successfully cancelling a job.'''
+        """Tests successfully cancelling a job."""
 
         url = '/jobs/%i/' % self.job.id
         data = {'status': 'COMPLETED'}
@@ -216,7 +226,7 @@ class TestJobsUpdateView(TestCase):
         )
 
     def test_successful(self):
-        '''Tests successfully calling the jobs view.'''
+        """Tests successfully calling the jobs view."""
 
         url = '/jobs/updates/'
         response = self.client.generic('GET', url)
@@ -237,7 +247,7 @@ class TestJobsUpdateView(TestCase):
             self.assertEqual(entry['input_files'][0]['id'], self.file.id)
 
     def test_status(self):
-        '''Tests successfully calling the jobs view filtered by status.'''
+        """Tests successfully calling the jobs view filtered by status."""
 
         url = '/jobs/updates/?status=RUNNING'
         response = self.client.generic('GET', url)
@@ -248,7 +258,7 @@ class TestJobsUpdateView(TestCase):
         self.assertEqual(result['results'][0]['job_type']['id'], self.job1.job_type.id)
 
     def test_job_type_id(self):
-        '''Tests successfully calling the jobs view filtered by job type identifier.'''
+        """Tests successfully calling the jobs view filtered by job type identifier."""
 
         url = '/jobs/updates/?job_type_id=%s' % self.job1.job_type.id
         response = self.client.generic('GET', url)
@@ -259,7 +269,7 @@ class TestJobsUpdateView(TestCase):
         self.assertEqual(result['results'][0]['job_type']['id'], self.job1.job_type.id)
 
     def test_job_type_name(self):
-        '''Tests successfully calling the jobs view filtered by job type name.'''
+        """Tests successfully calling the jobs view filtered by job type name."""
 
         url = '/jobs/updates/?job_type_name=%s' % self.job1.job_type.name
         response = self.client.generic('GET', url)
@@ -270,7 +280,7 @@ class TestJobsUpdateView(TestCase):
         self.assertEqual(result['results'][0]['job_type']['name'], self.job1.job_type.name)
 
     def test_job_type_category(self):
-        '''Tests successfully calling the jobs view filtered by job type category.'''
+        """Tests successfully calling the jobs view filtered by job type category."""
 
         url = '/jobs/updates/?job_type_category=%s' % self.job1.job_type.category
         response = self.client.generic('GET', url)
@@ -292,7 +302,7 @@ class TestJobTypesView(TestCase):
         self.job_type2 = job_test_utils.create_job_type(priority=1, mem=2.0)
 
     def test_successful(self):
-        '''Tests successfully calling the get all job types view.'''
+        """Tests successfully calling the get all job types view."""
 
         url = '/job-types/'
         response = self.client.get(url)
@@ -313,7 +323,7 @@ class TestJobTypesView(TestCase):
             self.assertEqual(entry['max_scheduled'], expected.max_scheduled)
 
     def test_name(self):
-        '''Tests successfully calling the jobs view filtered by job type name.'''
+        """Tests successfully calling the jobs view filtered by job type name."""
 
         url = '/job-types/?name=%s' % self.job_type1.name
         response = self.client.generic('GET', url)
@@ -324,7 +334,7 @@ class TestJobTypesView(TestCase):
         self.assertEqual(result['results'][0]['name'], self.job_type1.name)
 
     def test_category(self):
-        '''Tests successfully calling the jobs view filtered by job type category.'''
+        """Tests successfully calling the jobs view filtered by job type category."""
 
         url = '/job-types/?category=%s' % self.job_type1.category
         response = self.client.generic('GET', url)
@@ -335,7 +345,7 @@ class TestJobTypesView(TestCase):
         self.assertEqual(result['results'][0]['category'], self.job_type1.category)
 
     def test_sorting(self):
-        '''Tests custom sorting.'''
+        """Tests custom sorting."""
 
         url = '/job-types/?order=priority'
         response = self.client.get(url)
@@ -347,7 +357,7 @@ class TestJobTypesView(TestCase):
         self.assertEqual(result['results'][0]['version'], self.job_type2.version)
 
     def test_reverse_sorting(self):
-        '''Tests custom sorting in reverse.'''
+        """Tests custom sorting in reverse."""
 
         url = '/job-types/?order=-mem_required'
         response = self.client.get(url)
@@ -359,7 +369,7 @@ class TestJobTypesView(TestCase):
         self.assertEqual(result['results'][0]['version'], self.job_type2.version)
 
     def test_create(self):
-        '''Tests creating a new job type.'''
+        """Tests creating a new job type."""
         url = '/job-types/'
         json_data = {
             'name': 'job-type-post-test',
@@ -397,7 +407,7 @@ class TestJobTypesView(TestCase):
         self.assertIsNone(results['max_scheduled'])
 
     def test_create_max_scheduled(self):
-        '''Tests creating a new job type.'''
+        """Tests creating a new job type."""
         url = '/job-types/'
         json_data = {
             'name': 'job-type-max_scheduled-test',
@@ -432,7 +442,7 @@ class TestJobTypesView(TestCase):
         self.assertEqual(results['max_scheduled'], 42)
 
     def test_create_trigger(self):
-        '''Tests creating a new job type with a trigger rule.'''
+        """Tests creating a new job type with a trigger rule."""
         url = '/job-types/'
         json_data = {
             'name': 'job-type-post-test',
@@ -480,7 +490,7 @@ class TestJobTypesView(TestCase):
         self.assertEqual(results['trigger_rule']['type'], 'PARSE')
 
     def test_create_missing_param(self):
-        '''Tests creating a job type with missing fields.'''
+        """Tests creating a job type with missing fields."""
         url = '/job-types/'
         json_data = {
             'name': 'job-type-post-test',
@@ -490,7 +500,7 @@ class TestJobTypesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_bad_param(self):
-        '''Tests creating a job type with invalid type fields.'''
+        """Tests creating a job type with invalid type fields."""
         url = '/job-types/'
         json_data = {
             'name': 'job-type-post-test',
@@ -512,7 +522,7 @@ class TestJobTypesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_bad_error(self):
-        '''Tests creating a new job type with an invalid error relationship.'''
+        """Tests creating a new job type with an invalid error relationship."""
         url = '/job-types/'
         json_data = {
             'name': 'job-type-post-test',
@@ -538,7 +548,7 @@ class TestJobTypesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_bad_trigger_type(self):
-        '''Tests creating a new job type with an invalid trigger type.'''
+        """Tests creating a new job type with an invalid trigger type."""
         url = '/job-types/'
         json_data = {
             'name': 'job-type-post-test',
@@ -562,7 +572,7 @@ class TestJobTypesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_bad_trigger_config(self):
-        '''Tests creating a new job type with an invalid trigger rule configuration.'''
+        """Tests creating a new job type with an invalid trigger rule configuration."""
         url = '/job-types/'
         json_data = {
             'name': 'job-type-post-test',
@@ -631,7 +641,7 @@ class TestJobTypeDetailsView(TestCase):
         self.error2 = error_test_utils.create_error()
 
     def test_not_found(self):
-        '''Tests successfully calling the get job type details view with a job id that does not exist.'''
+        """Tests successfully calling the get job type details view with a job id that does not exist."""
 
         url = '/job-types/100/'
         response = self.client.get(url)
@@ -639,7 +649,7 @@ class TestJobTypeDetailsView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_successful(self):
-        '''Tests successfully calling the get job type details view.'''
+        """Tests successfully calling the get job type details view."""
 
         url = '/job-types/%d/' % self.job_type.id
         response = self.client.get(url)
@@ -662,7 +672,7 @@ class TestJobTypeDetailsView(TestCase):
         self.assertEqual(len(result['job_counts_24h']), 0)
 
     def test_edit_simple(self):
-        '''Tests editing only the basic attributes of a job type'''
+        """Tests editing only the basic attributes of a job type"""
 
         url = '/job-types/%d/' % self.job_type.id
         json_data = {
@@ -683,7 +693,7 @@ class TestJobTypeDetailsView(TestCase):
         self.assertEqual(result['trigger_rule']['id'], self.trigger_rule.id)
 
     def test_edit_interface(self):
-        '''Tests editing the interface of a job type'''
+        """Tests editing the interface of a job type"""
         interface = self.interface.copy()
         interface['command'] = 'test_cmd_edit'
 
@@ -702,7 +712,7 @@ class TestJobTypeDetailsView(TestCase):
         self.assertEqual(result['trigger_rule']['id'], self.trigger_rule.id)
 
     def test_edit_error_mapping(self):
-        '''Tests editing the error mapping of a job type'''
+        """Tests editing the error mapping of a job type"""
         error = error_test_utils.create_error(category='DATA')
         error_mapping = self.error_mapping.copy()
         error_mapping['exit_codes']['10'] = error.name
@@ -722,7 +732,7 @@ class TestJobTypeDetailsView(TestCase):
         self.assertEqual(result['trigger_rule']['id'], self.trigger_rule.id)
 
     def test_edit_trigger_rule(self):
-        '''Tests editing the trigger rule of a job type'''
+        """Tests editing the trigger rule of a job type"""
         trigger_config = self.trigger_config.copy()
         trigger_config['condition']['media_type'] = 'application/json'
 
@@ -745,7 +755,7 @@ class TestJobTypeDetailsView(TestCase):
         self.assertNotEqual(result['trigger_rule']['id'], self.trigger_rule.id)
 
     def test_edit_trigger_rule_pause(self):
-        '''Tests pausing the trigger rule of a job type'''
+        """Tests pausing the trigger rule of a job type"""
         trigger_config = self.trigger_config.copy()
         trigger_config['condition']['media_type'] = 'application/json'
 
@@ -766,7 +776,7 @@ class TestJobTypeDetailsView(TestCase):
         self.assertEqual(result['trigger_rule']['is_active'], False)
 
     def test_edit_trigger_rule_remove(self):
-        '''Tests removing the trigger rule from a job type'''
+        """Tests removing the trigger rule from a job type"""
         url = '/job-types/%d/' % self.job_type.id
         json_data = {
             'trigger_rule': None,
@@ -782,7 +792,7 @@ class TestJobTypeDetailsView(TestCase):
         self.assertIsNone(result['trigger_rule'])
 
     def test_edit_interface_and_trigger_rule(self):
-        '''Tests editing the job type interface and trigger rule together'''
+        """Tests editing the job type interface and trigger rule together"""
         interface = self.interface.copy()
         interface['command'] = 'test_cmd_edit'
         trigger_config = self.trigger_config.copy()
@@ -808,7 +818,7 @@ class TestJobTypeDetailsView(TestCase):
         self.assertNotEqual(result['trigger_rule']['id'], self.trigger_rule.id)
 
     def test_edit_bad_interface(self):
-        '''Tests attempting to edit a job type using an invalid job interface'''
+        """Tests attempting to edit a job type using an invalid job interface"""
         interface = self.interface.copy()
         interface['version'] = 'BAD'
 
@@ -821,7 +831,7 @@ class TestJobTypeDetailsView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_edit_bad_error_mapping(self):
-        '''Tests attempting to edit a job type using an invalid error mapping'''
+        """Tests attempting to edit a job type using an invalid error mapping"""
         error_mapping = self.error_mapping.copy()
         error_mapping['version'] = 'BAD'
 
@@ -834,7 +844,7 @@ class TestJobTypeDetailsView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_edit_bad_trigger(self):
-        '''Tests attempting to edit a job type using an invalid trigger rule'''
+        """Tests attempting to edit a job type using an invalid trigger rule"""
         trigger_config = self.trigger_config.copy()
         trigger_config['version'] = 'BAD'
 
@@ -851,7 +861,7 @@ class TestJobTypeDetailsView(TestCase):
 
 
 class TestJobTypesValidationView(TransactionTestCase):
-    '''Tests related to the job-types validation endpoint'''
+    """Tests related to the job-types validation endpoint"""
 
     def setUp(self):
         django.setup()
@@ -860,7 +870,7 @@ class TestJobTypesValidationView(TransactionTestCase):
         self.error = error_test_utils.create_error(category='ALGORITHM')
 
     def test_successful(self):
-        '''Tests validating a new job type.'''
+        """Tests validating a new job type."""
         url = '/job-types/validation/'
         json_data = {
             'name': 'job-type-test',
@@ -890,7 +900,7 @@ class TestJobTypesValidationView(TransactionTestCase):
         self.assertDictEqual(results, {'warnings': []}, 'JSON result was incorrect')
 
     def test_successful_trigger(self):
-        '''Tests validating a new job type with a trigger.'''
+        """Tests validating a new job type with a trigger."""
         url = '/job-types/validation/'
         json_data = {
             'name': 'job-type-test',
@@ -928,7 +938,7 @@ class TestJobTypesValidationView(TransactionTestCase):
         self.assertDictEqual(results, {'warnings': []}, 'JSON result was incorrect')
 
     def test_bad_param(self):
-        '''Tests validating a new job type with missing fields.'''
+        """Tests validating a new job type with missing fields."""
         url = '/job-types/validation/'
         json_data = {
             'name': 'job-type-post-test',
@@ -938,7 +948,7 @@ class TestJobTypesValidationView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_bad_error(self):
-        '''Tests validating a new job type with an invalid error relationship.'''
+        """Tests validating a new job type with an invalid error relationship."""
         url = '/job-types/validation/'
         json_data = {
             'name': 'job-type-post-test',
@@ -956,7 +966,7 @@ class TestJobTypesValidationView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_warnings(self):
-        '''Tests validating a new job type with mismatched media type warnings.'''
+        """Tests validating a new job type with mismatched media type warnings."""
         url = '/job-types/validation/'
         json_data = {
             'name': 'job-type-post-test',
@@ -996,7 +1006,7 @@ class TestJobTypesValidationView(TransactionTestCase):
         self.assertEqual(results['warnings'][0]['id'], 'media_type')
 
     def test_bad_trigger_type(self):
-        '''Tests validating a new job type with an invalid trigger type.'''
+        """Tests validating a new job type with an invalid trigger type."""
         url = '/job-types/validation/'
         json_data = {
             'name': 'job-type-post-test',
@@ -1020,7 +1030,7 @@ class TestJobTypesValidationView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_bad_trigger_config(self):
-        '''Tests validating a new job type with an invalid trigger rule configuration.'''
+        """Tests validating a new job type with an invalid trigger rule configuration."""
         url = '/job-types/validation/'
         json_data = {
             'name': 'job-type-post-test',
@@ -1055,7 +1065,7 @@ class TestJobTypesStatusView(TestCase):
         self.job_type = job_test_utils.create_job_type()
 
     def test_successful(self):
-        '''Tests successfully calling the status view.'''
+        """Tests successfully calling the status view."""
         job = job_test_utils.create_job(job_type=self.job_type, status='COMPLETED')
 
         url = '/job-types/status/'
@@ -1070,7 +1080,7 @@ class TestJobTypesStatusView(TestCase):
         self.assertEqual(result['results'][0]['job_counts'][0]['count'], 1)
 
     def test_running(self):
-        '''Tests getting running jobs regardless of time filters.'''
+        """Tests getting running jobs regardless of time filters."""
         old_timestamp = datetime.datetime(2015, 1, 1, tzinfo=timezone.utc)
         job_test_utils.create_job(job_type=self.job_type, status='COMPLETED', last_status_change=old_timestamp)
         job_test_utils.create_job(job_type=self.job_type, status='RUNNING', last_status_change=old_timestamp)
@@ -1104,7 +1114,7 @@ class TestJobTypesRunningView(TestCase):
         self.job = job_test_utils.create_job(status='RUNNING')
 
     def test_successful(self):
-        '''Tests successfully calling the running status view.'''
+        """Tests successfully calling the running status view."""
 
         url = '/job-types/running/'
         response = self.client.generic('GET', url)
@@ -1126,7 +1136,7 @@ class TestJobTypesSystemFailuresView(TestCase):
         self.job = job_test_utils.create_job(status='FAILED', error=self.error)
 
     def test_successful(self):
-        '''Tests successfully calling the system failures view.'''
+        """Tests successfully calling the system failures view."""
 
         url = '/job-types/system-failures/'
         response = self.client.generic('GET', url)
@@ -1140,7 +1150,7 @@ class TestJobTypesSystemFailuresView(TestCase):
 
 
 class TestJobsWithExecutionView(TransactionTestCase):
-    '''An integration test of the Jobs with latest execution view'''
+    """An integration test of the Jobs with latest execution view"""
 
     def setUp(self):
         django.setup()
@@ -1185,7 +1195,7 @@ class TestJobsWithExecutionView(TransactionTestCase):
         self.last_run_2b = job_test_utils.create_job_exe(job=self.job_2b, status='COMPLETED')
 
     def test_get_latest_job_exes(self):
-        '''Tests calling the jobs information service without a filter'''
+        """Tests calling the jobs information service without a filter"""
 
         job_map = {
             self.job_1a.id: (self.job_1a, self.job_type_1, self.last_run_1a),
@@ -1300,7 +1310,7 @@ class TestJobExecutionsView(TransactionTestCase):
         job_test_utils.create_job_exe(job=job_4, status='COMPLETED')
 
     def test_get_job_executions(self):
-        '''This test checks to make sure there are 10 job executions.'''
+        """This test checks to make sure there are 10 job executions."""
         url = '/job-executions/'
         response = self.client.generic('GET', url)
         results = json.loads(response.content)
@@ -1311,7 +1321,7 @@ class TestJobExecutionsView(TransactionTestCase):
         self.assertEqual(job_exe_count, 10)
 
     def test_get_job_executions_running_status(self):
-        '''This test checks to make sure there are 2 job executions running.'''
+        """This test checks to make sure there are 2 job executions running."""
         url = '/job-executions/?status=RUNNING'
         response = self.client.generic('GET', url)
         results = json.loads(response.content)

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -32,17 +32,17 @@ logger = logging.getLogger(__name__)
 
 
 class JobTypesView(APIView):
-    '''This view is the endpoint for retrieving the list of all job types.'''
+    """This view is the endpoint for retrieving the list of all job types."""
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request):
-        '''Retrieves the list of all job types and returns it in JSON form
+        """Retrieves the list of all job types and returns it in JSON form
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
 
         started = rest_util.parse_timestamp(request, 'started', required=False)
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
@@ -59,13 +59,13 @@ class JobTypesView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def post(self, request):
-        '''Creates a new job type and returns a link to the detail URL
+        """Creates a new job type and returns a link to the detail URL
 
         :param request: the HTTP POST request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
         name = rest_util.parse_string(request, 'name')
         version = rest_util.parse_string(request, 'version')
 
@@ -138,11 +138,11 @@ class JobTypesView(APIView):
 
 
 class JobTypeDetailsView(APIView):
-    '''This view is the endpoint for retrieving/updating details of a job type.'''
+    """This view is the endpoint for retrieving/updating details of a job type."""
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request, job_type_id):
-        '''Retrieves the details for a job type and return them in JSON form
+        """Retrieves the details for a job type and return them in JSON form
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
@@ -150,7 +150,7 @@ class JobTypeDetailsView(APIView):
         :type job_type_id: int encoded as a str
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
         try:
             job_type = JobType.objects.get_details(job_type_id)
         except JobType.DoesNotExist:
@@ -160,7 +160,7 @@ class JobTypeDetailsView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def patch(self, request, job_type_id):
-        '''Edits an existing job type and returns the updated details
+        """Edits an existing job type and returns the updated details
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
@@ -168,7 +168,7 @@ class JobTypeDetailsView(APIView):
         :type job_type_id: int encoded as a str
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
 
         # Validate the job interface
         interface_dict = rest_util.parse_dict(request, 'interface', required=False)
@@ -258,18 +258,18 @@ class JobTypeDetailsView(APIView):
 
 
 class JobTypesValidationView(APIView):
-    '''This view is the endpoint for validating a new job type before attempting to actually create it
-    '''
+    """This view is the endpoint for validating a new job type before attempting to actually create it
+    """
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def post(self, request):
-        '''Validates a new job type and returns any warnings discovered
+        """Validates a new job type and returns any warnings discovered
 
         :param request: the HTTP POST request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
         name = rest_util.parse_string(request, 'name')
         version = rest_util.parse_string(request, 'version')
 
@@ -333,17 +333,17 @@ class JobTypesValidationView(APIView):
 
 
 class JobTypesRunningView(APIView):
-    '''This view is the endpoint for retrieving the status of all currently running job types.'''
+    """This view is the endpoint for retrieving the status of all currently running job types."""
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request):
-        '''Retrieves the current status of running job types and returns it in JSON form
+        """Retrieves the current status of running job types and returns it in JSON form
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
 
         # Get all the running job types with statistics
         running_status = JobType.objects.get_running_status()
@@ -355,17 +355,17 @@ class JobTypesRunningView(APIView):
 
 
 class JobTypesSystemFailuresView(APIView):
-    '''This view is the endpoint for viewing system errors organized by job type.'''
+    """This view is the endpoint for viewing system errors organized by job type."""
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request):
-        '''Retrieves the job types that have failed with system errors and returns them in JSON form
+        """Retrieves the job types that have failed with system errors and returns them in JSON form
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
 
         # Get all the failed job types with statistics
         failed_status = JobType.objects.get_failed_status()
@@ -377,18 +377,18 @@ class JobTypesSystemFailuresView(APIView):
 
 
 class JobTypesStatusView(APIView):
-    '''This view is the endpoint for retrieving overall job type status information.'''
+    """This view is the endpoint for retrieving overall job type status information."""
 
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request):
-        '''Retrieves the list of all job types with status and returns it in JSON form
+        """Retrieves the list of all job types with status and returns it in JSON form
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
 
         # Get a list of all job type status counts
         started = rest_util.parse_timestamp(request, 'started', 'PT3H0M0S')
@@ -401,31 +401,32 @@ class JobTypesStatusView(APIView):
 
 
 class JobsView(APIView):
-    '''This view is the endpoint for retrieving a list of all available jobs.'''
+    """This view is the endpoint for retrieving a list of all available jobs."""
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request):
-        '''Retrieves jobs and returns it in JSON form
+        """Retrieves jobs and returns it in JSON form
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
 
         started = rest_util.parse_timestamp(request, 'started', required=False)
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
 
         job_status = rest_util.parse_string(request, 'status', required=False)
+        job_ids = rest_util.parse_int_list(request, 'job_id', required=False)
         job_type_ids = rest_util.parse_int_list(request, 'job_type_id', required=False)
         job_type_names = rest_util.parse_string_list(request, 'job_type_name', required=False)
         job_type_categories = rest_util.parse_string_list(request, 'job_type_category', required=False)
 
         order = rest_util.parse_string_list(request, 'order', required=False)
 
-        jobs = Job.objects.get_jobs(started, ended, job_status, job_type_ids, job_type_names, job_type_categories,
-                                    order)
+        jobs = Job.objects.get_jobs(started, ended, job_status, job_ids, job_type_ids, job_type_names,
+                                    job_type_categories, order)
 
         page = rest_util.perform_paging(request, jobs)
         serializer = JobListSerializer(page, context={'request': request})
@@ -433,11 +434,11 @@ class JobsView(APIView):
 
 
 class JobDetailsView(APIView):
-    '''This view is the endpoint for retrieving details about a single job.'''
+    """This view is the endpoint for retrieving details about a single job."""
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request, job_id):
-        '''Retrieves jobs and returns it in JSON form
+        """Retrieves jobs and returns it in JSON form
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
@@ -445,7 +446,7 @@ class JobDetailsView(APIView):
         :type job_id: int encoded as a str
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
 
         try:
             job = Job.objects.get_details(job_id)
@@ -456,7 +457,7 @@ class JobDetailsView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def patch(self, request, job_id):
-        '''Modify job info with a subset of fields
+        """Modify job info with a subset of fields
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
@@ -464,7 +465,7 @@ class JobDetailsView(APIView):
         :type job_id: int encoded as a str
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
 
         # Validate that no extra fields are included
         rest_util.check_update(request, ['status'])
@@ -485,18 +486,18 @@ class JobDetailsView(APIView):
 
 
 class JobUpdatesView(APIView):
-    '''This view is the endpoint for retrieving job updates over a given time range.'''
+    """This view is the endpoint for retrieving job updates over a given time range."""
 
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request):
-        '''Retrieves the job updates for a given time range and returns it in JSON form
+        """Retrieves the job updates for a given time range and returns it in JSON form
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
         started = rest_util.parse_timestamp(request, 'started', required=False)
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
@@ -518,30 +519,31 @@ class JobUpdatesView(APIView):
 
 
 class JobsWithExecutionView(APIView):
-    '''This view is the endpoint for viewing jobs and their associated latest execution'''
+    """This view is the endpoint for viewing jobs and their associated latest execution"""
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request):
-        '''Gets jobs and their associated latest execution
+        """Gets jobs and their associated latest execution
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
         started = rest_util.parse_timestamp(request, 'started', required=False)
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
 
         job_status = rest_util.parse_string(request, 'status', required=False)
+        job_ids = rest_util.parse_int_list(request, 'job_id', required=False)
         job_type_ids = rest_util.parse_int_list(request, 'job_type_id', required=False)
         job_type_names = rest_util.parse_string_list(request, 'job_type_name', required=False)
         job_type_categories = rest_util.parse_string_list(request, 'job_type_category', required=False)
 
         order = rest_util.parse_string_list(request, 'order', required=False)
 
-        jobs = Job.objects.get_jobs(started, ended, job_status, job_type_ids, job_type_names, job_type_categories,
-                                    order)
+        jobs = Job.objects.get_jobs(started, ended, job_status, job_ids, job_type_ids, job_type_names,
+                                    job_type_categories, order)
         page = rest_util.perform_paging(request, jobs)
 
         # Add the latest execution for each matching job
@@ -556,17 +558,17 @@ class JobsWithExecutionView(APIView):
 
 
 class JobExecutionsView(APIView):
-    '''This view is the endpoint for viewing job executions and their associated job_type id, name, and version'''
+    """This view is the endpoint for viewing job executions and their associated job_type id, name, and version"""
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request):
-        '''Gets job executions and their associated job_type id, name, and version
+        """Gets job executions and their associated job_type id, name, and version
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
         started = rest_util.parse_timestamp(request, 'started', required=False)
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
@@ -589,11 +591,11 @@ class JobExecutionsView(APIView):
 
 
 class JobExecutionDetailsView(APIView):
-    '''This view is the endpoint for viewing job execution detail'''
+    """This view is the endpoint for viewing job execution detail"""
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request, job_exe_id):
-        '''Gets job execution and associated job_type id, name, and version
+        """Gets job execution and associated job_type id, name, and version
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
@@ -601,7 +603,7 @@ class JobExecutionDetailsView(APIView):
         :type job_exe_id: int
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
         try:
             job_exe = JobExecution.objects.get_details(job_exe_id)
         except JobExecution.DoesNotExist:
@@ -612,11 +614,11 @@ class JobExecutionDetailsView(APIView):
 
 
 class JobExecutionLogView(APIView):
-    '''This view is the endpoint for viewing job execution logs'''
+    """This view is the endpoint for viewing job execution logs"""
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request, job_exe_id):
-        '''Gets job execution logs. This can be a slightly slow operation so it's a separate view from the details.
+        """Gets job execution logs. This can be a slightly slow operation so it's a separate view from the details.
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
@@ -624,7 +626,7 @@ class JobExecutionLogView(APIView):
         :type job_exe_id: int
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
         try:
             job_exe = JobExecution.objects.get_logs(job_exe_id)
         except JobExecution.DoesNotExist:

--- a/scale/queue/urls.py
+++ b/scale/queue/urls.py
@@ -5,12 +5,14 @@ import queue.views
 
 urlpatterns = patterns(
     '',
-    # TODO: Remove this once the UI migrates to /load
+    # TODO: Remove this once the UI migrates to /load/
     url(r'queue/depth/$', queue.views.QueueDepthView.as_view(), name='queue_depth_view'),
+    # TODO: Remove this once the UI migrates to /queue/requeue-jobs/
+    url(r'queue/requeue-job/$', queue.views.RequeueExistingJobView.as_view(), name='requeue_existing_job_view'),
 
     url(r'^load/$', queue.views.JobLoadView.as_view(), name='load_view'),
     url(r'^queue/new-job/$', queue.views.QueueNewJobView.as_view(), name='queue_new_job_view'),
     url(r'^queue/new-recipe/$', queue.views.QueueNewRecipeView.as_view(), name='queue_new_recipe_view'),
-    url(r'^queue/requeue-job/$', queue.views.RequeueExistingJobView.as_view(), name='requeue_existing_job_view'),
+    url(r'^queue/requeue-jobs/$', queue.views.RequeueJobsView.as_view(), name='requeue_jobs_view'),
     url(r'^queue/status/$', queue.views.QueueStatusView.as_view(), name='queue_status_view'),
 )

--- a/scale/queue/views.py
+++ b/scale/queue/views.py
@@ -1,4 +1,4 @@
-'''Defines the views for the RESTful queue services'''
+"""Defines the views for the RESTful queue services"""
 from __future__ import unicode_literals
 
 import datetime
@@ -15,7 +15,7 @@ from rest_framework.views import APIView
 import util.rest as rest_util
 from job.configuration.data.exceptions import InvalidData, StatusError
 from job.models import Job, JobType
-from job.serializers import JobDetailsSerializer
+from job.serializers import JobDetailsSerializer, JobListSerializer
 from queue.models import JobLoad, Queue
 from queue.serializers import JobLoadGroupListSerializer
 from recipe.models import Recipe, RecipeType
@@ -27,18 +27,18 @@ logger = logging.getLogger(__name__)
 
 
 class JobLoadView(APIView):
-    '''This view is the endpoint for retrieving the job load for a given time range.'''
+    """This view is the endpoint for retrieving the job load for a given time range."""
 
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request):
-        '''Retrieves the job load for a given time range and returns it in JSON form
+        """Retrieves the job load for a given time range and returns it in JSON form
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
         started = rest_util.parse_timestamp(request, 'started', default_value=rest_util.get_relative_days(7))
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended, max_duration=datetime.timedelta(days=31))
@@ -59,19 +59,19 @@ class JobLoadView(APIView):
 
 # TODO: Remove this once the UI migrates to /load
 class QueueDepthView(APIView):
-    '''This view is the endpoint for retrieving the queue depth for a given time range.
-    '''
+    """This view is the endpoint for retrieving the queue depth for a given time range.
+    """
 
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request):
-        '''Retrieves the queue depth for a given time range and returns it in JSON form
+        """Retrieves the queue depth for a given time range and returns it in JSON form
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
         started = rest_util.parse_timestamp(request, 'started')
         ended = rest_util.parse_timestamp(request, 'ended')
         rest_util.check_time_range(started, ended)
@@ -84,7 +84,7 @@ class QueueDepthView(APIView):
         return Response(results)
 
     def _process_job_type_depths(self, job_type_qry, job_types, queue_depth_dict, depth_times):
-        '''Processes the queue depths that are split by job type
+        """Processes the queue depths that are split by job type
 
         :param job_type_qry: the query with the depth results
         :type job_type_qry: :class:`queue.views.QueueDepthView.QueueDepthByJobTypeFilter`
@@ -94,7 +94,7 @@ class QueueDepthView(APIView):
         :type queue_depth_dict: dict
         :param depth_times: List to populate with ascending depth times
         :type depth_times: list
-        '''
+        """
 
         job_types_set = set()
         for job_type_depth in job_type_qry:
@@ -113,7 +113,7 @@ class QueueDepthView(APIView):
                 job_type_dict[job_type_depth.job_type_id] = job_type_depth.depth
 
     def _process_priority_depths(self, priority_qry, priorities, queue_depth_dict):
-        '''Processes the queue depths that are split by priority. The queue_depth_dict must have already been processed
+        """Processes the queue depths that are split by priority. The queue_depth_dict must have already been processed
         by _process_job_type_depths().
 
         :param priority_qry: the query with the depth results
@@ -122,7 +122,7 @@ class QueueDepthView(APIView):
         :type priorities: list
         :param queue_depth_dict: Dict of {time: ({job type ID: count}, {priority: count})}
         :type queue_depth_dict: dict
-        '''
+        """
 
         priorities_set = set()
         for priority_depth in priority_qry:
@@ -135,7 +135,7 @@ class QueueDepthView(APIView):
                 priority_dict[priority_depth.priority] = priority_depth.depth
 
     def _process_queue_depths(self, job_types, priorities, queue_depth_dict, depth_times):
-        '''Processes and creates the queue depth list
+        """Processes and creates the queue depth list
 
         :param job_types: the list of job types processed
         :type job_types: list
@@ -147,7 +147,7 @@ class QueueDepthView(APIView):
         :type depth_times: list
         :rtype: list
         :returns: list of queue depth data
-        '''
+        """
 
         queue_depths = []
         for depth_time in depth_times:
@@ -174,18 +174,18 @@ class QueueDepthView(APIView):
 
 
 class QueueNewJobView(APIView):
-    '''This view is the endpoint for creating new jobs and putting them on the queue.'''
+    """This view is the endpoint for creating new jobs and putting them on the queue."""
     parser_classes = (JSONParser,)
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def post(self, request):
-        '''Creates a new job, places it on the queue, and returns the new job information in JSON form
+        """Creates a new job, places it on the queue, and returns the new job information in JSON form
 
         :param request: the HTTP POST request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
 
         job_type_id = rest_util.parse_int(request, 'job_type_id')
         job_data = rest_util.parse_dict(request, 'job_data', {})
@@ -207,19 +207,19 @@ class QueueNewJobView(APIView):
 
 
 class QueueNewRecipeView(APIView):
-    '''This view is the endpoint for queuing recipes and returns the detail information for the recipe that was queued.
-    '''
+    """This view is the endpoint for queuing recipes and returns the detail information for the recipe that was queued.
+    """
     parser_classes = (JSONParser,)
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def post(self, request):
-        '''Queue a recipe and returns the new job information in JSON form
+        """Queue a recipe and returns the new job information in JSON form
 
         :param request: the HTTP POST request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
 
         recipe_type_id = rest_util.parse_int(request, 'recipe_type_id')
         recipe_data = rest_util.parse_dict(request, 'recipe_data', {})
@@ -241,38 +241,82 @@ class QueueNewRecipeView(APIView):
 
 
 class QueueStatusView(APIView):
-    '''This view is the endpoint for retrieving the queue status.
-    '''
+    """This view is the endpoint for retrieving the queue status.
+    """
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def get(self, request):
-        '''Retrieves the current status of the queue and returns it in JSON form
+        """Retrieves the current status of the queue and returns it in JSON form
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
-        '''
+        """
 
         queue_status = Queue.objects.get_queue_status()
         return Response({'queue_status': queue_status})
 
 
-class RequeueExistingJobView(APIView):
-    '''This view is the endpoint for requeuing jobs which have already been executed for the maximum number of tries
-    '''
+class RequeueJobsView(APIView):
+    """This view is the endpoint for requeuing jobs which have already been executed."""
     parser_classes = (JSONParser,)
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
 
     def post(self, request):
-        '''Increase max_tries, place it on the queue, and returns the new job information in JSON form
+        """Increase max_tries, place it on the queue, and returns the new job information in JSON form
+
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :returns: the HTTP response to send back to the user
+        """
+
+        started = rest_util.parse_timestamp(request, 'started', required=False)
+        ended = rest_util.parse_timestamp(request, 'ended', required=False)
+        rest_util.check_time_range(started, ended)
+
+        job_status = rest_util.parse_string(request, 'status', required=False)
+        job_ids = rest_util.parse_int_list(request, 'job_ids', required=False)
+        job_type_ids = rest_util.parse_int_list(request, 'job_type_ids', required=False)
+        job_type_names = rest_util.parse_string_list(request, 'job_type_names', required=False)
+        job_type_categories = rest_util.parse_string_list(request, 'job_type_categories', required=False)
+
+        priority = rest_util.parse_int(request, 'priority', required=False)
+
+        # Fetch all the jobs matching the filters
+        jobs = Job.objects.get_jobs(started, ended, job_status, job_ids, job_type_ids, job_type_names,
+                                    job_type_categories)
+        if not jobs:
+            raise Http404
+
+        # Attempt to queue all jobs matching the filters
+        requested_job_ids = {job.id for job in jobs}
+        Queue.objects.requeue_jobs(requested_job_ids, priority)
+
+        # Refresh models to get the new status information for all originally requested jobs
+        jobs = Job.objects.get_jobs(job_ids=requested_job_ids)
+
+        page = rest_util.perform_paging(request, jobs)
+        serializer = JobListSerializer(page, context={'request': request})
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+# TODO: Remove this once the UI migrates to /queue/requeue-jobs/
+class RequeueExistingJobView(APIView):
+    """This view is the endpoint for requeuing jobs which have already been executed for the maximum number of tries
+    """
+    parser_classes = (JSONParser,)
+    renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
+
+    def post(self, request):
+        """Increase max_tries, place it on the queue, and returns the new job information in JSON form
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :param job_id: The ID of the job to requeue. This job must exist and must be in a FAILED or CANCELED state.
         :rtype: int
         :returns: the HTTP response to send back to the user
-        '''
+        """
         job_id = request.DATA['job_id']
 
         try:

--- a/scale/util/rest.py
+++ b/scale/util/rest.py
@@ -1,4 +1,4 @@
-'''Defines utilities for building RESTful APIs.'''
+"""Defines utilities for building RESTful APIs."""
 from __future__ import unicode_literals
 
 import datetime
@@ -17,12 +17,12 @@ from util.parse import ParseError
 
 
 class ModelIdSerializer(serializers.Serializer):
-    '''Converts a model to a lightweight place holder object with only an identifier to REST output'''
+    """Converts a model to a lightweight place holder object with only an identifier to REST output"""
     id = serializers.IntegerField()
 
 
 class JSONField(serializers.CharField):
-    '''Represents JSON content for use in REST serializers.'''
+    """Represents JSON content for use in REST serializers."""
     type_name = 'JSONField'
     type_label = 'json'
     empty = {}
@@ -32,7 +32,7 @@ class JSONField(serializers.CharField):
     }
 
     def from_native(self, value):
-        '''Converts the given raw value to a Python object.'''
+        """Converts the given raw value to a Python object."""
         if value in validators.EMPTY_VALUES:
             return None
 
@@ -47,28 +47,28 @@ class JSONField(serializers.CharField):
 
 
 class BadParameter(APIException):
-    '''Exception indicating a REST API call contains an invalid value or a missing required parameter.'''
+    """Exception indicating a REST API call contains an invalid value or a missing required parameter."""
     status_code = status.HTTP_400_BAD_REQUEST
 
 
 class ReadOnly(APIException):
-    '''Exception indicating a REST API call is attempting to update a field that does not support it.'''
+    """Exception indicating a REST API call is attempting to update a field that does not support it."""
     status_code = status.HTTP_400_BAD_REQUEST
 
 
 def check_update(request, fields):
-    '''Checks whether the given request includes fields that are not allowed to be updated.
+    """Checks whether the given request includes fields that are not allowed to be updated.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param fields: A list of field names that are permitted.
-    :type fields: list[str]
+    :type fields: list[string]
     :returns: True when the request does not include extra fields.
     :rtype: bool
 
     :raises :class:`util.rest.ReadOnly`: If the request includes unsupported fields to update.
     :raises :class:`exceptions.AssertionError`: If fields in not a list or None.
-    '''
+    """
     fields = fields or []
     assert(type(fields) == type([]))
     extra = filter(lambda x, y=fields: x not in y, request.DATA.keys())
@@ -78,7 +78,7 @@ def check_update(request, fields):
 
 
 def check_time_range(started, ended, max_duration=None):
-    '''Checks whether the given time range is valid.
+    """Checks whether the given time range is valid.
 
     :param started: The start of a time range.
     :type started: datetime.datetime
@@ -90,7 +90,7 @@ def check_time_range(started, ended, max_duration=None):
     :rtype: bool
 
     :raises :class:`util.rest.BadParameter`: If there is a problem with the time range.
-    '''
+    """
     if not started or not ended:
         return True
     if started == ended:
@@ -106,17 +106,17 @@ def check_time_range(started, ended, max_duration=None):
 
 
 def check_together(names, values):
-    '''Checks whether a list of fields as a group. Either all or none of the fields should be provided.
+    """Checks whether a list of fields as a group. Either all or none of the fields should be provided.
 
     :param names: The list of field names to check.
-    :type names: list[str]
+    :type names: list[string]
     :param values: The list of field values to check.
     :type values: list[object]
     :returns: True when all parameters are provided and false if none of the parameters are provided.
     :rtype: bool
 
     :raises :class:`util.rest.BadParameter`: If the list of fields is mismatched.
-    '''
+    """
     if not names and not values:
         return False
     if len(names) != len(values):
@@ -132,15 +132,15 @@ def check_together(names, values):
 
 
 def has_params(request, *names):
-    '''Checks whether one or more parameters are included in the request.
+    """Checks whether one or more parameters are included in the request.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param names: One or more parameter names to check.
-    :type names: str
+    :type names: string
     :returns: True when all the parameters are provided or false if at least one is not provided.
     :rtype: bool
-    '''
+    """
     if not names:
         return False
     for name in names:
@@ -150,7 +150,7 @@ def has_params(request, *names):
 
 
 def get_relative_days(days):
-    '''Calculates a relative date/time in the past without any time offsets.
+    """Calculates a relative date/time in the past without any time offsets.
 
     This is useful when a service wants to have a default value of, for example 7 days back. If an ISO duration format
     is used, such as P7D then the current time will be factored in which results in the earliest day being incomplete
@@ -160,66 +160,66 @@ def get_relative_days(days):
     :type days: int
     :returns: An absolute time stamp that is the complete range of relative days back.
     :rtype: datetime.datetime
-    '''
+    """
     base_date = (timezone.now() - datetime.timedelta(days=days)).date()
     return datetime.datetime.combine(base_date, datetime.time.min).replace(tzinfo=timezone.utc)
 
 
 def parse_string(request, name, default_value=None, required=True, accepted_values=None):
-    '''Parses a string parameter from the given request.
+    """Parses a string parameter from the given request.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param name: The name of the parameter to parse.
-    :type name: str
+    :type name: string
     :param default_value: The name of the parameter to parse.
-    :type default_value: str
+    :type default_value: string
     :param required: Indicates whether or not the parameter is required. An exception will be raised if the parameter
         does not exist, there is no default value, and required is True.
     :type required: bool
     :param accepted_values: A list of values that are acceptable for the parameter.
-    :type accepted_values: list[str]
+    :type accepted_values: list[string]
     :returns: The value of the named parameter or the default value if provided.
-    :rtype: str
+    :rtype: string
 
     :raises :class:`util.rest.BadParameter`: If the value cannot be parsed.
-    '''
+    """
     value = _get_param(request, name, default_value, required)
     _check_accepted_value(name, value, accepted_values)
     return value
 
 
 def parse_string_list(request, name, default_value=None, required=True, accepted_values=None):
-    '''Parses a list of string parameters from the given request.
+    """Parses a list of string parameters from the given request.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param name: The name of the parameter to parse.
-    :type name: str
+    :type name: string
     :param default_value: The name of the parameter to parse.
-    :type default_value: list[str]
+    :type default_value: list[string]
     :param required: Indicates whether or not the parameter is required. An exception will be raised if the parameter
         does not exist, there is no default value, and required is True.
     :type required: bool
     :param accepted_values: A list of values that are acceptable for the parameter.
-    :type accepted_values: list[str]
+    :type accepted_values: list[string]
     :returns: The value of the named parameter or the default value if provided.
-    :rtype: str
+    :rtype: string
 
     :raises :class:`util.rest.BadParameter`: If the value cannot be parsed or does not match the validation list.
-    '''
+    """
     values = _get_param_list(request, name, default_value, required)
     _check_accepted_values(name, values, accepted_values)
     return values
 
 
 def parse_bool(request, name, default_value=None, required=True):
-    '''Parses a bool parameter from the given request.
+    """Parses a bool parameter from the given request.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param name: The name of the parameter to parse.
-    :type name: str
+    :type name: string
     :param default_value: The name of the parameter to parse.
     :type default_value: bool
     :param required: Indicates whether or not the parameter is required. An exception will be raised if the parameter
@@ -229,7 +229,7 @@ def parse_bool(request, name, default_value=None, required=True):
     :rtype: bool
 
     :raises :class:`util.rest.BadParameter`: If the value cannot be parsed.
-    '''
+    """
     value = _get_param(request, name, default_value, required)
     if not isinstance(value, basestring):
         return value
@@ -243,12 +243,12 @@ def parse_bool(request, name, default_value=None, required=True):
 
 
 def parse_int(request, name, default_value=None, required=True, accepted_values=None):
-    '''Parses an integer parameter from the given request.
+    """Parses an integer parameter from the given request.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param name: The name of the parameter to parse.
-    :type name: str
+    :type name: string
     :param default_value: The name of the parameter to parse.
     :type default_value: int
     :param required: Indicates whether or not the parameter is required. An exception will be raised if the parameter
@@ -260,7 +260,7 @@ def parse_int(request, name, default_value=None, required=True, accepted_values=
     :rtype: int
 
     :raises :class:`util.rest.BadParameter`: If the value cannot be parsed.
-    '''
+    """
     value = _get_param(request, name, default_value, required)
     if not isinstance(value, basestring):
         return value
@@ -274,12 +274,12 @@ def parse_int(request, name, default_value=None, required=True, accepted_values=
 
 
 def parse_int_list(request, name, default_value=None, required=True, accepted_values=None):
-    '''Parses a list of int parameters from the given request.
+    """Parses a list of int parameters from the given request.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param name: The name of the parameter to parse.
-    :type name: str
+    :type name: string
     :param default_value: The name of the parameter to parse.
     :type default_value: list[int]
     :param required: Indicates whether or not the parameter is required. An exception will be raised if the parameter
@@ -288,10 +288,10 @@ def parse_int_list(request, name, default_value=None, required=True, accepted_va
     :param accepted_values: A list of values that are acceptable for the parameter.
     :type accepted_values: list[int]
     :returns: The value of the named parameter or the default value if provided.
-    :rtype: str
+    :rtype: string
 
     :raises :class:`util.rest.BadParameter`: If the value cannot be parsed or does not match the validation list.
-    '''
+    """
     param_list = _get_param_list(request, name, default_value, required)
 
     if param_list and len(param_list):
@@ -307,12 +307,12 @@ def parse_int_list(request, name, default_value=None, required=True, accepted_va
 
 
 def parse_float(request, name, default_value=None, required=True, accepted_values=None):
-    '''Parses a floating point parameter from the given request.
+    """Parses a floating point parameter from the given request.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param name: The name of the parameter to parse.
-    :type name: str
+    :type name: string
     :param default_value: The name of the parameter to parse.
     :type default_value: float
     :param required: Indicates whether or not the parameter is required. An exception will be raised if the parameter
@@ -324,7 +324,7 @@ def parse_float(request, name, default_value=None, required=True, accepted_value
     :rtype: float
 
     :raises :class:`util.rest.BadParameter`: If the value cannot be parsed.
-    '''
+    """
     value = _get_param(request, name, default_value, required)
     if not isinstance(value, basestring):
         return value
@@ -338,14 +338,14 @@ def parse_float(request, name, default_value=None, required=True, accepted_value
 
 
 def parse_timestamp(request, name, default_value=None, required=True):
-    '''Parses any valid ISO datetime, duration, or timestamp parameter from the given request.
+    """Parses any valid ISO datetime, duration, or timestamp parameter from the given request.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param name: The name of the parameter to parse.
-    :type name: str
+    :type name: string
     :param default_value: The name of the parameter to parse.
-    :type default_value: datetime.timedelta
+    :type default_value: datetime.timedelta or string
     :param required: Indicates whether or not the parameter is required. An exception will be raised if the parameter
         does not exist, there is no default value, and required is True.
     :type required: bool
@@ -353,7 +353,7 @@ def parse_timestamp(request, name, default_value=None, required=True):
     :rtype: datetime.datetime
 
     :raises :class:`util.rest.BadParameter`: If the value cannot be parsed.
-    '''
+    """
     value = _get_param(request, name, default_value, required)
     if not isinstance(value, basestring):
         return value
@@ -368,14 +368,14 @@ def parse_timestamp(request, name, default_value=None, required=True):
 
 
 def parse_duration(request, name, default_value=None, required=True):
-    '''Parses a time duration parameter from the given request.
+    """Parses a time duration parameter from the given request.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param name: The name of the parameter to parse.
-    :type name: str
+    :type name: string
     :param default_value: The name of the parameter to parse.
-    :type default_value: datetime.timedelta
+    :type default_value: datetime.timedelta or string
     :param required: Indicates whether or not the parameter is required. An exception will be raised if the parameter
         does not exist, there is no default value, and required is True.
     :type required: bool
@@ -383,7 +383,7 @@ def parse_duration(request, name, default_value=None, required=True):
     :rtype: datetime.timedelta
 
     :raises :class:`util.rest.BadParameter`: If the value cannot be parsed.
-    '''
+    """
     value = _get_param(request, name, default_value, required)
     if not isinstance(value, basestring):
         return value
@@ -398,12 +398,12 @@ def parse_duration(request, name, default_value=None, required=True):
 
 
 def parse_datetime(request, name, default_value=None, required=True):
-    '''Parses a datetime parameter from the given request.
+    """Parses a datetime parameter from the given request.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param name: The name of the parameter to parse.
-    :type name: str
+    :type name: string
     :param default_value: The name of the parameter to parse.
     :type default_value: datetime.datetime
     :param required: Indicates whether or not the parameter is required. An exception will be raised if the parameter
@@ -413,7 +413,7 @@ def parse_datetime(request, name, default_value=None, required=True):
     :rtype: datetime.datetime
 
     :raises :class:`util.rest.BadParameter`: If the value cannot be parsed.
-    '''
+    """
     value = _get_param(request, name, default_value, required)
     if not isinstance(value, basestring):
         return value
@@ -430,12 +430,12 @@ def parse_datetime(request, name, default_value=None, required=True):
 
 
 def parse_dict(request, name, default_value=None, required=True):
-    '''Parses a dictionary parameter from the given request.
+    """Parses a dictionary parameter from the given request.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param name: The name of the parameter to parse.
-    :type name: str
+    :type name: string
     :param default_value: The name of the parameter to parse.
     :type default_value: dict
     :param required: Indicates whether or not the parameter is required. An exception will be raised if the parameter
@@ -445,7 +445,7 @@ def parse_dict(request, name, default_value=None, required=True):
     :rtype: dict
 
     :raises :class:`util.rest.BadParameter`: If the value cannot be parsed.
-    '''
+    """
     value = _get_param(request, name, default_value, required)
     if required and not isinstance(value, dict):
         raise BadParameter('Parameter must be a valid JSON object: "%s"' % name)
@@ -453,7 +453,7 @@ def parse_dict(request, name, default_value=None, required=True):
 
 
 def perform_paging(request, objects):
-    '''Performs paging on the given objects using the given request parameters
+    """Performs paging on the given objects using the given request parameters
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
@@ -461,7 +461,7 @@ def perform_paging(request, objects):
     :type objects: list
     :returns: the created page
     :rtype: :class:`django.core.paginator.Page`
-    '''
+    """
     # TODO: Replace this function with the paging features added to DRF 3.x
 
     try:
@@ -484,12 +484,12 @@ def perform_paging(request, objects):
 
 
 def _get_param(request, name, default_value=None, required=True):
-    '''Gets a parameter from the given request that works for either read or write operations.
+    """Gets a parameter from the given request that works for either read or write operations.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param name: The name of the parameter to parse.
-    :type name: str
+    :type name: string
     :param default_value: The name of the parameter to parse.
     :type default_value: object
     :param required: Indicates whether or not the parameter is required. An exception will be raised if the parameter
@@ -497,7 +497,7 @@ def _get_param(request, name, default_value=None, required=True):
     :type required: bool
     :returns: The value of the named parameter or the default value if provided.
     :rtype: object
-    '''
+    """
     value = None
     if name in request.QUERY_PARAMS:
         value = request.QUERY_PARAMS.get(name)
@@ -513,22 +513,22 @@ def _get_param(request, name, default_value=None, required=True):
 
 
 def _get_param_list(request, name, default_value=None, required=True):
-    '''Gets a list of parameters from the given request that works for either read or write operations.
+    """Gets a list of parameters from the given request that works for either read or write operations.
 
     :param request: The context of an active HTTP request.
     :type request: :class:`rest_framework.request.Request`
     :param name: The name of the parameter to parse.
-    :type name: str
+    :type name: string
     :param default_value: The name of the parameter to parse.
     :type default_value: object
     :returns: A list of the values of the named parameter or the default value if provided.
     :rtype: list[object]
-    '''
+    """
     value = None
     if name in request.QUERY_PARAMS:
         value = request.QUERY_PARAMS.getlist(name)
     if value is None and name in request.DATA:
-        value = request.DATA.getlist(name)
+        value = request.DATA.get(name)
 
     if value is None and default_value is not None:
         return default_value
@@ -539,30 +539,30 @@ def _get_param_list(request, name, default_value=None, required=True):
 
 
 def _check_accepted_value(name, value, accepted_values):
-    '''Checks that a parameter has a value that is acceptable.
+    """Checks that a parameter has a value that is acceptable.
 
     :param name: The name of the parameter.
-    :type name: str
+    :type name: string
     :param value: A value to validate.
     :type value: list[object]
     :param accepted_values: A list of values that are acceptable for the parameter.
     :type accepted_values: list[object]
-    '''
+    """
     if value and accepted_values:
         if value not in accepted_values:
             raise BadParameter('Parameter "%s" values must be one of: %s' % (name, accepted_values))
 
 
 def _check_accepted_values(name, values, accepted_values):
-    '''Checks that a list of parameters has values that are acceptable.
+    """Checks that a list of parameters has values that are acceptable.
 
     :param name: The name of the parameter.
-    :type name: str
+    :type name: string
     :param values: A list of values to validate.
     :type values: list[object]
     :param accepted_values: A list of values that are acceptable for the parameter.
     :type accepted_values: list[object]
-    '''
+    """
     if values and accepted_values:
         for value in values:
             _check_accepted_value(name, value, accepted_values)

--- a/scale/util/test/test_rest.py
+++ b/scale/util/test/test_rest.py
@@ -257,7 +257,9 @@ class TestRest(TestCase):
         '''Tests parsing a required list of string parameters that are provided via POST.'''
         request = MagicMock(Request)
         request.DATA = QueryDict('', mutable=True)
-        request.DATA.setlist('test', ['value1', 'value2'])
+        request.DATA.update({
+            'test': ['value1', 'value2']
+        })
 
         self.assertEqual(rest_util.parse_string_list(request, 'test'), ['value1', 'value2'])
 
@@ -473,7 +475,9 @@ class TestRest(TestCase):
         '''Tests parsing a required list of int parameters that are provided via POST.'''
         request = MagicMock(Request)
         request.DATA = QueryDict('', mutable=True)
-        request.DATA.setlist('test', ['1', '2'])
+        request.DATA.update({
+            'test': ['1', '2']
+        })
 
         self.assertEqual(rest_util.parse_int_list(request, 'test'), [1, 2])
 


### PR DESCRIPTION
This adds a new endpoint: /queue/requeue-jobs/
The new API supports common filters by job attributes as well as the option to set a new job priority.
Filters that support multiple values are handled as true arrays, unlike our other endpoints because the view is based on POST instead of GET.
Existing /queue/requeue-job/ endpoint is still present, but is not deprecated until the UI updates.