### PR TITLE
Issue 51

### DIFF
--- a/scale/job/migrations/0013_auto_20160316_1805.py
+++ b/scale/job/migrations/0013_auto_20160316_1805.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import djorm_pgjson.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('job', '0012_auto_20160310_1318'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='job',
+            name='docker_params',
+            field=djorm_pgjson.fields.JSONField(default={}, null=True, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='jobexecution',
+            name='docker_params',
+            field=djorm_pgjson.fields.JSONField(default={}, null=True, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='jobtype',
+            name='docker_params',
+            field=djorm_pgjson.fields.JSONField(default={}, null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/scale/job/migrations/0014_auto_20160317_1208.py
+++ b/scale/job/migrations/0014_auto_20160317_1208.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('job', '0013_auto_20160316_1805'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='job',
+            name='delete_superseded',
+            field=models.BooleanField(default=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='job',
+            name='is_superseded',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='job',
+            name='root_superseded_job',
+            field=models.ForeignKey(related_name='superseded_by_jobs', on_delete=django.db.models.deletion.PROTECT, blank=True, to='job.Job', null=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='job',
+            name='superseded',
+            field=models.DateTimeField(null=True, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='job',
+            name='superseded_job',
+            field=models.OneToOneField(related_name='superseded_by_job', null=True, on_delete=django.db.models.deletion.PROTECT, blank=True, to='job.Job'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='job',
+            name='last_modified',
+            field=models.DateTimeField(auto_now=True),
+            preserve_default=True,
+        ),
+        migrations.AlterIndexTogether(
+            name='job',
+            index_together=set([('last_modified', 'job_type', 'status')]),
+        ),
+    ]

--- a/scale/job/test/test_models.py
+++ b/scale/job/test/test_models.py
@@ -36,6 +36,23 @@ class TestJobManager(TransactionTestCase):
         self.assertIsNone(job.started)
         self.assertIsNone(job.ended)
 
+    def test_superseded_job(self):
+        """Tests creating a job that supersedes another job"""
+
+        old_job = job_test_utils.create_job()
+
+        event = trigger_test_utils.create_trigger_event()
+        new_job = Job.objects.create_job(old_job.job_type, event, old_job, False)
+        new_job.save()
+
+        new_job = Job.objects.get(pk=new_job.id)
+        self.assertEqual(new_job.status, 'PENDING')
+        self.assertFalse(new_job.is_superseded)
+        self.assertEqual(new_job.root_superseded_job_id, old_job.id)
+        self.assertEqual(new_job.superseded_job_id, old_job.id)
+        self.assertFalse(new_job.delete_superseded)
+        self.assertIsNone(new_job.superseded)
+
     def test_update_status_running(self):
         """Tests that job attributes are updated when a job is running."""
         job_1 = job_test_utils.create_job(num_exes=1, started=None, ended=timezone.now())

--- a/scale/recipe/migrations/0008_auto_20160317_1208.py
+++ b/scale/recipe/migrations/0008_auto_20160317_1208.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('recipe', '0007_auto_20160310_1318'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='recipe',
+            name='last_modified',
+            field=models.DateTimeField(auto_now=True),
+            preserve_default=True,
+        ),
+        migrations.AlterIndexTogether(
+            name='recipe',
+            index_together=set([('last_modified', 'recipe_type')]),
+        ),
+    ]

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -287,7 +287,7 @@ class Recipe(models.Model):
 
     created = models.DateTimeField(auto_now_add=True)
     completed = models.DateTimeField(blank=True, null=True)
-    last_modified = models.DateTimeField(auto_now=True, db_index=True)
+    last_modified = models.DateTimeField(auto_now=True)
 
     objects = RecipeManager()
 
@@ -312,6 +312,7 @@ class Recipe(models.Model):
     class Meta(object):
         """meta information for the db"""
         db_table = 'recipe'
+        index_together = ['last_modified', 'recipe_type']
 
 
 class RecipeJobManager(models.Manager):


### PR DESCRIPTION
I had to merge Trevor's job model changes for the Docker params into my branch, so this can't be merged until Trevor's issue is merged first.

Highlights for this issue:
1. New job model fields for handling superseded jobs. After more thought, I changed the fields from when I created the issue. Instead of creating two fields to go each direction, I created one as a OneToOneField and we can use the reverse relationship.

2. Updated JobManager.create_job() to handle a new job that supersedes an old job.

3. Create JobManager.superceded_jobs() that marks superseded jobs as such.