### PR TITLE
Issue 70 Adding inputs/outputs to job details

### DIFF
--- a/scale/docs/interface/rest/job.rst
+++ b/scale/docs/interface/rest/job.rst
@@ -238,16 +238,35 @@ These services provide access to information about "all", "currently running" an
 | results            | JSON Object       | An interface description for all the job results meta-data.                    |
 |                    |                   | (See :ref:`architecture_jobs_job_results_spec`)                                |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| input_files        | JSON Object       | A list of files that the job used as input.                                    |
-|                    |                   | (See :ref:`Scale File Details <rest_scale_file_details>`)                      |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
 | recipes            | Array             | A list of all recipes associated with the job.                                 |
 |                    |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                              |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | job_exes           | Array             | A list of all job executions associated with the job.                          |
 |                    |                   | (See :ref:`Job Execution Details <rest_job_execution_details>`)                |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| products           | Array             | A list of all generated products associated with the job.                      |
+| inputs             | Array             | A list of job interface inputs merged with their respective job data values.   |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .name              | String            | The name of the input as defined by the job type interface.                    |
+|                    |                   | (See :ref:`architecture_jobs_interface_spec`)                                  |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .type              | String            | The type of the input as defined by teh job type interface.                    |
+|                    |                   | (See :ref:`architecture_jobs_interface_spec`)                                  |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .value             | Various           | The actual value of the input, which can vary depending on the type. Simple    |
+|                    |                   | property inputs will include primitive values, whereas the file or files type  |
+|                    |                   | will include a full JSON representation of a Scale file object.                |
+|                    |                   | (See :ref:`Scale File Details <rest_scale_file_details>`)                      |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| outputs            | Array             | A list of job interface outputs merged with their respective job result values.|
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .name              | String            | The name of the output as defined by the job type interface.                   |
+|                    |                   | (See :ref:`architecture_jobs_interface_spec`)                                  |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .type              | String            | The type of the output as defined by teh job type interface.                   |
+|                    |                   | (See :ref:`architecture_jobs_interface_spec`)                                  |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .value             | Various           | The actual value of the output, which can vary depending on the type. A file or|
+|                    |                   | files type will include a full JSON representation of a Product file object.   |
 |                    |                   | (See :ref:`Product Details <rest_product_details>`)                            |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .. code-block:: javascript                                                                                              |
@@ -360,30 +379,6 @@ These services provide access to information about "all", "currently running" an
 |            ],                                                                                                           |
 |            "version": "1.0"                                                                                             |
 |        },                                                                                                               |
-|        "input_files": [                                                                                                 |
-|            {                                                                                                            |
-|                "id": 2,                                                                                                 |
-|                "workspace": {                                                                                           |
-|                    "id": 1,                                                                                             |
-|                    "name": "Raw Source"                                                                                 |
-|                },                                                                                                       |
-|                "file_name": "input_file.txt",                                                                           | 
-|                "media_type": "text/plain",                                                                              |
-|                "file_size": 1234,                                                                                       |
-|                "data_type": [],                                                                                         | 
-|                "is_deleted": false,                                                                                     |
-|                "uuid": "c8928d9183fc99122948e7840ec9a0fd",                                                              |
-|                "url": "http://host.com/input_file.txt",                                                                 |
-|                "created": "2015-09-10T15:24:53.962Z",                                                                   |
-|                "deleted": null,                                                                                         |
-|                "data_started": "2015-09-10T14:50:49Z",                                                                  |
-|                "data_ended": "2015-09-10T14:51:05Z",                                                                    |
-|                "geometry": null,                                                                                        |
-|                "center_point": null,                                                                                    |
-|                "meta_data": {...}                                                                                       |
-|                "last_modified": "2015-09-10T15:25:02.808Z"                                                              |
-|            }                                                                                                            |
-|        ],                                                                                                               |
 |        "recipes": [                                                                                                     |
 |            {                                                                                                            |
 |                "id": 4832,                                                                                              |
@@ -435,40 +430,72 @@ These services provide access to information about "all", "currently running" an
 |                "error": null                                                                                            |
 |            }                                                                                                            |
 |        ],                                                                                                               |
-|        "products": [                                                                                                    |
+|        "inputs": [                                                                                                      |
 |            {                                                                                                            |
-|                "id": 8484,                                                                                              |
-|                "workspace": {                                                                                           |
-|                    "id": 2,                                                                                             | 
-|                    "name": "Products"                                                                                   | 
-|                },                                                                                                       |
-|                "file_name": "file.kml",                                                                                 |
-|                "media_type": "application/vnd.google-earth.kml+xml",                                                    |
-|                "file_size": 1234,                                                                                       |
-|                "data_type": [],                                                                                         |
-|                "is_deleted": false,                                                                                     |
-|                "uuid": "c8928d9183fc99122948e7840ec9a0fd",                                                              |
-|                "url": "http://host.com/file/path/my_file.kml",                                                          | 
-|                "created": "2015-09-01T17:27:48.477Z",                                                                   | 
-|                "deleted": null,                                                                                         |
-|                "data_started": null,                                                                                    |
-|                "data_ended": null,                                                                                      |
-|                "geometry": null,                                                                                        |
-|                "center_point": null,                                                                                    | 
-|                "meta_data": {},                                                                                         |
-|                "last_modified": "2015-09-01T17:27:49.639Z",                                                             |
-|                "is_operational": true,                                                                                  |
-|                "is_published": true,                                                                                    |
-|                "published": "2015-09-01T17:27:49.461Z",                                                                 |
-|                "unpublished": null,                                                                                     |
-|                "job_type": {                                                                                            |
-|                    "id": 8                                                                                              |
-|                },                                                                                                       |
-|                "job": {                                                                                                 |
-|                    "id": 35                                                                                             |
-|                },                                                                                                       |
-|                "job_exe": {                                                                                             |
-|                    "id": 19                                                                                             |
+|                "name": "input_file",                                                                                    |
+|                "type": "file",                                                                                          |
+|                "value": {                                                                                               |
+|                    "id": 2,                                                                                             |
+|                    "workspace": {                                                                                       |
+|                        "id": 1,                                                                                         |
+|                        "name": "Raw Source"                                                                             |
+|                    },                                                                                                   |
+|                    "file_name": "input_file.txt",                                                                       |
+|                    "media_type": "text/plain",                                                                          |
+|                    "file_size": 1234,                                                                                   |
+|                    "data_type": [],                                                                                     |
+|                    "is_deleted": false,                                                                                 |
+|                    "uuid": "c8928d9183fc99122948e7840ec9a0fd",                                                          |
+|                    "url": "http://host.com/input_file.txt",                                                             |
+|                    "created": "2015-09-10T15:24:53.962Z",                                                               |
+|                    "deleted": null,                                                                                     |
+|                    "data_started": "2015-09-10T14:50:49Z",                                                              |
+|                    "data_ended": "2015-09-10T14:51:05Z",                                                                |
+|                    "geometry": null,                                                                                    |
+|                    "center_point": null,                                                                                |
+|                    "meta_data": {...}                                                                                   |
+|                    "last_modified": "2015-09-10T15:25:02.808Z"                                                          |
+|                }                                                                                                        |
+|            }                                                                                                            |
+|        ],                                                                                                               |
+|        "outputs": [                                                                                                     |
+|            {                                                                                                            |
+|                "name": "output_file",                                                                                   |
+|                "type": "file",                                                                                          |
+|                "value": {                                                                                               |
+|                    "id": 8484,                                                                                          |
+|                    "workspace": {                                                                                       |
+|                        "id": 2,                                                                                         |
+|                        "name": "Products"                                                                               |
+|                    },                                                                                                   |
+|                    "file_name": "file.kml",                                                                             |
+|                    "media_type": "application/vnd.google-earth.kml+xml",                                                |
+|                    "file_size": 1234,                                                                                   |
+|                    "data_type": [],                                                                                     |
+|                    "is_deleted": false,                                                                                 |
+|                    "uuid": "c8928d9183fc99122948e7840ec9a0fd",                                                          |
+|                    "url": "http://host.com/file/path/my_file.kml",                                                      |
+|                    "created": "2015-09-01T17:27:48.477Z",                                                               |
+|                    "deleted": null,                                                                                     |
+|                    "data_started": null,                                                                                |
+|                    "data_ended": null,                                                                                  |
+|                    "geometry": null,                                                                                    |
+|                    "center_point": null,                                                                                |
+|                    "meta_data": {},                                                                                     |
+|                    "last_modified": "2015-09-01T17:27:49.639Z",                                                         |
+|                    "is_operational": true,                                                                              |
+|                    "is_published": true,                                                                                |
+|                    "published": "2015-09-01T17:27:49.461Z",                                                             |
+|                    "unpublished": null,                                                                                 |
+|                    "job_type": {                                                                                        |
+|                        "id": 8                                                                                          |
+|                    },                                                                                                   |
+|                    "job": {                                                                                             |
+|                        "id": 35                                                                                         |
+|                    },                                                                                                   |
+|                    "job_exe": {                                                                                         |
+|                        "id": 19                                                                                         |
+|                    }                                                                                                    |
 |                }                                                                                                        |
 |            }                                                                                                            |
 |        ]                                                                                                                |

--- a/scale/job/serializers.py
+++ b/scale/job/serializers.py
@@ -1,4 +1,4 @@
-'''Defines the serializers for jobs and job types'''
+"""Defines the serializers for jobs and job types"""
 import rest_framework.pagination as pagination
 import rest_framework.serializers as serializers
 
@@ -6,7 +6,7 @@ from util.rest import ModelIdSerializer
 
 
 class JobTypeBaseSerializer(ModelIdSerializer):
-    '''Converts job type model fields to REST output'''
+    """Converts job type model fields to REST output"""
     name = serializers.CharField()
     version = serializers.CharField()
     title = serializers.CharField()
@@ -25,7 +25,7 @@ class JobTypeBaseSerializer(ModelIdSerializer):
 
 
 class JobTypeSerializer(JobTypeBaseSerializer):
-    '''Converts job type model fields to REST output'''
+    """Converts job type model fields to REST output"""
     uses_docker = serializers.BooleanField()
     docker_privileged = serializers.BooleanField()
     docker_image = serializers.CharField()
@@ -47,7 +47,7 @@ class JobTypeSerializer(JobTypeBaseSerializer):
 
 
 class JobTypeStatusCountsSerializer(serializers.Serializer):
-    '''Converts node status count object fields to REST output.'''
+    """Converts node status count object fields to REST output."""
     status = serializers.CharField()
     count = serializers.IntegerField()
     most_recent = serializers.DateTimeField()
@@ -55,7 +55,7 @@ class JobTypeStatusCountsSerializer(serializers.Serializer):
 
 
 class JobTypeDetailsSerializer(JobTypeSerializer):
-    '''Converts job type model fields to REST output.'''
+    """Converts job type model fields to REST output."""
     from error.serializers import ErrorSerializer
     from trigger.serializers import TriggerRuleDetailsSerializer
 
@@ -70,38 +70,38 @@ class JobTypeDetailsSerializer(JobTypeSerializer):
 
 
 class JobTypeListSerializer(pagination.PaginationSerializer):
-    '''Converts a list of job type models to paginated REST output.'''
+    """Converts a list of job type models to paginated REST output."""
     class Meta:
         object_serializer_class = JobTypeSerializer
 
 
 class JobTypeStatusSerializer(serializers.Serializer):
-    '''Converts job type status model and extra statistic fields to REST output.'''
+    """Converts job type status model and extra statistic fields to REST output."""
     job_type = JobTypeBaseSerializer()
     job_counts = JobTypeStatusCountsSerializer()
 
 
 class JobTypeStatusListSerializer(pagination.PaginationSerializer):
-    '''Converts a list of job type status models to paginated REST output.'''
+    """Converts a list of job type status models to paginated REST output."""
     class Meta:
         object_serializer_class = JobTypeStatusSerializer
 
 
 class JobTypeRunningStatusSerializer(serializers.Serializer):
-    '''Converts job type running status model and extra statistic fields to REST output.'''
+    """Converts job type running status model and extra statistic fields to REST output."""
     job_type = JobTypeBaseSerializer()
     count = serializers.IntegerField()
     longest_running = serializers.DateTimeField()
 
 
 class JobTypeRunningStatusListSerializer(pagination.PaginationSerializer):
-    '''Converts a list of job type running status models to paginated REST output.'''
+    """Converts a list of job type running status models to paginated REST output."""
     class Meta:
         object_serializer_class = JobTypeRunningStatusSerializer
 
 
 class JobTypeFailedStatusSerializer(serializers.Serializer):
-    '''Converts job type failed status model and extra statistic fields to REST output.'''
+    """Converts job type failed status model and extra statistic fields to REST output."""
     from error.serializers import ErrorSerializer
 
     job_type = JobTypeBaseSerializer()
@@ -112,25 +112,25 @@ class JobTypeFailedStatusSerializer(serializers.Serializer):
 
 
 class JobTypeFailedStatusListSerializer(pagination.PaginationSerializer):
-    '''Converts a list of job type failed status models to paginated REST output.'''
+    """Converts a list of job type failed status models to paginated REST output."""
     class Meta:
         object_serializer_class = JobTypeFailedStatusSerializer
 
 
 class JobTypeRevisionBaseSerializer(ModelIdSerializer):
-    '''Converts job type revision model fields to REST output.'''
+    """Converts job type revision model fields to REST output."""
     job_type = ModelIdSerializer()
     revision_num = serializers.IntegerField()
 
 
 class JobTypeRevisionSerializer(JobTypeRevisionBaseSerializer):
-    '''Converts job type revision model fields to REST output.'''
+    """Converts job type revision model fields to REST output."""
     interface = serializers.CharField()
     created = serializers.DateTimeField()
 
 
 class JobBaseSerializer(ModelIdSerializer):
-    '''Converts job model fields to REST output.'''
+    """Converts job model fields to REST output."""
     job_type = JobTypeBaseSerializer()
     job_type_rev = ModelIdSerializer()
     event = ModelIdSerializer()
@@ -142,7 +142,7 @@ class JobBaseSerializer(ModelIdSerializer):
 
 
 class JobSerializer(JobBaseSerializer):
-    '''Converts job model fields to REST output.'''
+    """Converts job model fields to REST output."""
     from error.serializers import ErrorBaseSerializer
     from trigger.serializers import TriggerEventBaseSerializer
 
@@ -167,12 +167,12 @@ class JobSerializer(JobBaseSerializer):
 
 
 class JobRevisionSerializer(JobSerializer):
-    '''Converts job model fields to REST output.'''
+    """Converts job model fields to REST output."""
     job_type_rev = JobTypeRevisionSerializer()
 
 
 class JobExecutionBaseSerializer(ModelIdSerializer):
-    '''Converts job execution model fields to REST output'''
+    """Converts job execution model fields to REST output"""
     status = serializers.CharField()
     command_arguments = serializers.CharField()
     timeout = serializers.IntegerField()
@@ -200,8 +200,41 @@ class JobExecutionBaseSerializer(ModelIdSerializer):
     error = ModelIdSerializer()
 
 
+class JobDetailsInputSerializer(serializers.Serializer):
+    """Converts job detail model input fields to REST output"""
+    from storage.serializers import ScaleFileBaseSerializer
+
+    name = serializers.CharField()
+    type = serializers.CharField()
+
+    FILE_SERIALIZER = ScaleFileBaseSerializer
+
+    def to_native(self, obj):
+        result = super(JobDetailsInputSerializer, self).to_native(obj)
+
+        value = None
+        if 'value' in obj:
+            if obj['type'] == 'file':
+                value = self.FILE_SERIALIZER().to_native(obj['value'])
+            elif obj['type'] == 'files':
+                value = [self.FILE_SERIALIZER().to_native(v) for v in obj['value']]
+            else:
+                value = obj['value']
+        result['value'] = value
+        return result
+
+
+class JobDetailsOutputSerializer(JobDetailsInputSerializer):
+    """Converts job detail model output fields to REST output"""
+    try:
+        from product.serializers import ProductFileBaseSerializer
+        FILE_SERIALIZER = ProductFileBaseSerializer()
+    except:
+        pass
+
+
 class JobDetailsSerializer(JobSerializer):
-    '''Converts job model and related fields to REST output.'''
+    """Converts job model and related fields to REST output."""
     from error.serializers import ErrorSerializer
     from storage.serializers import ScaleFileBaseSerializer
     from trigger.serializers import TriggerEventDetailsSerializer
@@ -214,18 +247,18 @@ class JobDetailsSerializer(JobSerializer):
     data = serializers.CharField()
     results = serializers.CharField()
 
-    job_exes = JobExecutionBaseSerializer()
-
     # Attempt to serialize related model fields
     # Use a localized import to make higher level application dependencies optional
     try:
         from recipe.serializers import RecipeSerializer
         recipes = RecipeSerializer()
     except:
-        pass
+        recipes = []
 
-    inputs = serializers.CharField()
-    outputs = serializers.CharField()
+    job_exes = JobExecutionBaseSerializer()
+
+    inputs = JobDetailsInputSerializer()
+    outputs = JobDetailsOutputSerializer()
 
     # TODO Remove this attribute once the UI migrates to "inputs"
     input_files = ScaleFileBaseSerializer()
@@ -235,30 +268,30 @@ class JobDetailsSerializer(JobSerializer):
         from product.serializers import ProductFileBaseSerializer
         products = ProductFileBaseSerializer()
     except:
-        pass
+        products = []
 
 
 class JobListSerializer(pagination.PaginationSerializer):
-    '''Converts a list of job models to paginated REST output.'''
+    """Converts a list of job models to paginated REST output."""
     class Meta:
         object_serializer_class = JobSerializer
 
 
 class JobUpdateSerializer(JobSerializer):
-    '''Converts job updates to REST output'''
+    """Converts job updates to REST output"""
     from storage.serializers import ScaleFileBaseSerializer
 
     input_files = ScaleFileBaseSerializer()
 
 
 class JobUpdateListSerializer(pagination.PaginationSerializer):
-    '''Converts a list of job update models to paginated REST output.'''
+    """Converts a list of job update models to paginated REST output."""
     class Meta:
         object_serializer_class = JobUpdateSerializer
 
 
 class JobExecutionSerializer(JobExecutionBaseSerializer):
-    '''Converts job execution model fields to REST output'''
+    """Converts job execution model fields to REST output"""
     from error.serializers import ErrorBaseSerializer
     from node.serializers import NodeBaseSerializer
 
@@ -268,13 +301,13 @@ class JobExecutionSerializer(JobExecutionBaseSerializer):
 
 
 class JobExecutionListSerializer(pagination.PaginationSerializer):
-    '''Converts a list of job execution models to paginated REST output.'''
+    """Converts a list of job execution models to paginated REST output."""
     class Meta:
         object_serializer_class = JobExecutionSerializer
 
 
 class JobExecutionDetailsSerializer(JobExecutionSerializer):
-    '''Converts job execution model fields to REST output'''
+    """Converts job execution model fields to REST output"""
     from error.serializers import ErrorSerializer
     from node.serializers import NodeSerializer
 
@@ -298,18 +331,18 @@ class JobExecutionDetailsSerializer(JobExecutionSerializer):
 
 
 class JobExecutionLogSerializer(JobExecutionSerializer):
-    '''Converts job execution model fields to REST output'''
+    """Converts job execution model fields to REST output"""
     is_finished = serializers.BooleanField()
     stdout = serializers.CharField()
     stderr = serializers.CharField()
 
 
 class JobWithExecutionSerializer(JobSerializer):
-    '''Converts job with latest execution model fields to REST output'''
+    """Converts job with latest execution model fields to REST output"""
     latest_job_exe = JobExecutionBaseSerializer()
 
 
 class JobWithExecutionListSerializer(pagination.PaginationSerializer):
-    '''Converts a list of job with latest execution models to paginated REST output.'''
+    """Converts a list of job with latest execution models to paginated REST output."""
     class Meta:
         object_serializer_class = JobWithExecutionSerializer

--- a/scale/job/serializers.py
+++ b/scale/job/serializers.py
@@ -214,7 +214,6 @@ class JobDetailsSerializer(JobSerializer):
     data = serializers.CharField()
     results = serializers.CharField()
 
-    input_files = ScaleFileBaseSerializer()
     job_exes = JobExecutionBaseSerializer()
 
     # Attempt to serialize related model fields
@@ -225,6 +224,13 @@ class JobDetailsSerializer(JobSerializer):
     except:
         pass
 
+    inputs = serializers.CharField()
+    outputs = serializers.CharField()
+
+    # TODO Remove this attribute once the UI migrates to "inputs"
+    input_files = ScaleFileBaseSerializer()
+
+    # TODO Remove this attribute once the UI migrates to "outputs"
     try:
         from product.serializers import ProductFileBaseSerializer
         products = ProductFileBaseSerializer()

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -136,17 +136,33 @@ class TestJobDetailsView(TestCase):
             'command': 'test_cmd',
             'command_arguments': 'test_arg',
             'input_data': [{
+                'type': 'property',
+                'name': 'input_field',
+            }, {
                 'type': 'file',
-                'name': 'input_file'
+                'name': 'input_file',
+            }, {
+                'type': 'files',
+                'name': 'input_files',
             }],
-            'output_data': [],
+            'output_data': [{
+                'type': 'file',
+                'name': 'output_file',
+            }, {
+                'type': 'files',
+                'name': 'output_files',
+            }],
             'shared_resources': [],
         }
+
+        job_data = {
+            'input_data': []
+        }
+        job_results = {
+            'output_data': []
+        }
         self.job_type = job_test_utils.create_job_type(interface=job_interface)
-        self.job = job_test_utils.create_job(
-            job_type=self.job_type,
-            data={'input_data': [{'name': 'input_file', 'file_id': self.file.id}]},
-        )
+        self.job = job_test_utils.create_job(job_type=self.job_type, data=job_data, results=job_results)
 
         # Attempt to stage related models
         self.job_exe = job_test_utils.create_job_exe(job=self.job)
@@ -157,7 +173,7 @@ class TestJobDetailsView(TestCase):
             self.recipe_job = recipe_test_utils.create_recipe_job(self.recipe, job=self.job)
         except:
             self.recipe = None
-            self.receip_job = None
+            self.recipe_job = None
 
         try:
             import product.test.utils as product_test_utils
@@ -165,8 +181,8 @@ class TestJobDetailsView(TestCase):
         except:
             self.product = None
 
-    def test_successful(self):
-        """Tests successfully calling the jobs view."""
+    def test_successful_empty(self):
+        """Tests successfully calling the job details view with no data or results."""
 
         url = '/jobs/%i/' % self.job.id
         response = self.client.generic('GET', url)
@@ -175,8 +191,14 @@ class TestJobDetailsView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(result['job_type']['name'], self.job.job_type.name)
         self.assertEqual(result['job_type_rev']['job_type']['id'], self.job.job_type.id)
-        self.assertEqual(len(result['input_files']), 1)
-        self.assertEqual(result['input_files'][0]['id'], self.file.id)
+
+        self.assertEqual(len(result['inputs']), 3)
+        for data_input in result['inputs']:
+            self.assertIsNone(data_input['value'])
+
+        self.assertEqual(len(result['outputs']), 2)
+        for data_output in result['outputs']:
+            self.assertIsNone(data_output['value'])
 
         if self.job_exe:
             self.assertEqual(result['job_exes'][0]['command_arguments'], self.job_exe.command_arguments)
@@ -188,10 +210,97 @@ class TestJobDetailsView(TestCase):
         else:
             self.assertEqual(len(result['recipes']), 0)
 
+    def test_successful_property(self):
+        """Tests successfully calling the job details view for one input property."""
+        self.job.job_type_rev.interface['input_data'] = [{
+            'name': 'input_field',
+            'type': 'property',
+        }]
+        self.job.job_type_rev.save()
+        self.job.data['input_data'] = [{
+            'name': 'input_field',
+            'value': 10,
+        }]
+        self.job.save()
+
+        url = '/jobs/%i/' % self.job.id
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(len(result['inputs']), 1)
+        self.assertEqual(result['inputs'][0]['value'], 10)
+
+    def test_successful_file(self):
+        """Tests successfully calling the job details view for one input/output file."""
+        self.job.job_type_rev.interface['input_data'] = [{
+            'name': 'input_file',
+            'type': 'file',
+        }]
+        self.job.job_type_rev.interface['output_data'] = [{
+            'name': 'output_file',
+            'type': 'file',
+        }]
+        self.job.job_type_rev.save()
+        self.job.data['input_data'] = [{
+            'name': 'input_file',
+            'file_id': self.file.id,
+        }]
         if self.product:
-            self.assertEqual(result['products'][0]['file_name'], self.product.file_name)
-        else:
-            self.assertEqual(len(result['products']), 0)
+            self.job.results['output_data'] = [{
+                'name': 'output_file',
+                'file_id': self.product.id,
+            }]
+        self.job.save()
+
+        url = '/jobs/%i/' % self.job.id
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(len(result['inputs']), 1)
+        self.assertEqual(result['inputs'][0]['value']['id'], self.file.id)
+
+        if self.product:
+            self.assertEqual(len(result['outputs']), 1)
+            self.assertEqual(result['outputs'][0]['value']['id'], self.product.id)
+
+    def test_successful_files(self):
+        """Tests successfully calling the job details view for multiple input/output files."""
+        self.job.job_type_rev.interface['input_data'] = [{
+            'name': 'input_files',
+            'type': 'files',
+        }]
+        self.job.job_type_rev.interface['output_data'] = [{
+            'name': 'output_files',
+            'type': 'files',
+        }]
+        self.job.job_type_rev.save()
+        self.job.data['input_data'] = [{
+            'name': 'input_files',
+            'file_ids': [self.file.id],
+        }]
+        if self.product:
+            self.job.results['output_data'] = [{
+                'name': 'output_files',
+                'file_ids': [self.product.id],
+            }]
+        self.job.save()
+
+        url = '/jobs/%i/' % self.job.id
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(len(result['inputs']), 1)
+        self.assertEqual(result['inputs'][0]['value'][0]['id'], self.file.id)
+
+        if self.product:
+            self.assertEqual(len(result['outputs']), 1)
+            self.assertEqual(result['outputs'][0]['value'][0]['id'], self.product.id)
 
     def test_cancel_successful(self):
         """Tests successfully cancelling a job."""
@@ -204,7 +313,7 @@ class TestJobDetailsView(TestCase):
         self.assertEqual(result['status'], 'CANCELED')
 
     def test_cancel_bad_param(self):
-        """Tests successfully cancelling a job."""
+        """Tests cancelling a job with invalid arguments."""
 
         url = '/jobs/%i/' % self.job.id
         data = {'foo': 'bar'}
@@ -212,7 +321,7 @@ class TestJobDetailsView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_cancel_bad_value(self):
-        """Tests successfully cancelling a job."""
+        """Tests cancelling a job with an incorrect status."""
 
         url = '/jobs/%i/' % self.job.id
         data = {'status': 'COMPLETED'}

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -130,7 +130,21 @@ class TestJobDetailsView(TestCase):
         django.setup()
 
         self.file = storage_test_utils.create_file()
+
+        job_interface = {
+            'version': '1.0',
+            'command': 'test_cmd',
+            'command_arguments': 'test_arg',
+            'input_data': [{
+                'type': 'file',
+                'name': 'input_file'
+            }],
+            'output_data': [],
+            'shared_resources': [],
+        }
+        self.job_type = job_test_utils.create_job_type(interface=job_interface)
         self.job = job_test_utils.create_job(
+            job_type=self.job_type,
             data={'input_data': [{'name': 'input_file', 'file_id': self.file.id}]},
         )
 

--- a/scale/job/test/utils.py
+++ b/scale/job/test/utils.py
@@ -76,7 +76,7 @@ register_trigger_rule_handler(MockErrorTriggerRuleHandler())
 
 
 def create_job(job_type=None, event=None, status='PENDING', error=None, data=None, num_exes=0, queued=None,
-               started=None, ended=None, last_status_change=None, priority=100):
+               started=None, ended=None, last_status_change=None, priority=100, results=None):
     '''Creates a job model for unit testing
 
     :returns: The job model
@@ -106,6 +106,7 @@ def create_job(job_type=None, event=None, status='PENDING', error=None, data=Non
     job.ended = ended
     job.last_status_change = last_status_change
     job.error = error
+    job.results = results
     job.save()
     return job
 


### PR DESCRIPTION
- Adds "inputs" and "outputs" top-level list attributes to the job details view.
- Each input or output consists of a name, type, and value. When a job has not yet run, the name and types of its inputs and outputs will always be defined, but the value may be null. A value can consist of primitives, a file, or an array of files. A file could be a basic scale file or a product file.
- Deprecates the "input_files" and "products" attributes for future removal.
- The serializer implementation is a bit of a hack because the value attribute can contain different types that must be handled dynamically.