### PR TITLE
Added versioned URLs for REST API.

### DIFF
--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -7,7 +7,7 @@ import django.core.urlresolvers as urlresolvers
 import rest_framework.status as status
 from django.db import transaction
 from django.http.response import Http404
-from rest_framework.generics import GenericAPIView, ListAPIView, RetrieveAPIView
+from rest_framework.generics import GenericAPIView, ListAPIView, ListCreateAPIView, RetrieveAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -31,7 +31,7 @@ from util.rest import BadParameter
 logger = logging.getLogger(__name__)
 
 
-class JobTypesView(ListAPIView):
+class JobTypesView(ListCreateAPIView):
     """This view is the endpoint for retrieving the list of all job types."""
     queryset = JobType.objects.all()
     serializer_class = JobTypeSerializer
@@ -59,7 +59,7 @@ class JobTypesView(ListAPIView):
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
 
-    def post(self, request):
+    def create(self, request):
         """Creates a new job type and returns a link to the detail URL
 
         :param request: the HTTP POST request

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -93,13 +93,18 @@ MIDDLEWARE_CLASSES = (
 )
 
 REST_FRAMEWORK = {
+    'DEFAULT_FILTER_BACKENDS': (
+        'rest_framework.filters.DjangoFilterBackend',
+    ),
     'DEFAULT_PAGINATION_CLASS': 'util.rest.DefaultPagination',
-    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
         'rest_framework.renderers.BrowsableAPIRenderer',
         'rest_framework.renderers.AdminRenderer',
     ),
+    'ALLOWED_VERSIONS': ('v3',),
+    'DEFAULT_VERSION': 'v3',
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
 }
 
 ROOT_URLCONF = 'scale.urls'

--- a/scale/scale/urls.py
+++ b/scale/scale/urls.py
@@ -1,9 +1,31 @@
-'''Combines all of the URLs for the Scale RESTful services'''
+"""Combines all of the URLs for the Scale RESTful services"""
+
 from django.conf.urls import patterns, include, url
+
+import util.rest as rest_util
 
 # Enable the admin applications
 from django.contrib import admin
 admin.autodiscover()
+
+# Add all the applications that expose REST APIs
+REST_API_APPS = [
+    'error',
+    'ingest',
+    'job',
+    'metrics',
+    'node',
+    'port',
+    'product',
+    'queue',
+    'recipe',
+    'scheduler',
+    'source',
+    'storage',
+]
+
+# Generate URLs for all REST APIs with version prefix
+rest_urls = rest_util.get_versioned_urls(REST_API_APPS)
 
 urlpatterns = patterns(
     '',
@@ -11,17 +33,4 @@ urlpatterns = patterns(
     # Map all the paths required by the admin applications
     url(r'^admin/', include(admin.site.urls)),
 
-    # Include RESTful API URLs
-    url(r'', include('error.urls')),
-    url(r'', include('ingest.urls')),
-    url(r'', include('job.urls')),
-    url(r'', include('metrics.urls')),
-    url(r'', include('node.urls')),
-    url(r'', include('port.urls')),
-    url(r'', include('product.urls')),
-    url(r'', include('queue.urls')),
-    url(r'', include('recipe.urls')),
-    url(r'', include('scheduler.urls')),
-    url(r'', include('source.urls')),
-    url(r'', include('storage.urls')),
-)
+) + rest_urls

--- a/scale/util/rest.py
+++ b/scale/util/rest.py
@@ -2,12 +2,13 @@
 from __future__ import unicode_literals
 
 import datetime
-import json
 
 import django.utils.timezone as timezone
 import rest_framework.pagination as pagination
 import rest_framework.serializers as serializers
 import rest_framework.status as status
+from django.conf import settings
+from django.conf.urls import include, url
 from rest_framework.exceptions import APIException
 
 import util.parse as parse_util
@@ -34,6 +35,37 @@ class BadParameter(APIException):
 class ReadOnly(APIException):
     """Exception indicating a REST API call is attempting to update a field that does not support it."""
     status_code = status.HTTP_400_BAD_REQUEST
+
+
+def get_versioned_urls(apps):
+    """Generates a list of URL patterns for applications with REST APIs
+
+    :param apps: A list of application names to register.
+    :type apps: list[string]
+    :returns: A list of URL patterns for REST APIs with version prefixes.
+    :rtype: list[:class:`django.core.urlresolvers.RegexURLPattern`]
+    """
+    urls = []
+
+    # TODO Remove the default version once applications are migrated
+    for app in apps:
+        urls.append(url(r'', include(app + '.urls')))
+
+    # Check whether the application is configured to use versions
+    rest_settings = getattr(settings, 'REST_FRAMEWORK', None)
+    if not rest_settings:
+        return urls
+    allowed_versions = rest_settings.get('ALLOWED_VERSIONS', None)
+    if not allowed_versions:
+        return urls
+
+    # Generate a URL pattern for each endpoint with a version prefix
+    for version in allowed_versions:
+        version_urls = []
+        for app in apps:
+            version_urls.append(url(r'^' + version + '/', include(app + '.urls', namespace=version)))
+        urls.extend(version_urls)
+    return urls
 
 
 def check_update(request, fields):


### PR DESCRIPTION
We decided to implement REST API versions using the URL prefix approach. DRF handles this by requiring a prefix for every URL pattern and declaring a namepsace for reverse lookups. Because every URL pattern must be updated, I created a utility method to automate it. This scheme is described here:
http://www.django-rest-framework.org/api-guide/versioning/#namespaceversioning

Therefore, to start a new version, we can simply add 'v4' to the settings file and all the existing APIs will be cloned to the new parent endpoint. Add that point, new serializer or view behavior can be implemented that inspect the requested version and take action accordingly using the request.version attribute.

- All existing endpoints should continue to work.
- All existing endpoints are now duplicated under the /v3 prefix.
- Once the UI, production search indexers, and specific production jobs are migrated we can remove the old endpoints without a version prefix.

Closes #107 