### PR TITLE
Issue 155 - Non-null Strike field

### DIFF
--- a/scale/ingest/migrations/0002_auto_20160414_0937.py
+++ b/scale/ingest/migrations/0002_auto_20160414_0937.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ingest', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ingest',
+            name='strike',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, default=1, to='ingest.Strike'),
+            preserve_default=False,
+        ),
+    ]

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -265,7 +265,7 @@ class Ingest(models.Model):
 
     :keyword file_name: The name of the file
     :type file_name: :class:`django.db.models.CharField`
-    :keyword strike: The Strike process that handled this file's transfer
+    :keyword strike: The Strike process that created this ingest
     :type strike: :class:`django.db.models.ForeignKey`
     :keyword job: The ingest job that is processing this ingest
     :type job: :class:`django.db.models.ForeignKey`
@@ -318,10 +318,9 @@ class Ingest(models.Model):
     )
 
     file_name = models.CharField(max_length=250, db_index=True)
-    strike = models.ForeignKey('ingest.Strike', blank=True, null=True)
+    strike = models.ForeignKey('ingest.Strike', on_delete=models.PROTECT)
     job = models.ForeignKey('job.Job', blank=True, null=True)
-    status = models.CharField(choices=INGEST_STATUSES, default='TRANSFERRING',
-                              max_length=50, db_index=True)
+    status = models.CharField(choices=INGEST_STATUSES, default='TRANSFERRING', max_length=50, db_index=True)
 
     transfer_path = models.CharField(max_length=1000)
     bytes_transferred = models.BigIntegerField()


### PR DESCRIPTION
This is a simple change to make the strike field non-nullable in the ingest model. This helps a number of other pieces of the code which expects the strike field to be populated.

This closes #155.