### PR TITLE
Issue 124 - Default Algorithm Error

### DIFF
--- a/scale/job/configuration/interface/error_interface.py
+++ b/scale/job/configuration/interface/error_interface.py
@@ -68,21 +68,20 @@ class ErrorInterface(object):
         return self.definition
 
     def get_error(self, exit_code=None):
-        ''' This method retrieves an error given an exit_code.
+        '''This method retrieves an error given an exit code
 
-        :param exit_code: The exit code from a previously ran job.
+        :param exit_code: The exit code from a task
         :type exit_code: int
-        :returns: The error model mapped to the given exit code.
+        :returns: The error model mapped to the given exit code
         :rtype: :class:`error.models.Error`
         '''
 
         error = None
         if exit_code is not None:
-            # if the exit code is zero, None should be returned
+            # If the exit code is zero, None should be returned
             if exit_code == 0:
                 return None
 
-            # get the exit codes
             exit_codes = self.definition.get('exit_codes')
             if exit_codes:
                 # Retrieve the error item using the exit code from the dict
@@ -91,6 +90,10 @@ class ErrorInterface(object):
                 if error_name is not None:
                     # get the name to search for in the 'Error' database table
                     error = self._lookup_error(error_name)
+
+            if not error:
+                # No exit code match, so return general algorithm error
+                error = Error.objects.get_builtin_error('algorithm-unknown')
 
         return error
 
@@ -131,10 +134,10 @@ class ErrorInterface(object):
         :rtype: :class:`error.models.Error`
         '''
         try:
-            return Error.objects.get(name=name)
+            return Error.objects.get_builtin_error(name)
         except Error.DoesNotExist:
             logger.exception('Unable to find error mapping: %s', name)
-            pass
+            return None
 
     def _populate_default_values(self):
         '''Goes through the definition and fills in any missing default values'''

--- a/scale/job/configuration/interface/error_interface.py
+++ b/scale/job/configuration/interface/error_interface.py
@@ -68,11 +68,12 @@ class ErrorInterface(object):
         return self.definition
 
     def get_error(self, exit_code=None):
-        '''This method retrieves an error given an exit code
+        '''This method retrieves the error that maps to the given exit code. If the exit code is non-zero (success) None
+        is returned. For a failure exit code with no mapping, a general algorithm error is returned.
 
         :param exit_code: The exit code from a task
         :type exit_code: int
-        :returns: The error model mapped to the given exit code
+        :returns: The error model mapped to the given exit code, possibly None
         :rtype: :class:`error.models.Error`
         '''
 

--- a/scale/job/fixtures/basic_job_errors.json
+++ b/scale/job/fixtures/basic_job_errors.json
@@ -46,5 +46,17 @@
             "created": "2015-03-11T00:00:00.0Z",
             "last_modified": "2015-03-11T00:00:00.0Z"
         }
+    },
+    {
+        "model": "error.Error",
+        "pk": null,
+        "fields": {
+            "name": "algorithm-unknown",
+            "title": "Algorithm Failure",
+            "description": "The algorithm failed by returning a non-zero exit code. To allow Scale to detect more specific problems with the algorithm, please define the appropriate errors for the non-zero exit codes that the algorithm may return.",
+            "category": "ALGORITHM",
+            "created": "2016-04-13T00:00:00.0Z",
+            "last_modified": "2016-04-13T00:00:00.0Z"
+        }
     }
 ]


### PR DESCRIPTION
This issue involved the creation of a default algorithm error that is reported for all job tasks that fail with a non-zero exit code that has no user-defined error mapped. This closes #124.

1. New error added to fixture
2. Small logic change in error mapping code
3. Added unit test