### PR TITLE
Issue 130 - Fix pre and post exit codes

### DIFF
--- a/scale/error/fixtures/basic_errors.json
+++ b/scale/error/fixtures/basic_errors.json
@@ -5,7 +5,7 @@
         "fields": {
             "name": "unknown",
             "title": "Unknown",
-            "description": "The cause of this failure is unknown. System administrators should investigate this failure to determine the true cause and make sure it is correctly tracked in the future.",
+            "description": "The cause of this failure is unknown. System administrators should investigate this failure to determine the root cause and make sure it is correctly tracked in the future.",
             "category": "SYSTEM",
             "created": "2015-03-11T00:00:00.0Z",
             "last_modified": "2015-03-11T00:00:00.0Z"
@@ -17,10 +17,22 @@
         "fields": {
             "name": "database",
             "title": "Database",
-            "description": "A query against the Scale database failed.",
+            "description": "An error occurred with the Scale database. System administrators should investigate this failure to determine the root cause and correct it.",
             "category": "SYSTEM",
             "created": "2015-03-11T00:00:00.0Z",
             "last_modified": "2015-03-11T00:00:00.0Z"
+        }
+    },
+    {
+        "model": "error.Error",
+        "pk": null,
+        "fields": {
+            "name": "database-operation",
+            "title": "Database Operation",
+            "description": "A Scale database operation failure occurred. This can be caused by issues such as the database reaching its connection limit, being unreachable, query deadlocks, and other operation issues.",
+            "category": "SYSTEM",
+            "created": "2016-04-14T00:00:00.0Z",
+            "last_modified": "2016-04-14T00:00:00.0Z"
         }
     },
     {

--- a/scale/error/models.py
+++ b/scale/error/models.py
@@ -36,6 +36,14 @@ class ErrorManager(models.Manager):
         """
         return self.get_builtin_error('database')
 
+    def get_database_operation_error(self):
+        """Returns the error for a database operation problem
+
+        :returns: The database operation error
+        :rtype: :class:`error.models.Error`
+        """
+        return self.get_builtin_error('database-operation')
+
     def get_filesystem_error(self):
         """Returns the error for a filesystem problem
 

--- a/scale/job/management/commands/scale_pre_steps.py
+++ b/scale/job/management/commands/scale_pre_steps.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 
 from django.core.management.base import BaseCommand
-from django.db.utils import DatabaseError
+from django.db.utils import DatabaseError, OperationalError
 from optparse import make_option
 
 import job.execution.file_system as file_system
@@ -20,11 +20,14 @@ from util.retry import retry_database_query
 logger = logging.getLogger(__name__)
 
 
-# Exit codes that map to specific job errors
-DB_EXIT_CODE = 1001
-IO_EXIT_CODE = 1002
-NFS_EXIT_CODE = 1003
+GENERAL_FAIL_EXIT_CODE = 1
+# Exit codes that map to specific errors
+DB_EXIT_CODE = 2
+DB_OP_EXIT_CODE = 3
+IO_EXIT_CODE = 4
+NFS_EXIT_CODE = 5
 EXIT_CODE_DICT = {DB_EXIT_CODE, Error.objects.get_database_error,
+                  DB_OP_EXIT_CODE, Error.objects.get_database_operation_error,
                   IO_EXIT_CODE, Error.objects.get_filesystem_error,
                   NFS_EXIT_CODE, Error.objects.get_nfs_error}
 
@@ -80,14 +83,17 @@ class Command(BaseCommand):
         except Exception as ex:
             logger.exception('Job Execution %i: Error performing pre-job steps', job_exe_id)
 
-            exit_code = -1
-            if isinstance(ex, DatabaseError):
+            exit_code = GENERAL_FAIL_EXIT_CODE
+            if isinstance(ex, OperationalError):
+                exit_code = DB_OP_EXIT_CODE
+            elif isinstance(ex, DatabaseError):
                 exit_code = DB_EXIT_CODE
             elif isinstance(ex, NfsError):
                 exit_code = NFS_EXIT_CODE
             elif isinstance(ex, IOError):
                 exit_code = IO_EXIT_CODE
             sys.exit(exit_code)
+
         logger.info('Command completed: scale_pre_steps')
 
     def _chmod_job_dir(self, target_dir):


### PR DESCRIPTION
This issue looked at the pre and post task exit codes. This closes #130.

1. Created a new error to differentiate database and operational errors, which is the difference between database programming type issues and connection type issues.

2. Changed task exit codes to fit within 8 bits. Apparently Mesos only reports 8 bits worth of exit code, so the large exit codes were being truncated at the binary level and not matching the expected value in the scheduler.