### PR TITLE
Issue 158 - Builtin Error Metrics

### DIFF
--- a/scale/docs/interface/rest/error.rst
+++ b/scale/docs/interface/rest/error.rst
@@ -61,6 +61,8 @@ These services provide access to information about registered errors and error m
 +--------------------+-------------------+-------------------------------------------------------------------------------------+
 | .category          | String            | The category of the error. Choices: [SYSTEM, ALGORITHM, DATA].                      |
 +--------------------+-------------------+-------------------------------------------------------------------------------------+
+| .is_builtin        | Boolean           | Whether the error was loaded during the installation process.                       |
++--------------------+-------------------+-------------------------------------------------------------------------------------+
 | .created           | ISO-8601 Datetime | When the associated database model was initially created.                           |
 +--------------------+-------------------+-------------------------------------------------------------------------------------+
 | .last_modified     | ISO-8601 Datetime | When the associated database model was last saved.                                  |
@@ -78,6 +80,7 @@ These services provide access to information about registered errors and error m
 |                "title": "Unknown",                                                                                           |
 |                "description": "The error that caused the failure is unknown.",                                               |
 |                "category": "SYSTEM",                                                                                         |
+|                "is_builtin": true,                                                                                           |
 |                "created": "2015-03-11T00:00:00Z",                                                                            |
 |                "last_modified": "2015-03-11T00:00:00Z"                                                                       |
 |            },                                                                                                                |
@@ -137,6 +140,7 @@ These services provide access to information about registered errors and error m
 |        "title": "Error 1",                                                                                                   |
 |        "description": "This is an algorithm error",                                                                          |
 |        "category": "ALGORITHM",                                                                                              |
+|        "is_builtin": false,                                                                                                  |
 |        "created": "2015-03-11T00:00:00Z",                                                                                    |
 |        "last_modified": "2015-03-11T00:00:00Z"                                                                               |
 |    }                                                                                                                         |
@@ -170,6 +174,8 @@ These services provide access to information about registered errors and error m
 +--------------------+-------------------+-------------------------------------------------------------------------------------+
 | category           | String            | The category of the error. Choices: [SYSTEM, ALGORITHM, DATA].                      |
 +--------------------+-------------------+-------------------------------------------------------------------------------------+
+| is_builtin         | Boolean           | Whether the error was loaded during the installation process.                       |
++--------------------+-------------------+-------------------------------------------------------------------------------------+
 | created            | ISO-8601 Datetime | When the associated database model was initially created.                           |
 +--------------------+-------------------+-------------------------------------------------------------------------------------+
 | last_modified      | ISO-8601 Datetime | When the associated database model was last saved.                                  |
@@ -182,6 +188,7 @@ These services provide access to information about registered errors and error m
 |        "title": "Unknown",                                                                                                   |
 |        "description": "The error that caused the failure is unknown.",                                                       |
 |        "category": "SYSTEM",                                                                                                 |
+|        "is_builtin": true,                                                                                                   |
 |        "created": "2015-03-11T00:00:00Z",                                                                                    |
 |        "last_modified": "2015-03-11T00:00:00Z"                                                                               |
 |    }                                                                                                                         |
@@ -234,6 +241,7 @@ These services provide access to information about registered errors and error m
 |        "title": "My Error",                                                                                                  |
 |        "description": "An edited error description.",                                                                        |
 |        "category": "ALGORITHM",                                                                                              |
+|        "is_builtin": false,                                                                                                  |
 |        "created": "2015-03-11T00:00:00Z",                                                                                    |
 |        "last_modified": "2015-03-11T00:00:00Z"                                                                               |
 |    }                                                                                                                         |

--- a/scale/docs/interface/rest/job_type.rst
+++ b/scale/docs/interface/rest/job_type.rst
@@ -1140,6 +1140,7 @@ These services provide access to information about job types.
 |                    "name": "Unknown",                                                                                   |
 |                    "description": "The error that caused the failure is unknown.",                                      |
 |                    "category": "SYSTEM",                                                                                |
+|                    "is_builtin": true,                                                                                  |
 |                    "created": "2015-03-11T00:00:00Z",                                                                   |
 |                    "last_modified": "2015-03-11T00:00:00Z"                                                              |
 |                },                                                                                                       |

--- a/scale/error/fixtures/basic_errors.json
+++ b/scale/error/fixtures/basic_errors.json
@@ -7,6 +7,7 @@
             "title": "Unknown",
             "description": "The cause of this failure is unknown. System administrators should investigate this failure to determine the root cause and make sure it is correctly tracked in the future.",
             "category": "SYSTEM",
+            "is_builtin": true,
             "created": "2015-03-11T00:00:00.0Z",
             "last_modified": "2015-03-11T00:00:00.0Z"
         }
@@ -19,6 +20,7 @@
             "title": "Database",
             "description": "An error occurred with the Scale database. System administrators should investigate this failure to determine the root cause and correct it.",
             "category": "SYSTEM",
+            "is_builtin": true,
             "created": "2015-03-11T00:00:00.0Z",
             "last_modified": "2015-03-11T00:00:00.0Z"
         }
@@ -31,6 +33,7 @@
             "title": "Database Operation",
             "description": "A Scale database operation failure occurred. This can be caused by issues such as the database reaching its connection limit, being unreachable, query deadlocks, and other operation issues.",
             "category": "SYSTEM",
+            "is_builtin": true,
             "created": "2016-04-14T00:00:00.0Z",
             "last_modified": "2016-04-14T00:00:00.0Z"
         }
@@ -43,6 +46,7 @@
             "title": "Filesystem IO",
             "description": "An IO operation on the node's local filesystem failed.",
             "category": "SYSTEM",
+            "is_builtin": true,
             "created": "2015-03-11T00:00:00.0Z",
             "last_modified": "2015-03-11T00:00:00.0Z"
         }
@@ -55,6 +59,7 @@
             "title": "NFS",
             "description": "An NFS (Network File System) operation failed.",
             "category": "SYSTEM",
+            "is_builtin": true,
             "created": "2015-03-11T00:00:00.0Z",
             "last_modified": "2015-03-11T00:00:00.0Z"
         }

--- a/scale/error/migrations/0003_error_is_builtin.py
+++ b/scale/error/migrations/0003_error_is_builtin.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('error', '0002_auto_20151217_1319'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='error',
+            name='is_builtin',
+            field=models.BooleanField(default=False, db_index=True),
+            preserve_default=True,
+        ),
+    ]

--- a/scale/error/models.py
+++ b/scale/error/models.py
@@ -11,14 +11,13 @@ CACHED_BUILTIN_ERRORS = {}  # {Name: Error model}
 
 
 class ErrorManager(models.Manager):
-    """Provides additional methods for handling errors
-    """
+    """Provides additional methods for handling errors"""
 
     def get_builtin_error(self, name):
         """Returns the builtin error with the given name
 
         :param name: The name of the error
-        :type name: str
+        :type name: string
         :returns: The error with the given name
         :rtype: :class:`error.models.Error`
         """
@@ -142,6 +141,8 @@ class Error(models.Model):
     :type description: :class:`django.db.models.CharField`
     :keyword category: The category of the error
     :type category: :class:`django.db.models.CharField`
+    :keyword is_builtin: Where the error was loaded during system installation.
+    :type is_builtin: :class:`django.db.models.BooleanField`
 
     :keyword created: When the error model was created
     :type created: :class:`django.db.models.DateTimeField`
@@ -158,6 +159,7 @@ class Error(models.Model):
     title = models.CharField(blank=True, max_length=50, null=True)
     description = models.CharField(max_length=250, null=True)
     category = models.CharField(db_index=True, choices=CATEGORIES, default='SYSTEM', max_length=50)
+    is_builtin = models.BooleanField(db_index=True, default=False)
 
     created = models.DateTimeField(auto_now_add=True)
     last_modified = models.DateTimeField(auto_now=True)
@@ -165,8 +167,7 @@ class Error(models.Model):
     objects = ErrorManager()
 
     def natural_key(self):
-        """Django method to define the natural key for an error as the error
-        name
+        """Django method to define the natural key for an error as the name
 
         :returns: A tuple representing the natural key
         :rtype: tuple(str,)

--- a/scale/error/serializers.py
+++ b/scale/error/serializers.py
@@ -1,23 +1,24 @@
-'''Defines the serializers for errors'''
+"""Defines the serializers for errors"""
 import rest_framework.serializers as serializers
 
 from util.rest import ModelIdSerializer
 
 
 class ErrorBaseSerializer(ModelIdSerializer):
-    '''Converts error model fields to REST output'''
+    """Converts error model fields to REST output"""
     name = serializers.CharField()
     title = serializers.CharField()
     description = serializers.CharField()
     category = serializers.CharField()
+    is_builtin = serializers.BooleanField()
 
 
 class ErrorSerializer(ErrorBaseSerializer):
-    '''Converts error model fields to REST output'''
+    """Converts error model fields to REST output"""
     created = serializers.DateTimeField()
     last_modified = serializers.DateTimeField()
 
 
 class ErrorDetailsSerializer(ErrorSerializer):
-    '''Converts error model fields to REST output'''
+    """Converts error model fields to REST output"""
     pass

--- a/scale/error/test/test_views.py
+++ b/scale/error/test/test_views.py
@@ -1,4 +1,3 @@
-#@PydevCodeAnalysisIgnore
 from __future__ import unicode_literals
 
 import json
@@ -17,12 +16,12 @@ class TestErrorsView(TestCase):
         django.setup()
 
         Error.objects.all().delete()  # Need to remove initial errors loaded by fixtures
-        error_test_utils.create_error(category='SYSTEM')
+        error_test_utils.create_error(category='SYSTEM', is_builtin=True)
         error_test_utils.create_error(category='ALGORITHM')
         error_test_utils.create_error(category='DATA')
 
     def test_list_errors(self):
-        '''Tests successfully calling the get Errors method.'''
+        """Tests successfully calling the get Errors method."""
 
         url = '/errors/'
         response = self.client.get(url)
@@ -32,7 +31,7 @@ class TestErrorsView(TestCase):
         self.assertEqual(len(result['results']), 3)
 
     def test_create_error_success(self):
-        '''Test successfully calling the create Error method.'''
+        """Test successfully calling the create Error method."""
 
         url = '/errors/'
         json_data = {
@@ -50,9 +49,10 @@ class TestErrorsView(TestCase):
         self.assertEqual(result['title'], 'Error 4')
         self.assertEqual(result['description'], 'new error #4')
         self.assertEqual(result['category'], 'ALGORITHM')
+        self.assertFalse(result['is_builtin'])
 
     def test_create_error_missing(self):
-        '''Test calling the create Error method with missing data.'''
+        """Test calling the create Error method with missing data."""
 
         url = '/errors/'
         json_data = {
@@ -64,7 +64,7 @@ class TestErrorsView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
 
     def test_create_error_bad_category(self):
-        '''Test calling the create Error method with a bad category value.'''
+        """Test calling the create Error method with a bad category value."""
 
         url = '/errors/'
         json_data = {
@@ -78,7 +78,7 @@ class TestErrorsView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
 
     def test_create_error_system(self):
-        '''Test that system errors cannot be created.'''
+        """Test that system errors cannot be created."""
 
         url = '/errors/'
         json_data = {
@@ -98,12 +98,12 @@ class TestErrorDetailsView(TestCase):
         django.setup()
 
         Error.objects.all().delete()  # Need to remove initial errors loaded by fixtures
-        self.error1 = error_test_utils.create_error(category='SYSTEM')
+        self.error1 = error_test_utils.create_error(category='SYSTEM', is_builtin=True)
         self.error2 = error_test_utils.create_error(category='ALGORITHM')
         self.error3 = error_test_utils.create_error(category='DATA')
 
     def test_get_error_success(self):
-        '''Test successfully calling the Get Error method.'''
+        """Test successfully calling the Get Error method."""
 
         url = '/errors/%d/' % self.error1.id
         response = self.client.get(url)
@@ -115,9 +115,10 @@ class TestErrorDetailsView(TestCase):
         self.assertEqual(result['title'], self.error1.title)
         self.assertEqual(result['description'], self.error1.description)
         self.assertEqual(result['category'], self.error1.category)
+        self.assertTrue(result['is_builtin'])
 
     def test_get_error_not_found(self):
-        '''Test calling the Get Error method with a bad error id.'''
+        """Test calling the Get Error method with a bad error id."""
 
         url = '/errors/9999/'
         response = self.client.get(url)
@@ -125,7 +126,7 @@ class TestErrorDetailsView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_edit_error_success(self):
-        '''Test successfully calling the edit Error method.'''
+        """Test successfully calling the edit Error method."""
 
         url = '/errors/%d/' % self.error2.id
         json_data = {
@@ -140,9 +141,10 @@ class TestErrorDetailsView(TestCase):
         self.assertEqual(result['title'], 'error EDIT')
         self.assertEqual(result['description'], self.error2.description)
         self.assertEqual(result['category'], self.error2.category)
+        self.assertFalse(result['is_builtin'])
 
     def test_edit_error_not_found(self):
-        '''Test calling the edit Error method with a bad error id.'''
+        """Test calling the edit Error method with a bad error id."""
 
         url = '/errors/9999/'
         json_data = {
@@ -153,7 +155,7 @@ class TestErrorDetailsView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_edit_error_bad_catgory(self):
-        '''Test calling the edit Error method with a bad category.'''
+        """Test calling the edit Error method with a bad category."""
 
         url = '/errors/%d/' % self.error2.id
         json_data = {
@@ -164,7 +166,7 @@ class TestErrorDetailsView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
 
     def test_edit_error_system(self):
-        '''Test that an existing system error cannot be edited.'''
+        """Test that an existing system error cannot be edited."""
 
         url = '/errors/%d/' % self.error1.id
         json_data = {
@@ -175,7 +177,7 @@ class TestErrorDetailsView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
 
     def test_edit_error_change_system(self):
-        '''Test that an existing error cannot be changed to a system level error.'''
+        """Test that an existing error cannot be changed to a system level error."""
 
         url = '/errors/%d/' % self.error2.id
         json_data = {

--- a/scale/error/test/utils.py
+++ b/scale/error/test/utils.py
@@ -1,19 +1,22 @@
-'''Defines utility methods for testing errors'''
+"""Defines utility methods for testing errors"""
+from __future__ import unicode_literals
+
 from error.models import Error
 
 NAME_COUNTER = 1
 
 
-def create_error(name=None, title=None, description=u'Test error description', category=u'SYSTEM'):
-    '''Creates a error model for unit testing
+def create_error(name=None, title=None, description='Test error description', category='SYSTEM', is_builtin=False):
+    """Creates a error model for unit testing
 
     :returns: The error model
     :rtype: :class:`error.models.Error`
-    '''
+    """
 
     if not name:
         global NAME_COUNTER
         name = u'error-%i' % NAME_COUNTER
-        NAME_COUNTER = NAME_COUNTER + 1
+        NAME_COUNTER += 1
 
-    return Error.objects.create(name=name, title=title, description=description, category=category)
+    return Error.objects.create(name=name, title=title, description=description, category=category,
+                                is_builtin=is_builtin)

--- a/scale/job/clock.py
+++ b/scale/job/clock.py
@@ -1,4 +1,4 @@
-'''Contains the functionality of the Scale clock process'''
+"""Contains the functionality of the Scale clock process"""
 from __future__ import unicode_literals
 import abc
 import datetime
@@ -19,16 +19,16 @@ _PROCESSORS = {}
 
 
 class ClockEventError(Exception):
-    '''Error class used when a clock event processor encounters a problem.'''
+    """Error class used when a clock event processor encounters a problem."""
     pass
 
 
 class ClockEventProcessor(object):
-    '''Base class used to process triggered clock events.'''
+    """Base class used to process triggered clock events."""
     __metaclass__ = abc.ABCMeta
 
     def process_event(self, event, last_event=None):
-        '''Callback when a new event is triggered that sub-classes have registered to process.
+        """Callback when a new event is triggered that sub-classes have registered to process.
 
         :param event: The new event that requires processing.
         :type event: :class:`trigger.models.TriggerEvent`
@@ -36,17 +36,17 @@ class ClockEventProcessor(object):
         :type last_event: :class:`trigger.models.TriggerEvent`
 
         :raises :class:`job.clock.ClockEventError`: If the event should be cancelled for any reason.
-        '''
+        """
         raise NotImplemented()
 
 
 def perform_tick():
-    '''Performs an iteration of the Scale clock.
+    """Performs an iteration of the Scale clock.
 
     A clock iteration consists of inspecting any trigger rules and corresponding events to see if there are any that
     have exceeded their scheduled time threshold. For rules that are due to run, a new event is created of the
     configured type and the registered clock function is executed.
-    '''
+    """
 
     # Check all the clock trigger rules
     rules = TriggerRule.objects.filter(type='CLOCK', is_active=True)
@@ -60,15 +60,15 @@ def perform_tick():
 
 
 def register_processor(name, processor_class):
-    '''Registers the given processor class definition to be called by the Scale clock at the given interval.
+    """Registers the given processor class definition to be called by the Scale clock at the given interval.
 
     Processors from other applications can be registered during their ready() method.
 
     :param name: The system name of the processor, which is used in trigger rule configurations.
-    :type name: str
+    :type name: string
     :param processor_class: The processor class to invoke when the associated event is triggered.
     :type processor_class: :class:`job.clock.ClockProcessor`
-    '''
+    """
     if name not in _PROCESSORS:
         _PROCESSORS[name] = []
     logger.debug('Registering clock processor: %s -> %s', name, processor_class)
@@ -76,13 +76,13 @@ def register_processor(name, processor_class):
 
 
 def _check_rule(rule):
-    '''Checks the given rule for validation errors and then triggers an event for processing if the schedule requires.
+    """Checks the given rule for validation errors and then triggers an event for processing if the schedule requires.
 
     :param rule: The system name of the processor, which is used in trigger rule configurations.
     :type rule: :class:`trigger.models.TriggerRule`
 
     :raises :class:`job.clock.ClockEventError`: If there is a configuration problem with the rule.
-    '''
+    """
 
     # Validate the processor name attribute
     if rule.name not in _PROCESSORS:
@@ -108,7 +108,7 @@ def _check_rule(rule):
 
 
 def _check_schedule(duration, last_event=None):
-    '''Checks the given rule schedule and previously triggered event to determine whether a new event should trigger.
+    """Checks the given rule schedule and previously triggered event to determine whether a new event should trigger.
 
     :param duration: The scheduled duration used to determine when to fire the next trigger event.
     :type duration: datetime.timedelta
@@ -117,7 +117,7 @@ def _check_schedule(duration, last_event=None):
     :type last_event: :class:`trigger.models.TriggerEvent`
     :returns: True if a new event should be triggered, false otherwise.
     :rtype: bool
-    '''
+    """
     # The master clock smallest unit is 1 minute so clear anything smaller to avoid schedule drift
     current = timezone.now().replace(second=0, microsecond=0)
     base = datetime.datetime(year=current.year, month=current.month, day=current.day, tzinfo=timezone.utc)
@@ -133,8 +133,8 @@ def _check_schedule(duration, last_event=None):
     # This recovers infrequent jobs after the system has been down for longer than the schedule
     elapsed = current - last_event.occurred
     if ((duration >= datetime.timedelta(days=1) and elapsed >= datetime.timedelta(days=1) or
-         duration >= datetime.timedelta(hours=1) and elapsed >= datetime.timedelta(hours=1)) and
-        elapsed >= duration):
+            duration >= datetime.timedelta(hours=1) and elapsed >= datetime.timedelta(hours=1)) and
+            elapsed >= duration):
         return True
 
     # Trigger based on absolute time within the current day
@@ -146,7 +146,7 @@ def _check_schedule(duration, last_event=None):
 
 @transaction.atomic
 def _trigger_event(rule, last_event=None):
-    '''Creates a new event based on the given rule and invokes the registered processor to handle it.
+    """Creates a new event based on the given rule and invokes the registered processor to handle it.
 
     :param rule: The rule form which to derive the new event.
     :type rule: :class:`trigger.models.TriggerRule`
@@ -155,7 +155,7 @@ def _trigger_event(rule, last_event=None):
     :type last_event: :class:`trigger.models.TriggerEvent`
 
     :raises :class:`job.clock.ClockEventError`: If the registered processor rejects the event.
-    '''
+    """
 
     # Create a new trigger event for the rule
     event_type = rule.configuration['event_type']

--- a/scale/job/fixtures/basic_job_errors.json
+++ b/scale/job/fixtures/basic_job_errors.json
@@ -7,6 +7,7 @@
             "title": "Task Launch",
             "description": "A task for this job execution failed to launch.",
             "category": "SYSTEM",
+            "is_builtin": true,
             "created": "2016-04-13T00:00:00.0Z",
             "last_modified": "2016-04-13T00:00:00.0Z"
         }
@@ -19,6 +20,7 @@
             "title": "Docker Task Launch",
             "description": "A Docker task for this job execution failed to launch a Docker container.",
             "category": "SYSTEM",
+            "is_builtin": true,
             "created": "2016-04-13T00:00:00.0Z",
             "last_modified": "2016-04-13T00:00:00.0Z"
         }
@@ -31,6 +33,7 @@
             "title": "Node Lost",
             "description": "The node failed and was lost, causing this job execution to be lost.",
             "category": "SYSTEM",
+            "is_builtin": true,
             "created": "2015-03-11T00:00:00.0Z",
             "last_modified": "2015-03-11T00:00:00.0Z"
         }
@@ -43,6 +46,7 @@
             "title": "Timeout",
             "description": "The job execution exceeded its timeout threshold.",
             "category": "ALGORITHM",
+            "is_builtin": true,
             "created": "2015-03-11T00:00:00.0Z",
             "last_modified": "2015-03-11T00:00:00.0Z"
         }
@@ -55,6 +59,7 @@
             "title": "Algorithm Failure",
             "description": "The algorithm failed by returning a non-zero exit code. To allow Scale to detect more specific problems with the algorithm, please define the appropriate errors for the non-zero exit codes that the algorithm may return.",
             "category": "ALGORITHM",
+            "is_builtin": true,
             "created": "2016-04-13T00:00:00.0Z",
             "last_modified": "2016-04-13T00:00:00.0Z"
         }

--- a/scale/metrics/apps.py
+++ b/scale/metrics/apps.py
@@ -1,21 +1,22 @@
-'''Defines the application configuration for the scale metrics application'''
+"""Defines the application configuration for the scale metrics application"""
+from __future__ import unicode_literals
 from django.apps import AppConfig
 
 
 class MetricsConfig(AppConfig):
-    '''Configuration for the metrics app
-    '''
-    name = u'metrics'
-    label = u'metrics'
-    verbose_name = u'Metrics collection'
+    """Configuration for the metrics app"""
+    name = 'metrics'
+    label = 'metrics'
+    verbose_name = 'Metrics collection'
 
     def ready(self):
-        '''Registers the metrics processors with the clock system.'''
+        """Registers the metrics processors with the clock system."""
         import job.clock as clock
         import metrics.registry as registry
         from metrics.daily_metrics import DailyMetricsProcessor
-        from metrics.models import MetricsIngest, MetricsJobType
-        from metrics.serializers import MetricsIngestDetailsSerializer, MetricsJobTypeDetailsSerializer
+        from metrics.models import MetricsError, MetricsIngest, MetricsJobType
+        from metrics.serializers import (MetricsErrorDetailsSerializer, MetricsIngestDetailsSerializer,
+                                         MetricsJobTypeDetailsSerializer)
 
         clock.register_processor('scale-daily-metrics', DailyMetricsProcessor)
 
@@ -23,5 +24,6 @@ class MetricsConfig(AppConfig):
         # clock.register_processor('scale-resource-metrics', ResourceMetricsProcessor)
 
         # Register metrics type providers
+        registry.register_provider(MetricsError.objects, MetricsErrorDetailsSerializer)
         registry.register_provider(MetricsIngest.objects, MetricsIngestDetailsSerializer)
         registry.register_provider(MetricsJobType.objects, MetricsJobTypeDetailsSerializer)

--- a/scale/metrics/daily_metrics.py
+++ b/scale/metrics/daily_metrics.py
@@ -1,4 +1,5 @@
-'''Defines the clock event processor for daily system metrics.'''
+"""Defines the clock event processor for daily system metrics."""
+from __future__ import unicode_literals
 import datetime
 import logging
 
@@ -12,19 +13,19 @@ logger = logging.getLogger(__name__)
 
 
 class DailyMetricsProcessor(ClockEventProcessor):
-    '''This class schedules daily metrics jobs on the cluster.'''
+    """This class schedules daily metrics jobs on the cluster."""
 
     def process_event(self, event, last_event=None):
-        '''See :meth:`job.clock.ClockEventProcessor.process_event`.
+        """See :meth:`job.clock.ClockEventProcessor.process_event`.
 
         Compares the new event with the last event any missing metrics jobs.
-        '''
+        """
 
         # Attempt to get the daily metrics job type
         try:
-            job_type = JobType.objects.filter(name=u'scale-daily-metrics').last()
+            job_type = JobType.objects.filter(name='scale-daily-metrics').last()
         except JobType.DoesNotExist:
-            raise ClockEventError(u'Missing required job type: scale-daily-metrics')
+            raise ClockEventError('Missing required job type: scale-daily-metrics')
 
         if last_event:
             # Build a list of days that require metrics
@@ -37,9 +38,9 @@ class DailyMetricsProcessor(ClockEventProcessor):
         # Schedule one job for each required day
         for day in days:
             job_data = {
-                u'input_data': [{
-                    u'name': u'Day',
-                    u'value': day.strftime(u'%Y-%m-%d'),
+                'input_data': [{
+                    'name': 'Day',
+                    'value': day.strftime('%Y-%m-%d'),
                 }]
             }
             Queue.objects.queue_new_job(job_type, job_data, event)

--- a/scale/metrics/migrations/0006_metricserror.py
+++ b/scale/metrics/migrations/0006_metricserror.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+import metrics.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('error', '0003_error_is_builtin'),
+        ('metrics', '0005_auto_20160415_1636'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='MetricsError',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('occurred', models.DateField(db_index=True)),
+                ('total_count', metrics.models.PlotIntegerField(help_text='Number of jobs that failed with a particular error type.', null=True, verbose_name='Total Count', blank=True)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('error', models.ForeignKey(to='error.Error', on_delete=django.db.models.deletion.PROTECT)),
+            ],
+            options={
+                'db_table': 'metrics_error',
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/scale/metrics/serializers.py
+++ b/scale/metrics/serializers.py
@@ -75,6 +75,13 @@ class MetricsPlotMultiSerializer(MetricsPlotSerializer):
     values = MetricsPlotMultiValueSerializer(many=True)
 
 
+class MetricsErrorDetailsSerializer(MetricsTypeDetailsSerializer):
+    """Converts ingest metrics details model fields to REST output"""
+    from error.serializers import ErrorBaseSerializer
+
+    choices = ErrorBaseSerializer(many=True)
+
+
 class MetricsIngestDetailsSerializer(MetricsTypeDetailsSerializer):
     """Converts ingest metrics details model fields to REST output"""
     from ingest.serializers import StrikeBaseSerializer

--- a/scale/metrics/test/utils.py
+++ b/scale/metrics/test/utils.py
@@ -1,9 +1,24 @@
 '''Defines utility methods for testing metrics'''
 import django.utils.timezone as timezone
 
+import error.test.utils as error_test_utils
 import ingest.test.utils as ingest_test_utils
 import job.test.utils as job_test_utils
-from metrics.models import MetricsIngest, MetricsJobType
+from metrics.models import MetricsError, MetricsIngest, MetricsJobType
+
+
+def create_error(error=None, occurred=None, **kwargs):
+    '''Creates a metrics ingest model for unit testing
+
+    :returns: The metrics ingest model
+    :rtype: :class:`metrics.models.MetricsIngest`
+    '''
+    if not error:
+        error = error_test_utils.create_error(is_builtin=True)
+    if not occurred:
+        occurred = timezone.now()
+
+    return MetricsError.objects.create(error=error, occurred=occurred, **kwargs)
 
 
 def create_ingest(strike=None, occurred=None, **kwargs):

--- a/scale/scheduler/fixtures/scheduler_errors.json
+++ b/scale/scheduler/fixtures/scheduler_errors.json
@@ -7,6 +7,7 @@
             "title": "Lost By Scheduler",
             "description": "The Scale scheduler lost this job execution. This can occur when the scheduler fails or restarts.",
             "category": "SYSTEM",
+            "is_builtin": true,
             "created": "2015-03-11T00:00:00.0Z",
             "last_modified": "2015-03-11T00:00:00.0Z"
         }
@@ -19,6 +20,7 @@
             "title": "Lost By Mesos",
             "description": "Apache Mesos lost a task that was part of this job execution.",
             "category": "SYSTEM",
+            "is_builtin": true,
             "created": "2015-03-11T00:00:00.0Z",
             "last_modified": "2015-03-11T00:00:00.0Z"
         }


### PR DESCRIPTION
- Added a new "is_builtin" field to the error model.
- Updated all errors created via fixtures to be flagged as built-in.
- Added new field to REST services/docs.
- Created a new errors daily metrics table that counts these error types based on job executions.

NOTE: Although there is a migration to add the new field, it will default all existing records to false. Production systems will need to manually change the value to true where applicable.

Closes #158 