### PR TITLE
Issue 156 - Add Error Information to Jobs API

### DIFF
--- a/scale/docs/Makefile
+++ b/scale/docs/Makefile
@@ -51,7 +51,7 @@ html:
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 code_docs:
-	$(SPHINXAPIDOC) -f -T -o $(CODE_DOCS) ..
+	$(SPHINXAPIDOC) -f -T -o $(CODE_DOCS) .. ../scale
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/scale/docs/architecture/django/index.rst
+++ b/scale/docs/architecture/django/index.rst
@@ -22,7 +22,6 @@ system. Source code documentation for every app is provided below:
    code_docs/product
    code_docs/queue
    code_docs/recipe
-   code_docs/scale
    code_docs/scheduler
    code_docs/shared_resource
    code_docs/source

--- a/scale/docs/interface/rest/job.rst
+++ b/scale/docs/interface/rest/job.rst
@@ -2,7 +2,7 @@
 .. _rest_job:
 
 Job Services
-===============================================================================
+============
 
 These services provide access to information about "all", "currently running" and "previously finished" jobs.
 
@@ -47,6 +47,10 @@ These services provide access to information about "all", "currently running" an
 |                    |                   |          | Duplicate it to filter by multiple values.                          |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | job_type_category  | String            | Optional | Return only jobs with a given job type category.                    |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| error_category     | String            | Optional | Return only jobs that failed due to an error with a given category. |
+|                    |                   |          | Choices: [SYSTEM, DATA, ALGORITHM].                                 |
 |                    |                   |          | Duplicate it to filter by multiple values.                          |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
@@ -775,6 +779,10 @@ These services provide access to information about "all", "currently running" an
 |                    |                   |          | Duplicate it to filter by multiple values.                          |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | job_type_category  | String            | Optional | Return only jobs with a given job type category.                    |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| error_category     | String            | Optional | Return only jobs that failed due to an error with a given category. |
+|                    |                   |          | Choices: [SYSTEM, DATA, ALGORITHM].                                 |
 |                    |                   |          | Duplicate it to filter by multiple values.                          |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | **Successful Response**                                                                                                 |

--- a/scale/docs/interface/rest/job_execution.rst
+++ b/scale/docs/interface/rest/job_execution.rst
@@ -2,7 +2,7 @@
 .. _rest_job_execution:
 
 Job Execution Services
-===============================================================================
+======================
 
 These services provide access to information about "all", "currently running" and "previously finished" job executions.
 

--- a/scale/docs/interface/rest/queue.rst
+++ b/scale/docs/interface/rest/queue.rst
@@ -646,6 +646,8 @@ place jobs and recipes on the queue for processing.
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | job_type_categories| Array[String]     | Optional | Queue only jobs with a given job type category.                     |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
+| error_categories   | Array[String]     | Optional | Queue only jobs with a given error category.                        |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
 | priority           | Integer           | Optional | Change the priority of matching jobs when adding them to the queue. |
 |                    |                   |          | Defaults to jobs current priority, lower number is higher priority. |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+

--- a/scale/docs/make.bat
+++ b/scale/docs/make.bat
@@ -60,7 +60,7 @@ if "%1" == "html" (
 )
 
 if "%1" == "code_docs" (
-    %SPHINXAPIDOC% -f -T -o %CODE_DOCS% ..
+    %SPHINXAPIDOC% -f -T -o %CODE_DOCS% .. ..\scale
     if errorlevel 1 exit /b 1
     goto end
 )

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -107,7 +107,7 @@ class JobManager(models.Manager):
         return job
 
     def get_jobs(self, started=None, ended=None, status=None, job_ids=None, job_type_ids=None, job_type_names=None,
-                 job_type_categories=None, order=None):
+                 job_type_categories=None, error_categories=None, order=None):
         """Returns a list of jobs within the given time range.
 
         :param started: Query jobs updated after this amount of time.
@@ -124,6 +124,8 @@ class JobManager(models.Manager):
         :type job_type_names: list[str]
         :param job_type_categories: Query jobs of the type associated with the category.
         :type job_type_categories: list[str]
+        :param error_categories: Query jobs that failed due to errors associated with the category.
+        :type error_categories: list[str]
         :param order: A list of fields to control the sort order.
         :type order: list[str]
         :returns: The list of jobs that match the time range.
@@ -150,6 +152,8 @@ class JobManager(models.Manager):
             jobs = jobs.filter(job_type__name__in=job_type_names)
         if job_type_categories:
             jobs = jobs.filter(job_type__category__in=job_type_categories)
+        if error_categories:
+            jobs = jobs.filter(error__category__in=error_categories)
 
         # Apply sorting
         if order:
@@ -1308,7 +1312,7 @@ class JobExecution(models.Model):
         """Get the Docker params as a list of lists. Performs some basic validation.
 
         :returns: The Docker params as a list of lists
-        :rtype: list
+        :rtype: []
         """
 
         if self.docker_params is None or len(self.docker_params) == 0:

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -103,6 +103,21 @@ class TestJobsView(TestCase):
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['job_type']['category'], self.job1.job_type.category)
 
+    def test_error_category(self):
+        """Tests successfully calling the jobs view filtered by error category."""
+
+        error = error_test_utils.create_error(category='DATA')
+        job = job_test_utils.create_job(error=error)
+
+        url = '/jobs/?error_category=%s' % error.category
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['id'], job.id)
+        self.assertEqual(result['results'][0]['error']['category'], error.category)
+
     def test_order_by(self):
         """Tests successfully calling the jobs view with sorting."""
 
@@ -1403,6 +1418,21 @@ class TestJobsWithExecutionView(TransactionTestCase):
 
         for job_entry in results['results']:
             self.assertTrue(job_entry['id'] in (self.job_2a.id, self.job_2b.id))
+
+    def test_error_category(self):
+        """Tests successfully calling the jobs view filtered by error category."""
+
+        error = error_test_utils.create_error(category='DATA')
+        job = job_test_utils.create_job(error=error)
+
+        url = '/jobs/executions/?error_category=%s' % error.category
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['id'], job.id)
+        self.assertEqual(result['results'][0]['error']['category'], error.category)
 
 
 class TestJobExecutionsView(TransactionTestCase):

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -427,11 +427,12 @@ class JobsView(ListAPIView):
         job_type_ids = rest_util.parse_int_list(request, 'job_type_id', required=False)
         job_type_names = rest_util.parse_string_list(request, 'job_type_name', required=False)
         job_type_categories = rest_util.parse_string_list(request, 'job_type_category', required=False)
+        error_categories = rest_util.parse_string_list(request, 'error_category', required=False)
 
         order = rest_util.parse_string_list(request, 'order', required=False)
 
         jobs = Job.objects.get_jobs(started, ended, job_status, job_ids, job_type_ids, job_type_names,
-                                    job_type_categories, order)
+                                    job_type_categories, error_categories, order)
 
         page = self.paginate_queryset(jobs)
         serializer = self.get_serializer(page, many=True)
@@ -546,11 +547,12 @@ class JobsWithExecutionView(ListAPIView):
         job_type_ids = rest_util.parse_int_list(request, 'job_type_id', required=False)
         job_type_names = rest_util.parse_string_list(request, 'job_type_name', required=False)
         job_type_categories = rest_util.parse_string_list(request, 'job_type_category', required=False)
+        error_categories = rest_util.parse_string_list(request, 'error_category', required=False)
 
         order = rest_util.parse_string_list(request, 'order', required=False)
 
         jobs = Job.objects.get_jobs(started, ended, job_status, job_ids, job_type_ids, job_type_names,
-                                    job_type_categories, order)
+                                    job_type_categories, error_categories, order)
 
         # Add the latest execution for each matching job
         page = self.paginate_queryset(jobs)

--- a/scale/queue/test/test_views.py
+++ b/scale/queue/test/test_views.py
@@ -472,6 +472,25 @@ class TestRequeueJobsView(TestCase):
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['job_type']['category'], self.job_3.job_type.category)
 
+    def test_error_categories(self):
+        """Tests successfully calling the requeue view filtered by job error category."""
+
+        error = error_test_utils.create_error(category='DATA')
+        job = job_test_utils.create_job(error=error)
+
+        json_data = {
+            'error_categories': [error.category],
+        }
+
+        url = '/queue/requeue-jobs/'
+        response = self.client.post(url, json.dumps(json_data), 'application/json')
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['id'], job.id)
+        self.assertEqual(result['results'][0]['error']['category'], error.category)
+
     def test_priority(self):
         """Tests successfully calling the requeue view changing the job priority."""
 

--- a/scale/queue/views.py
+++ b/scale/queue/views.py
@@ -161,12 +161,14 @@ class RequeueJobsView(GenericAPIView):
         job_type_ids = rest_util.parse_int_list(request, 'job_type_ids', required=False)
         job_type_names = rest_util.parse_string_list(request, 'job_type_names', required=False)
         job_type_categories = rest_util.parse_string_list(request, 'job_type_categories', required=False)
+        error_categories = rest_util.parse_string_list(request, 'error_categories', required=False)
 
         priority = rest_util.parse_int(request, 'priority', required=False)
 
         # Fetch all the jobs matching the filters
-        jobs = Job.objects.get_jobs(started, ended, job_status, job_ids, job_type_ids, job_type_names,
-                                    job_type_categories)
+        jobs = Job.objects.get_jobs(started=started, ended=ended, status=job_status, job_ids=job_ids,
+                                    job_type_ids=job_type_ids, job_type_names=job_type_names,
+                                    job_type_categories=job_type_categories, error_categories=error_categories)
         if not jobs:
             raise Http404
 

--- a/scale/source/models.py
+++ b/scale/source/models.py
@@ -76,7 +76,7 @@ class SourceFileManager(models.GeoManager):
         :param data_ended: The end time of the data contained in the source file, possibly None
         :type data_ended: :class:`datetime.datetime` or None
         :param data_types: List of strings containing the data types tags for this source file.
-        :type data_types: list
+        :type data_types: [string]
         :param new_workspace_path: New workspace path to move the source file to now that parse data is available. If
             None, the source file should not be moved.
         :type new_workspace_path: str

--- a/scale/util/command.py
+++ b/scale/util/command.py
@@ -16,7 +16,7 @@ def execute_command_line(cmd_list):
     '''Executes the given command list on the command line
 
     :param cmd_list: The list of commands
-    :type cmd_list: list
+    :type cmd_list: []
     '''
 
     logger.debug('Executing: %s', ' '.join(cmd_list))


### PR DESCRIPTION
- Confirmed that error model fields are already included in the jobs list view.
- Added an error_category filter to jobs view, jobs with executions view, and requeue view.
- Fixed some sphinx warnings.

Closes #156