### PR TITLE
Issue 99 - Source File Detail API

### DIFF
--- a/scale/docs/rest/source_file.rst
+++ b/scale/docs/rest/source_file.rst
@@ -133,6 +133,180 @@ These services provide access to information about source files that Scale has i
 |    }                                                                                                                    |
 +-------------------------------------------------------------------------------------------------------------------------+
 
+.. _rest_source_file_details:
+
++-------------------------------------------------------------------------------------------------------------------------+
+| **Source File Details**                                                                                                 |
++=========================================================================================================================+
+| Returns a specific source file and all its related model information including ingests and derived products.            |
++-------------------------------------------------------------------------------------------------------------------------+
+| **GET** /sources/{id}/                                                                                                  |
+|         Where {id} is the unique identifier of an existing model.                                                       |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **GET** /sources/{file_name}/                                                                                           |
+|         Where {file_name} is the unique name of a source file associated with an existing model.                        |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Successful Response**                                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Status**         | 200 OK                                                                                             |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Content Type**   | *application/json*                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| id                 | Integer           | The unique identifier of the model.                                            |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| workspace          | JSON Object       | The workspace that has stored the source file.                                 |
+|                    |                   | (See :ref:`Workspace Details <rest_workspace_details>`)                        |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| file_name          | String            | The name of the source file.                                                   |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| media_type         | String            | The IANA media type of the source file.                                        |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| file_size          | Integer           | The size of the source file in bytes.                                          |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| data_type          | Array             | List of strings describing the data type of the source file.                   |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| is_deleted         | Boolean           | Whether the source file has been deleted.                                      |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| uuid               | String            | A unique identifier that stays stable across multiple job execution runs.      |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| url                | URL               | The absolute URL to use for downloading the file.                              |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| created            | ISO-8601 Datetime | When the associated database model was initially created.                      |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| deleted            | ISO-8601 Datetime | When the source file was deleted.                                              |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| data_started       | ISO-8601 Datetime | When collection of the underlying data file started.                           |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| data_ended         | ISO-8601 Datetime | When collection of the underlying data file ended.                             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| geometry           | WKT String        | The full geospatial geometry footprint of the source file.                     |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| center_point       | WKT String        | The central geospatial location of the source file.                            |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| meta_data          | JSON Object       | A dictionary of key/value pairs that describe source-specific attributes.      |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| countries          | Array             | A list of zero or more strings with the ISO3 country codes for countries       |
+|                    |                   | contained in the geographic boundary of this file.                             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| last_modified      | ISO-8601 Datetime | When the associated database model was last saved.                             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| is_parsed          | Boolean           | Whether this source file was successfully parsed and ingested into the system. |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| parsed             | ISO-8601 Datetime | When the source file was originally parsed by Scale.                           |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| ingests            | Array             | A list of records that represent each attempt to parse and ingest the file.    |
+|                    |                   | (See :ref:`Ingest Details <rest_ingest_details>`)                              |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| products           | Array             | A list of all product files derived from this source file during jobs.         |
+|                    |                   | (See :ref:`Product Details <rest_product_details>`)                            |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .. code-block:: javascript                                                                                              |
+|                                                                                                                         |
+|    {                                                                                                                    |
+|        "id": 1,                                                                                                         |
+|        "workspace": {                                                                                                   |
+|            "id": 1,                                                                                                     |
+|            "name": "Raw Source"                                                                                         |
+|        },                                                                                                               |
+|        "file_name": "my_file.kml",                                                                                      |
+|        "media_type": "application/vnd.google-earth.kml+xml",                                                            |
+|        "file_size": 100,                                                                                                |
+|        "data_type": [],                                                                                                 |
+|        "is_deleted": false,                                                                                             |
+|        "uuid": "c8928d9183fc99122948e7840ec9a0fd",                                                                      |
+|        "url": "http://host.com/file/path/my_file.kml",                                                                  |
+|        "created": "1970-01-01T00:00:00Z",                                                                               |
+|        "deleted": null,                                                                                                 |
+|        "data_started": null,                                                                                            |
+|        "data_ended": null,                                                                                              |
+|        "geometry": null,                                                                                                |
+|        "center_point": null,                                                                                            |
+|        "meta_data": {},                                                                                                 |
+|        "countries": [],                                                                                                 |
+|        "last_modified": "1970-01-01T00:00:00Z",                                                                         |
+|        "is_parsed": true,                                                                                               |
+|        "parsed": "1970-01-01T00:00:00Z",                                                                                |
+|        "ingests": [                                                                                                     |
+|            {                                                                                                            |
+|                "id": 1,                                                                                                 |
+|                "file_name": "my_file.kml",                                                                              |
+|                "strike": {                                                                                              |
+|                    "id": 1                                                                                              |
+|                },                                                                                                       |
+|                "status": "INGESTED",                                                                                    |
+|                "bytes_transferred": 100,                                                                                |
+|                "transfer_started": "1970-01-01T00:00:00Z",                                                              |
+|                "transfer_ended": "1970-01-01T00:00:00Z",                                                                |
+|                "media_type": "application/vnd.google-earth.kml+xml",                                                    |
+|                "file_size": 4806986,                                                                                    |
+|                "data_type": [],                                                                                         |
+|                "ingest_started": "1970-01-01T00:00:00Z",                                                                |
+|                "ingest_ended": "1970-01-01T00:00:00Z",                                                                  |
+|                "source_file": {                                                                                         |
+|                    "id": 1                                                                                              |
+|                },                                                                                                       |
+|                "created": "1970-01-01T00:00:00Z",                                                                       |
+|                "last_modified": "1970-01-01T00:00:00Z"                                                                  |
+|            },                                                                                                           |
+|            ...                                                                                                          |
+|        ],                                                                                                               |
+|        "products": [                                                                                                    |
+|            {                                                                                                            |
+|                "id": 2,                                                                                                 |
+|                "workspace": {                                                                                           |
+|                    "id": 2,                                                                                             |
+|                    "name": "Products"                                                                                   |
+|                },                                                                                                       |
+|                "file_name": "my_file.png",                                                                              |
+|                "media_type": "image/png",                                                                               |
+|                "file_size": 50,                                                                                         |
+|                "data_type": [],                                                                                         |
+|                "is_deleted": false,                                                                                     |
+|                "uuid": "03696f8c30b1757c9108fb9a7d67924f",                                                              |
+|                "url": "http://host.com/file/path/my_file.png",                                                          |
+|                "created": "1970-01-01T00:00:00Z",                                                                       |
+|                "deleted": null,                                                                                         |
+|                "data_started": "1970-01-01T00:00:00Z",                                                                  |
+|                "data_ended": null,                                                                                      |
+|                "geometry": null,                                                                                        |
+|                "center_point": null,                                                                                    |
+|                "meta_data": null,                                                                                       |
+|                "countries": [],                                                                                         |
+|                "last_modified": "1970-01-01T00:00:00Z",                                                                 |
+|                "is_operational": true,                                                                                  |
+|                "is_published": true,                                                                                    |
+|                "published": "1970-01-01T00:00:00Z",                                                                     |
+|                "unpublished": null,                                                                                     |
+|                "job_type": {                                                                                            |
+|                    "id": 6,                                                                                             |
+|                    "name": "kml-parse",                                                                                 |
+|                    "version": "1.0.0",                                                                                  |
+|                    "title": "KML Parse",                                                                                |
+|                    "description": "Parse KML into a PNG image",                                                         |
+|                    "category": null,                                                                                    |
+|                    "author_name": null,                                                                                 |
+|                    "author_url": null,                                                                                  |
+|                    "is_system": false,                                                                                  |
+|                    "is_long_running": false,                                                                            |
+|                    "is_active": true,                                                                                   |
+|                    "is_operational": true,                                                                              |
+|                    "is_paused": false,                                                                                  |
+|                    "icon_code": null                                                                                    |
+|                },                                                                                                       |
+|                "job": {                                                                                                 |
+|                    "id": 6                                                                                              |
+|                },                                                                                                       |
+|                "job_exe": {                                                                                             |
+|                    "id": 6                                                                                              |
+|                }                                                                                                        |
+|            },                                                                                                           |
+|            ...                                                                                                          |
+|        ]                                                                                                                |
+|    }                                                                                                                    |
++-------------------------------------------------------------------------------------------------------------------------+
+
 .. _rest_source_file_updates:
 
 +-------------------------------------------------------------------------------------------------------------------------+
@@ -272,5 +446,3 @@ These services provide access to information about source files that Scale has i
 |        ]                                                                                                                |
 |    }                                                                                                                    |
 +-------------------------------------------------------------------------------------------------------------------------+
-
-.. _rest_source_file_details:

--- a/scale/product/test/utils.py
+++ b/scale/product/test/utils.py
@@ -2,8 +2,30 @@
 from __future__ import unicode_literals
 
 from job.test import utils as job_utils
-from product.models import ProductFile
+from product.models import FileAncestryLink, ProductFile
 from storage.test import utils as storage_utils
+
+
+def create_file_link(ancestor=None, descendant=None, job=None, job_exe=None, recipe=None):
+    """Creates a file ancestry link model for unit testing
+
+    :returns: The file ancestry link model
+    :rtype: :class:`product.models.FileAncestryLink`
+    """
+
+    if not job:
+        if descendant and descendant.job:
+            job = descendant.job
+        else:
+            job = job_utils.create_job()
+    if not job_exe:
+        if descendant and descendant.job:
+            job_exe = descendant.job_exe
+        else:
+            job_exe = job_utils.create_job_exe(job_type=job.job_type, job=job)
+
+    return FileAncestryLink.objects.create(ancestor=ancestor, descendant=descendant, job=job, job_exe=job_exe,
+                                           recipe=recipe)
 
 
 def create_product(job_exe=None, workspace=None, has_been_published=False, file_name='my_test_file.txt',

--- a/scale/source/serializers_extra.py
+++ b/scale/source/serializers_extra.py
@@ -1,0 +1,24 @@
+"""Defines the serializers for sources that require extra fields from other applications"""
+import rest_framework.serializers as serializers
+
+from source.serializers import SourceFileSerializer
+
+
+class SourceFileDetailsSerializer(SourceFileSerializer):
+    """Converts source file model fields to REST output"""
+    is_parsed = serializers.BooleanField()
+    parsed = serializers.DateTimeField()
+
+    # Attempt to serialize related model fields
+    # Use a localized import to make higher level application dependencies optional
+    try:
+        from ingest.serializers import IngestBaseSerializer
+        ingests = IngestBaseSerializer(many=True)
+    except:
+        ingests = []
+
+    try:
+        from product.serializers import ProductFileSerializer
+        products = ProductFileSerializer(many=True)
+    except:
+        products = []

--- a/scale/source/test/test_views.py
+++ b/scale/source/test/test_views.py
@@ -1,10 +1,9 @@
-#@PydevCodeAnalysisIgnore
+from __future__ import unicode_literals
+
 import json
 
 import django
-from django.db.utils import DatabaseError
 from django.test import TestCase
-from mock import patch
 from rest_framework import status
 
 import source.test.utils as source_test_utils
@@ -19,7 +18,7 @@ class TestSourcesView(TestCase):
         self.source2 = source_test_utils.create_source(is_parsed=False)
 
     def test_invalid_started(self):
-        '''Tests calling the source files view when the started parameter is invalid.'''
+        """Tests calling the source files view when the started parameter is invalid."""
 
         url = '/sources/?started=hello'
         response = self.client.generic('GET', url)
@@ -27,7 +26,7 @@ class TestSourcesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_missing_tz_started(self):
-        '''Tests calling the source files view when the started parameter is missing timezone.'''
+        """Tests calling the source files view when the started parameter is missing timezone."""
 
         url = '/sources/?started=1970-01-01T00:00:00'
         response = self.client.generic('GET', url)
@@ -35,7 +34,7 @@ class TestSourcesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_invalid_ended(self):
-        '''Tests calling the source files view when the ended parameter is invalid.'''
+        """Tests calling the source files view when the ended parameter is invalid."""
 
         url = '/sources/?started=1970-01-01T00:00:00Z&ended=hello'
         response = self.client.generic('GET', url)
@@ -43,7 +42,7 @@ class TestSourcesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_missing_tz_ended(self):
-        '''Tests calling the source files view when the ended parameter is missing timezone.'''
+        """Tests calling the source files view when the ended parameter is missing timezone."""
 
         url = '/sources/?started=1970-01-01T00:00:00Z&ended=1970-01-02T00:00:00'
         response = self.client.generic('GET', url)
@@ -51,7 +50,7 @@ class TestSourcesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_negative_time_range(self):
-        '''Tests calling the source files view with a negative time range.'''
+        """Tests calling the source files view with a negative time range."""
 
         url = '/sources/?started=1970-01-02T00:00:00Z&ended=1970-01-01T00:00:00'
         response = self.client.generic('GET', url)
@@ -59,7 +58,7 @@ class TestSourcesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_is_parsed(self):
-        '''Tests successfully calling the source files view filtered by is_parsed flag.'''
+        """Tests successfully calling the source files view filtered by is_parsed flag."""
 
         url = '/sources/?is_parsed=true'
         response = self.client.generic('GET', url)
@@ -70,7 +69,7 @@ class TestSourcesView(TestCase):
         self.assertEqual(result['results'][0]['is_parsed'], self.source1.is_parsed)
 
     def test_file_name(self):
-        '''Tests successfully calling the source files view filtered by file name.'''
+        """Tests successfully calling the source files view filtered by file name."""
 
         url = '/sources/?file_name=test.txt'
         response = self.client.generic('GET', url)
@@ -81,7 +80,7 @@ class TestSourcesView(TestCase):
         self.assertEqual(result['results'][0]['file_name'], self.source1.file_name)
 
     def test_successful(self):
-        '''Tests successfully calling the source files view.'''
+        """Tests successfully calling the source files view."""
 
         url = '/sources/'
         response = self.client.generic('GET', url)
@@ -89,6 +88,73 @@ class TestSourcesView(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(result['results']), 2)
+
+
+class TestSourceDetailsView(TestCase):
+
+    def setUp(self):
+        django.setup()
+
+        self.source = source_test_utils.create_source()
+
+        try:
+            import ingest.test.utils as ingest_test_utils
+            self.ingest = ingest_test_utils.create_ingest(source_file=self.source)
+        except:
+            self.ingest = None
+
+        try:
+            import product.test.utils as product_test_utils
+            self.product = product_test_utils.create_product()
+
+            product_test_utils.create_file_link(ancestor=self.source, descendant=self.product)
+        except:
+            self.product = None
+
+    def test_id(self):
+        """Tests successfully calling the source files view by id."""
+
+        url = '/sources/%i/' % self.source.id
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        if self.ingest:
+            self.assertEqual(len(result['ingests']), 1)
+            self.assertEqual(result['ingests'][0]['id'], self.ingest.id)
+
+        if self.product:
+            self.assertEqual(len(result['products']), 1)
+            self.assertEqual(result['products'][0]['id'], self.product.id)
+
+    def test_file_name(self):
+        """Tests successfully calling the source files view by file name."""
+
+        url = '/sources/%s/' % self.source.file_name
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        if self.ingest:
+            self.assertEqual(len(result['ingests']), 1)
+            self.assertEqual(result['ingests'][0]['id'], self.ingest.id)
+
+        if self.product:
+            self.assertEqual(len(result['products']), 1)
+            self.assertEqual(result['products'][0]['id'], self.product.id)
+
+    def test_missing(self):
+        """Tests calling the source files view with an invalid id or file name."""
+
+        url = '/sources/12345/'
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        url = '/sources/missing_file.txt/'
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
 class TestSourceUpdatesView(TestCase):
@@ -100,7 +166,7 @@ class TestSourceUpdatesView(TestCase):
         self.source2 = source_test_utils.create_source(is_parsed=False)
 
     def test_invalid_started(self):
-        '''Tests calling the source file updates view when the started parameter is invalid.'''
+        """Tests calling the source file updates view when the started parameter is invalid."""
 
         url = '/sources/updates/?started=hello'
         response = self.client.generic('GET', url)
@@ -108,7 +174,7 @@ class TestSourceUpdatesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_missing_tz_started(self):
-        '''Tests calling the source file updates view when the started parameter is missing timezone.'''
+        """Tests calling the source file updates view when the started parameter is missing timezone."""
 
         url = '/sources/updates/?started=1970-01-01T00:00:00'
         response = self.client.generic('GET', url)
@@ -116,7 +182,7 @@ class TestSourceUpdatesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_invalid_ended(self):
-        '''Tests calling the source file updates view when the ended parameter is invalid.'''
+        """Tests calling the source file updates view when the ended parameter is invalid."""
 
         url = '/sources/updates/?started=1970-01-01T00:00:00Z&ended=hello'
         response = self.client.generic('GET', url)
@@ -124,7 +190,7 @@ class TestSourceUpdatesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_missing_tz_ended(self):
-        '''Tests calling the source file updates view when the ended parameter is missing timezone.'''
+        """Tests calling the source file updates view when the ended parameter is missing timezone."""
 
         url = '/sources/updates/?started=1970-01-01T00:00:00Z&ended=1970-01-02T00:00:00'
         response = self.client.generic('GET', url)
@@ -132,7 +198,7 @@ class TestSourceUpdatesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_negative_time_range(self):
-        '''Tests calling the source file updates view with a negative time range.'''
+        """Tests calling the source file updates view with a negative time range."""
 
         url = '/sources/updates/?started=1970-01-02T00:00:00Z&ended=1970-01-01T00:00:00'
         response = self.client.generic('GET', url)
@@ -140,7 +206,7 @@ class TestSourceUpdatesView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_is_parsed(self):
-        '''Tests successfully calling the source files view filtered by is_parsed flag.'''
+        """Tests successfully calling the source files view filtered by is_parsed flag."""
 
         url = '/sources/updates/?is_parsed=true'
         response = self.client.generic('GET', url)
@@ -151,7 +217,7 @@ class TestSourceUpdatesView(TestCase):
         self.assertEqual(result['results'][0]['is_parsed'], self.source1.is_parsed)
 
     def test_file_name(self):
-        '''Tests successfully calling the source file updates view filtered by file name.'''
+        """Tests successfully calling the source file updates view filtered by file name."""
 
         url = '/sources/updates/?file_name=test.txt'
         response = self.client.generic('GET', url)
@@ -162,7 +228,7 @@ class TestSourceUpdatesView(TestCase):
         self.assertEqual(result['results'][0]['file_name'], self.source1.file_name)
 
     def test_successful(self):
-        '''Tests successfully calling the source file updates view.'''
+        """Tests successfully calling the source file updates view."""
 
         url = '/sources/updates/'
         response = self.client.generic('GET', url)

--- a/scale/source/urls.py
+++ b/scale/source/urls.py
@@ -5,6 +5,8 @@ import source.views as views
 
 urlpatterns = patterns(
     '',
-    url(r'^sources/updates/$', views.SourceUpdatesView.as_view(), name='source_updates_view'),
     url(r'^sources/$', views.SourcesView.as_view(), name='sources_view'),
+    url(r'^sources/updates/$', views.SourceUpdatesView.as_view(), name='source_updates_view'),
+    url(r'^sources/(?P<source_id>\d+)/$', views.SourceDetailsView.as_view(), name='source_details_view'),
+    url(r'^sources/(?P<file_name>[\w.]{0,250})/$', views.SourceDetailsView.as_view(), name='source_details_view'),
 )

--- a/scale/source/views.py
+++ b/scale/source/views.py
@@ -3,11 +3,14 @@ from __future__ import unicode_literals
 
 import logging
 
-from rest_framework.generics import ListAPIView
+from django.http.response import Http404
+from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.response import Response
 
 import util.rest as rest_util
 from source.models import SourceFile
 from source.serializers import SourceFileSerializer, SourceFileUpdateSerializer
+from source.serializers_extra import SourceFileDetailsSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -25,20 +28,54 @@ class SourcesView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
-        started = rest_util.parse_timestamp(request, u'started', required=False)
-        ended = rest_util.parse_timestamp(request, u'ended', required=False)
+        started = rest_util.parse_timestamp(request, 'started', required=False)
+        ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
 
-        is_parsed = rest_util.parse_bool(request, u'is_parsed', required=False)
-        file_name = rest_util.parse_string(request, u'file_name', required=False)
+        is_parsed = rest_util.parse_bool(request, 'is_parsed', required=False)
+        file_name = rest_util.parse_string(request, 'file_name', required=False)
 
-        order = rest_util.parse_string_list(request, u'order', required=False)
+        order = rest_util.parse_string_list(request, 'order', required=False)
 
         sources = SourceFile.objects.get_sources(started, ended, is_parsed, file_name, order)
 
         page = self.paginate_queryset(sources)
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
+
+
+class SourceDetailsView(RetrieveAPIView):
+    """This view is the endpoint for retrieving/updating details of an ingest."""
+    queryset = SourceFile.objects.all()
+    serializer_class = SourceFileDetailsSerializer
+
+    def retrieve(self, request, source_id=None, file_name=None):
+        """Retrieves the details for an ingest and return them in JSON form
+
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :param source_id: The id of the source
+        :type source_id: int encoded as a string
+        :param file_name: The name of the source
+        :type file_name: string
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+
+        # Support retrieving by file name in addition to the usual identifier
+        if file_name:
+            sources = SourceFile.objects.filter(file_name=file_name).values('id').order_by('-parsed')
+            if not sources:
+                raise Http404
+            source_id = sources[0]['id']
+
+        try:
+            source = SourceFile.objects.get_details(source_id)
+        except SourceFile.DoesNotExist:
+            raise Http404
+
+        serializer = self.get_serializer(source)
+        return Response(serializer.data)
 
 
 class SourceUpdatesView(ListAPIView):
@@ -54,14 +91,14 @@ class SourceUpdatesView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
-        started = rest_util.parse_timestamp(request, u'started', required=False)
-        ended = rest_util.parse_timestamp(request, u'ended', required=False)
+        started = rest_util.parse_timestamp(request, 'started', required=False)
+        ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
 
-        is_parsed = rest_util.parse_bool(request, u'is_parsed', required=False)
-        file_name = rest_util.parse_string(request, u'file_name', required=False)
+        is_parsed = rest_util.parse_bool(request, 'is_parsed', required=False)
+        file_name = rest_util.parse_string(request, 'file_name', required=False)
 
-        order = rest_util.parse_string_list(request, u'order', required=False)
+        order = rest_util.parse_string_list(request, 'order', required=False)
 
         sources = SourceFile.objects.get_sources(started, ended, is_parsed, file_name, order)
 


### PR DESCRIPTION
- Added a new endpoint /sources/X/, where X can be either a model id or a file name.
- Response includes the source model details and lists of its associated ingests and products.
- Implementation was a bit awkward to workaround circular dependency issues with higher-level models.

Closes #99