### PR TITLE
Issue 202 - Refactored queue status view to follow REST guidelines.

### DIFF
--- a/scale/docs/rest/queue.rst
+++ b/scale/docs/rest/queue.rst
@@ -83,7 +83,7 @@ place jobs and recipes on the queue for processing.
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Get Queue Status**                                                                                                    |
 +=========================================================================================================================+
-| Returns the current status of the queue by grouping the queued jobs by their types                                      |
+| Returns the current status of the queue by grouping the queued jobs by their types.                                     |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /queue/status/                                                                                                  |
 +-------------------------------------------------------------------------------------------------------------------------+
@@ -95,33 +95,49 @@ place jobs and recipes on the queue for processing.
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **JSON Fields**                                                                                                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| queue_status       | List              | List of job types on the queue with meta-data                                  |
+| count              | Integer           | The total number of results that match the query parameters.                   |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| count              | Integer           | The number of jobs of this type on the queue                                   |
+| next               | URL               | A URL to the next page of results.                                             |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| longest_queued     | ISO-8601 Datetime | When the job that has been queued the longest of this type was queued          |
+| previous           | URL               | A URL to the previous page of results.                                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| job_type_name      | String            | The name of this job type                                                      |
+| results            | Array             | List of result JSON objects that match the query parameters.                   |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| job_type_version   | String            | The version of this job type                                                   |
+| .job_type          | JSON Object       | The job type being summarized within the queue.                                |
+|                    |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| highest_priority   | Integer           | The highest priority of any job of this type                                   |
+| .count             | Integer           | The total number of jobs of the type in the queue.                             |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| is_job_type_paused | Boolean           | If this job type has been paused (jobs of this type won't be scheduled)        |
+| .longest_queued    | ISO-8601 Datetime | When the job that has been queued the longest of the type was queued.          |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .highest_priority  | Integer           | The highest priority of any job of the type in the queue.                      |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .. code-block:: javascript                                                                                              |
 |                                                                                                                         |
 |    {                                                                                                                    |
-|        "queue_status": [                                                                                                |
-|           {                                                                                                             |
-|              "count": 19,                                                                                               |
-|              "longest_queued": "1970-01-01T00:00:00.000Z",                                                              |
-|              "job_type_name": "My Job Type",                                                                            |
-|              "job_type_version": "1.0",                                                                                 |
-|              "highest_priority": 1,                                                                                     |
-|              "is_job_type_paused": false                                                                                |
-|           },                                                                                                            |
-|           ...                                                                                                           |
+|        "count": 1,                                                                                                      |
+|        "next": null,                                                                                                    |
+|        "previous": null,                                                                                                |
+|        "results": [                                                                                                     |
+|            {                                                                                                            |
+|                "job_type": {                                                                                            |
+|                    "id": 1,                                                                                             |
+|                    "name": "scale-ingest",                                                                              |
+|                    "version": "1.0",                                                                                    |
+|                    "title": "Scale Ingest",                                                                             |
+|                    "description": "Ingests a source file into a workspace",                                             |
+|                    "is_system": true,                                                                                   |
+|                    "is_long_running": false,                                                                            |
+|                    "is_active": true,                                                                                   |
+|                    "is_operational": true,                                                                              |
+|                    "is_paused": false,                                                                                  |
+|                    "icon_code": "f013"                                                                                  |
+|                },                                                                                                       |
+|                "count": 19,                                                                                             |
+|                "longest_queued": "1970-01-01T00:00:00.000Z",                                                            |
+|                "highest_priority": 1                                                                                    |
+|            },                                                                                                           |
+|            ...                                                                                                          |
 |        ]                                                                                                                |
 |    }                                                                                                                    |
 +-------------------------------------------------------------------------------------------------------------------------+

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1833,13 +1833,9 @@ class JobTypeManager(models.Manager):
         :rtype: list[:class:`job.models.JobTypeRunningStatus`]
         """
 
-        # Make a list of all the basic job type fields to fetch
-        job_type_fields = ['id', 'name', 'version', 'title', 'description', 'category', 'is_system',
-                           'is_long_running', 'is_active', 'is_operational', 'is_paused', 'icon_code']
-
         # Fetch a count of all running jobs with type information
         # We have to specify values to workaround the JSON fields throwing an error when used with annotate
-        job_dicts = Job.objects.values(*['job_type__%s' % f for f in job_type_fields])
+        job_dicts = Job.objects.values(*['job_type__%s' % f for f in JobType.BASE_FIELDS])
         job_dicts = job_dicts.filter(status='RUNNING')
         job_dicts = job_dicts.annotate(count=models.Count('job_type'),
                                        longest_running=models.Min('last_status_change'))
@@ -1848,7 +1844,7 @@ class JobTypeManager(models.Manager):
         # Convert each result to a real job type model with added statistics
         results = []
         for job_dict in job_dicts:
-            job_type_dict = {f: job_dict['job_type__%s' % f] for f in job_type_fields}
+            job_type_dict = {f: job_dict['job_type__%s' % f] for f in JobType.BASE_FIELDS}
             job_type = JobType(**job_type_dict)
 
             status = JobTypeRunningStatus(job_type, job_dict['count'], job_dict['longest_running'])
@@ -1865,16 +1861,12 @@ class JobTypeManager(models.Manager):
         :rtype: list[:class:`job.models.JobTypeFailedStatus`]
         """
 
-        # Make a list of all the basic job type fields to fetch
-        job_type_fields = ['id', 'name', 'version', 'title', 'description', 'category', 'is_system',
-                           'is_long_running', 'is_active', 'is_operational', 'is_paused', 'icon_code']
-
         # Make a list of all the basic error fields to fetch
-        error_fields = ['id', 'name', 'description', 'category', 'created', 'last_modified']
+        error_fields = ['id', 'name', 'title', 'description', 'category', 'created', 'last_modified']
 
         # We have to specify values to workaround the JSON fields throwing an error when used with annotate
         query_fields = []
-        query_fields.extend(['job_type__%s' % f for f in job_type_fields])
+        query_fields.extend(['job_type__%s' % f for f in JobType.BASE_FIELDS])
         query_fields.extend(['error__%s' % f for f in error_fields])
 
         # Fetch a count of all running jobs with type information
@@ -1888,7 +1880,7 @@ class JobTypeManager(models.Manager):
         # Convert each result to a real job type model with added statistics
         results = []
         for job_dict in job_dicts:
-            job_type_dict = {f: job_dict['job_type__%s' % f] for f in job_type_fields}
+            job_type_dict = {f: job_dict['job_type__%s' % f] for f in JobType.BASE_FIELDS}
             job_type = JobType(**job_type_dict)
 
             error_dict = {f: job_dict['error__%s' % f] for f in error_fields}
@@ -2057,6 +2049,9 @@ class JobType(models.Model):
     :keyword last_modified: When the job type was last modified
     :type last_modified: :class:`django.db.models.DateTimeField`
     """
+
+    BASE_FIELDS = ('id', 'name', 'version', 'title', 'description', 'category', 'author_name', 'author_url',
+                   'is_system', 'is_long_running', 'is_active', 'is_operational', 'is_paused', 'icon_code')
 
     UNEDITABLE_FIELDS = ('name', 'version', 'is_system', 'is_long_running', 'is_active', 'requires_cleanup',
                          'uses_docker', 'revision_num', 'created', 'archived', 'paused', 'last_modified')

--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -220,6 +220,25 @@ class QueueEventProcessor(object):
         raise NotImplemented()
 
 
+class QueueStatus(object):
+    """Represents queue status statistics.
+
+    :keyword job_type: The job type being counted.
+    :type job_type: :class:`job.models.JobType`
+    :keyword count: The number of job executions running for the associated job type.
+    :type count: int
+    :keyword longest_queued: The date/time of the last queued job execution for the associated job type.
+    :type longest_queued: datetime.datetime
+    :keyword highest_priority: The priority of the most important job execution for the associated job type.
+    :type highest_priority: int
+    """
+    def __init__(self, job_type, count=0, longest_queued=None, highest_priority=100):
+        self.job_type = job_type
+        self.count = count
+        self.longest_queued = longest_queued
+        self.highest_priority = highest_priority
+
+
 class QueueManager(models.Manager):
     """Provides additional methods for managing the queue
     """
@@ -237,31 +256,27 @@ class QueueManager(models.Manager):
         return Queue.objects.order_by('priority', 'queued').iterator()
 
     def get_queue_status(self):
-        """Returns the current status of the queue, which is a list of dicts with each dict containing a job type and
-        version with overall stats for that type
+        """Returns the current status of the queue with statistics broken down by job type.
 
-        :returns: The list of each job type with stats
-        :rtype: list of dict
+        :returns: A list of each job type with calculated statistics.
+        :rtype: list[:class:`queue.models.QueueStatus`]
         """
 
-        status_qry = Queue.objects.values('job_type__name', 'job_type__version', 'job_type__is_paused')
-        status_qry = status_qry.annotate(count=models.Count('job_type'), longest_queued=models.Min('queued'),
-                                         highest_priority=models.Min('priority'))
-        status_qry = status_qry.order_by('job_type__is_paused', 'highest_priority', 'longest_queued')
+        status_dicts = Queue.objects.values(*['job_type__%s' % f for f in JobType.BASE_FIELDS])
+        status_dicts = status_dicts.annotate(count=models.Count('job_type'), longest_queued=models.Min('queued'),
+                                             highest_priority=models.Min('priority'))
+        status_dicts = status_dicts.order_by('job_type__is_paused', 'highest_priority', 'longest_queued')
 
-        # Remove double underscores
-        for entry in status_qry:
-            name = entry['job_type__name']
-            version = entry['job_type__version']
-            is_paused = entry['job_type__is_paused']
-            del entry['job_type__name']
-            del entry['job_type__version']
-            del entry['job_type__is_paused']
-            entry['job_type_name'] = name
-            entry['job_type_version'] = version
-            entry['is_job_type_paused'] = is_paused
+        # Convert each result to a real job type model with added statistics
+        results = []
+        for status_dict in status_dicts:
+            job_type_dict = {f: status_dict['job_type__%s' % f] for f in JobType.BASE_FIELDS}
+            job_type = JobType(**job_type_dict)
 
-        return status_qry
+            status = QueueStatus(job_type, status_dict['count'], status_dict['longest_queued'],
+                                 status_dict['highest_priority'])
+            results.append(status)
+        return results
 
     @transaction.atomic
     def handle_job_cancellation(self, job_id, when):

--- a/scale/queue/serializers.py
+++ b/scale/queue/serializers.py
@@ -1,11 +1,21 @@
-'''Defines the serializers for queue models'''
+"""Defines the serializers for queue models"""
 import rest_framework.serializers as serializers
 
 
 class JobLoadGroupSerializer(serializers.Serializer):
-    '''Converts job load model fields to REST output'''
+    """Converts job load model fields to REST output"""
     time = serializers.DateTimeField()
 
     pending_count = serializers.IntegerField()
     queued_count = serializers.IntegerField()
     running_count = serializers.IntegerField()
+
+
+class QueueStatusSerializer(serializers.Serializer):
+    """Converts queue status model fields to REST output"""
+    from job.serializers import JobTypeBaseSerializer
+
+    job_type = JobTypeBaseSerializer()
+    count = serializers.IntegerField()
+    longest_queued = serializers.DateTimeField()
+    highest_priority = serializers.IntegerField()

--- a/scale/queue/test/test_views.py
+++ b/scale/queue/test/test_views.py
@@ -271,6 +271,9 @@ class TestQueueStatusView(TestCase):
     def setUp(self):
         django.setup()
 
+        self.job_type = job_test_utils.create_job_type()
+        self.queue = queue_test_utils.create_queue(job_type=self.job_type, priority=123)
+
     def test_successful(self):
         """Tests successfully calling the queue status view."""
 
@@ -279,8 +282,11 @@ class TestQueueStatusView(TestCase):
         result = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue('queue_status' in result, 'Result is missing queue_status field')
-        self.assertTrue(isinstance(result['queue_status'], list), 'queue_status must be a list')
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['job_type']['id'], self.job_type.id)
+        self.assertEqual(result['results'][0]['count'], 1)
+        self.assertEqual(result['results'][0]['highest_priority'], 123)
+        self.assertIsNotNone(result['results'][0]['longest_queued'])
 
 
 class TestRequeueJobsView(TestCase):


### PR DESCRIPTION
- Refactored the queue status view to follow REST guidelines.
- The refactor adds the missing icon_code field available, as well as the other base job type fields.
- Left the original response structure in place as well for backward compatibility.
- Also added just the icon_code field to the original structure so that it can be optionally used without the UI needing to refactor immediately if desired.