### PR TITLE
Issue 229 PR - Opening up permissions on output_data directory

### DIFF
--- a/dockerfiles/framework/scale/Dockerfile
+++ b/dockerfiles/framework/scale/Dockerfile
@@ -18,6 +18,8 @@ COPY local_settings.py /opt/scale/scale/
 COPY entryPoint.sh /opt/scale/
 
 RUN mkdir -p /var/log/scale /var/lib/scale-metrics /scale/input_data /scale/output_data \
- && chown -R scale /opt/scale /var/log/scale /var/lib/scale-metrics /scale
+ && chown -R scale /opt/scale /var/log/scale /var/lib/scale-metrics /scale \
+ && chmod -R 777 /scale/output_data
+
 USER scale
 ENTRYPOINT ["./entryPoint.sh"]


### PR DESCRIPTION
I changed the Dockerfile to open up the permissions to 777 on the /scale/output_data so that algorithm job containers can run as any users and have appropriate access to write output files.