### PR TITLE
Issue 18 - AWS S3 broker

### DIFF
--- a/scale/pip/build_linux.txt
+++ b/scale/pip/build_linux.txt
@@ -2,6 +2,7 @@
 # Use command: pip install -r build_linux.txt
 
 # Main requirements
+boto>=2.40.0,<2.41.0
 Django>=1.7.3,<1.8.0
 django-filter>=0.7,<=0.8
 djangorestframework>=3.3.0,<3.4.0

--- a/scale/pip/dev_win.txt
+++ b/scale/pip/dev_win.txt
@@ -2,6 +2,7 @@
 # Use command: pip install -r dev_win.txt --upgrade
 
 # Main requirements
+boto>=2.40.0,<2.41.0
 Django>=1.7.3,<1.8.0
 django-filter>=0.7,<=0.8
 djangorestframework>=3.3.0,<3.4.0

--- a/scale/pip/prod_linux.txt
+++ b/scale/pip/prod_linux.txt
@@ -2,6 +2,7 @@
 # Use command: pip install -r prod_linux.txt
 
 # Main requirements
+boto>=2.40.0,<2.41.0
 Django>=1.7.3,<1.8.0
 django-filter>=0.7,<=0.8
 djangorestframework>=3.3.0,<3.4.0

--- a/scale/product/models.py
+++ b/scale/product/models.py
@@ -303,8 +303,7 @@ class ProductFileManager(models.GeoManager):
             product.save()
 
     def upload_files(self, file_entries, input_file_ids, job_exe, workspace):
-        """Uploads the given local product files into the workspace. All database changes will be made in an atomic
-        transaction.
+        """Uploads the given local product files into the workspace.
 
         :param file_entries: List of files where each file is a tuple of (absolute local path, workspace path for
             storing the file, media_type)

--- a/scale/source/models.py
+++ b/scale/source/models.py
@@ -147,7 +147,6 @@ class SourceFileManager(models.GeoManager):
         old_workspace_path = src_file.file_path
         if new_workspace_path and src_file.workspace.is_move_enabled:
             ScaleFile.objects.move_files([FileMove(src_file, new_workspace_path)])
-            src_file.save()
 
         try:
             # Check trigger rules for parsed source files
@@ -156,7 +155,6 @@ class SourceFileManager(models.GeoManager):
             # Move file back if there was an error
             if new_workspace_path and src_file.workspace.is_move_enabled:
                 ScaleFile.objects.move_files([FileMove(src_file, old_workspace_path)])
-                src_file.save()
             raise
 
     def store_file(self, local_path, data_types, workspace, remote_path):

--- a/scale/storage/apps.py
+++ b/scale/storage/apps.py
@@ -1,10 +1,23 @@
-'''Defines the configuration for the storage app'''
+"""Defines the configuration for the storage application"""
+from __future__ import unicode_literals
 from django.apps import AppConfig
 
 
 class StorageConfig(AppConfig):
-    '''Configuration for the storage app
-    '''
-    name = u'storage'
-    label = u'storage'
-    verbose_name = u'Storage'
+    """Configuration for the storage app"""
+    name = 'storage'
+    label = 'storage'
+    verbose_name = 'Storage'
+
+    def ready(self):
+        """Registers the storage brokers with the broker system."""
+        import storage.brokers.factory as factory
+
+        from storage.brokers.host_broker import HostBroker
+        from storage.brokers.nfs_broker import NfsBroker
+        from storage.brokers.s3_broker import S3Broker
+
+        # Register broker types
+        factory.add_broker_type(HostBroker)
+        factory.add_broker_type(NfsBroker)
+        factory.add_broker_type(S3Broker)

--- a/scale/storage/brokers/broker.py
+++ b/scale/storage/brokers/broker.py
@@ -55,8 +55,8 @@ class Broker(object):
         will be given for volume_path.
 
         The files list contains the ScaleFile models representing the files to be deleted. The broker should only delete
-        each file itself and not any parent directories. No changes should be made to the ScaleFile models. Scale will
-        mark the models as deleted in the database after the files have been successfully deleted.
+        each file itself and not any parent directories. Each file model should be updated and saved when a delete is
+        successful, including fields such as is_deleted and deleted.
 
         :param volume_path: Absolute path to the local container location onto which the volume file system was mounted,
             None if this broker does not use a container volume
@@ -76,8 +76,9 @@ class Broker(object):
         use a container volume, None will be given for volume_path.
 
         The file_downloads list contains named tuples that each contain a ScaleFile model to be downloaded and the
-        absolute local container path where the file should be downloaded. No changes should be made to the ScaleFile
-        models. Any directories in the absolute local container paths should already exist.
+        absolute local container path where the file should be downloaded. Typically, no changes are needed to file
+        models during a download, but any changes should be saved by the broker. Any directories in the absolute local
+        container paths should already exist.
 
         :param volume_path: Absolute path to the local container location onto which the volume file system was mounted,
             None if this broker does not use a container volume
@@ -109,9 +110,8 @@ class Broker(object):
         The file_moves list contains named tuples that each contain a ScaleFile model to be moved and the new relative
         file_path field for the new location of the file. The broker is expected to set the file_path field of each
         ScaleFile model to its new location (which the broker may alter) and is free to alter any additional fields as
-        necessary. The broker should NOT perform a model save/update to the database. Scale will save/update the models
-        in the database after they have all been successfully moved. The directories in the new file_path may not exist,
-        so it is the responsibility of the broker to create them if necessary.
+        necessary. The broker is responsible for saving any changes to models when a move is successful The directories
+        in the new file_path may not exist, so it is the responsibility of the broker to create them if necessary.
 
         :param volume_path: Absolute path to the local container location onto which the volume file system was mounted,
             None if this broker does not use a container volume
@@ -134,9 +134,9 @@ class Broker(object):
         local container path where the file currently exists. The broker is free to alter the ScaleFile fields of the
         uploaded files, including the final file_path (the given file_path is a recommendation by Scale that guarantees
         path uniqueness). The ScaleFile models may not have been saved to the database yet and so may not have their id
-        field populated. The broker should NOT perform a model save/update to the database. Scale will save the models
-        into the database after they have all been successfully uploaded. The directories in the remote file_path may
-        not exist, so it is the responsibility of the broker to create them if necessary.
+        field populated. The broker should perform a model save/update to the database for any files that are
+        successfully uploaded. The directories in the remote file_path may not exist, so it is the responsibility of the
+        broker to create them if necessary.
 
         :param volume_path: Absolute path to the local container location onto which the volume file system was mounted,
             None if this broker does not use a container volume

--- a/scale/storage/brokers/broker.py
+++ b/scale/storage/brokers/broker.py
@@ -3,9 +3,9 @@ from abc import ABCMeta
 from collections import namedtuple
 
 
-FileDownload = namedtuple('FileDownload', 'file local_path')
-FileMove = namedtuple('FileMove', 'file new_path')
-FileUpload = namedtuple('FileUpload', 'file local_path')
+FileDownload = namedtuple('FileDownload', ['file', 'local_path'])
+FileMove = namedtuple('FileMove', ['file', 'new_path'])
+FileUpload = namedtuple('FileUpload', ['file', 'local_path'])
 
 
 class Broker(object):

--- a/scale/storage/brokers/factory.py
+++ b/scale/storage/brokers/factory.py
@@ -1,20 +1,45 @@
 """Defines the factory for creating brokers"""
-from storage.brokers.host_broker import HostBroker
-from storage.brokers.nfs_broker import NfsBroker
+from __future__ import unicode_literals
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_BROKERS = {}
 
 
-BROKERS = {HostBroker().broker_type: HostBroker, NfsBroker().broker_type: NfsBroker}
+def add_broker_type(broker_class):
+    """Registers a broker class so it can be used for storage operations.
+
+    :param broker_class: The class definition for a broker.
+    :type broker_class: class:`storage.brokers.broker.Broker`
+    """
+
+    broker = broker_class()
+    if broker.broker_type in _BROKERS:
+        logger.warning('Duplicate broker registration: %s', broker.broker_type)
+    _BROKERS[broker.broker_type] = broker_class
 
 
 def get_broker(broker_type):
-    """Returns a broker of the given type
+    """Returns a broker of the given type.
 
-    :param broker_type: The broker type
+    :param broker_type: The unique identifier of a registered broker.
     :type broker_type: string
-    :returns: a broker for storing and retrieving files
+    :returns: A broker for storing and retrieving files.
     :rtype: :class:`storage.brokers.broker.Broker`
     """
 
-    if broker_type in BROKERS:
-        return BROKERS[broker_type]()
+    if broker_type in _BROKERS:
+        return _BROKERS[broker_type]()
     raise KeyError('\'%s\' is an invalid broker type' % broker_type)
+
+
+def get_broker_types():
+    """Returns a list of type identifiers for all registered brokers.
+
+    :returns: A list of broker type identifiers.
+    :rtype: [string]
+    """
+
+    return _BROKERS.keys()

--- a/scale/storage/brokers/host_broker.py
+++ b/scale/storage/brokers/host_broker.py
@@ -5,6 +5,8 @@ import logging
 import os
 import shutil
 
+import django.utils.timezone as timezone
+
 from storage.brokers.broker import Broker, BrokerVolume
 from storage.brokers.exceptions import InvalidBrokerConfiguration
 from util.command import execute_command_line
@@ -32,6 +34,9 @@ class HostBroker(Broker):
             if os.path.exists(path_to_delete):
                 logger.info('Deleting %s', path_to_delete)
                 os.remove(path_to_delete)
+
+                scale_file.is_deleted = True
+                scale_file.deleted = timezone.now()
 
     def download_files(self, volume_path, file_downloads):
         """See :meth:`storage.brokers.broker.Broker.download_files`

--- a/scale/storage/brokers/host_broker.py
+++ b/scale/storage/brokers/host_broker.py
@@ -5,8 +5,6 @@ import logging
 import os
 import shutil
 
-import django.utils.timezone as timezone
-
 from storage.brokers.broker import Broker, BrokerVolume
 from storage.brokers.exceptions import InvalidBrokerConfiguration
 from util.command import execute_command_line
@@ -35,8 +33,9 @@ class HostBroker(Broker):
                 logger.info('Deleting %s', path_to_delete)
                 os.remove(path_to_delete)
 
-                scale_file.is_deleted = True
-                scale_file.deleted = timezone.now()
+                # Update model attributes
+                scale_file.set_deleted()
+                scale_file.save()
 
     def download_files(self, volume_path, file_downloads):
         """See :meth:`storage.brokers.broker.Broker.download_files`
@@ -74,7 +73,10 @@ class HostBroker(Broker):
             shutil.move(full_old_path, full_new_path)
             logger.info('Setting file permissions for %s', full_new_path)
             os.chmod(full_new_path, 0644)
+
+            # Update model attributes
             file_move.file.file_path = file_move.new_path
+            file_move.file.save()
 
     def upload_files(self, volume_path, file_uploads):
         """See :meth:`storage.brokers.broker.Broker.upload_files`
@@ -92,6 +94,9 @@ class HostBroker(Broker):
             shutil.copy(file_upload.local_path, path_to_upload)
             logger.info('Setting file permissions for %s', path_to_upload)
             os.chmod(path_to_upload, 0644)
+
+            # Create new model
+            file_upload.file.save()
 
     def validate_configuration(self, config):
         """See :meth:`storage.brokers.broker.Broker.validate_configuration`

--- a/scale/storage/brokers/nfs_broker.py
+++ b/scale/storage/brokers/nfs_broker.py
@@ -5,6 +5,8 @@ import logging
 import os
 import shutil
 
+import django.utils.timezone as timezone
+
 from storage.brokers.broker import Broker, BrokerVolume
 from storage.brokers.exceptions import InvalidBrokerConfiguration
 from util.command import execute_command_line
@@ -33,6 +35,9 @@ class NfsBroker(Broker):
             if os.path.exists(path_to_delete):
                 logger.info('Deleting %s', path_to_delete)
                 os.remove(path_to_delete)
+
+                scale_file.is_deleted = True
+                scale_file.deleted = timezone.now()
 
     def download_files(self, volume_path, file_downloads):
         """See :meth:`storage.brokers.broker.Broker.download_files`

--- a/scale/storage/brokers/s3_broker.py
+++ b/scale/storage/brokers/s3_broker.py
@@ -7,7 +7,6 @@ import time
 from collections import namedtuple
 
 import boto
-import django.utils.timezone as timezone
 from boto.exception import S3ResponseError
 from boto.s3.connection import S3Connection
 from boto.s3.key import Key
@@ -43,8 +42,9 @@ class S3Broker(Broker):
 
                 self._delete_file(s3_key, scale_file)
 
-                scale_file.is_deleted = True
-                scale_file.deleted = timezone.now()
+                # Update model attributes
+                scale_file.set_deleted()
+                scale_file.save()
 
     def download_files(self, volume_path, file_downloads):
         """See :meth:`storage.brokers.broker.Broker.download_files`"""
@@ -73,7 +73,9 @@ class S3Broker(Broker):
 
                 self._move_file(s3_key, file_move.file, file_move.new_path)
 
+                # Update model attributes
                 file_move.file.file_path = file_move.new_path
+                file_move.file.save()
 
     def upload_files(self, volume_path, file_uploads):
         """See :meth:`storage.brokers.broker.Broker.upload_files`"""
@@ -86,6 +88,9 @@ class S3Broker(Broker):
                 s3_key.encrypted = settings.S3_ENCRYPTED
 
                 self._upload_file(s3_key, file_upload.file, file_upload.local_path)
+
+                # Create new model
+                file_upload.file.save()
 
     def validate_configuration(self, config):
         """See :meth:`storage.brokers.broker.Broker.validate_configuration`"""

--- a/scale/storage/brokers/s3_broker.py
+++ b/scale/storage/brokers/s3_broker.py
@@ -1,0 +1,304 @@
+"""Defines an S3 broker that utilizes the Amazon Web Services Simple Storage Service (S3) as its storage system"""
+from __future__ import unicode_literals
+
+import logging
+import ssl
+import time
+from collections import namedtuple
+
+import boto
+import django.utils.timezone as timezone
+from boto.exception import S3ResponseError
+from boto.s3.connection import S3Connection
+from boto.s3.key import Key
+
+import storage.settings as settings
+from storage.brokers.broker import Broker
+from storage.brokers.exceptions import InvalidBrokerConfiguration
+from storage.configuration.workspace_configuration import ValidationWarning
+from storage.exceptions import FileDoesNotExist
+
+logger = logging.getLogger(__name__)
+
+S3Credentials = namedtuple('S3Credentials', ['access_key_id', 'secret_access_key'])
+
+
+class S3Broker(Broker):
+    """Broker that utilizes the AWS Boto library to read/write files to S3 cloud storage."""
+
+    def __init__(self):
+        """Constructor"""
+
+        super(S3Broker, self).__init__('s3')
+
+        self._credentials = None
+        self._bucket_name = None
+
+    def delete_files(self, volume_path, files):
+        """See :meth:`storage.brokers.broker.Broker.delete_files`"""
+
+        with BrokerConnection(self._credentials) as conn:
+            for scale_file in files:
+                s3_key = conn.get_key(self._bucket_name, scale_file.file_path)
+
+                self._delete_file(s3_key, scale_file)
+
+                scale_file.is_deleted = True
+                scale_file.deleted = timezone.now()
+
+    def download_files(self, volume_path, file_downloads):
+        """See :meth:`storage.brokers.broker.Broker.download_files`"""
+
+        with BrokerConnection(self._credentials) as conn:
+            for file_download in file_downloads:
+                s3_key = conn.get_key(self._bucket_name, file_download.file.file_path)
+
+                self._download_file(s3_key, file_download.file, file_download.local_path)
+
+    def load_configuration(self, config):
+        """See :meth:`storage.brokers.broker.Broker.load_configuration`"""
+
+        self._bucket_name = config['bucket_name']
+
+        # TODO Change credentials to use an encrypted store key reference
+        credentials_dict = config['credentials']
+        self._credentials = S3Credentials(credentials_dict['access_key_id'], credentials_dict['secret_access_key'])
+
+    def move_files(self, volume_path, file_moves):
+        """See :meth:`storage.brokers.broker.Broker.move_files`"""
+
+        with BrokerConnection(self._credentials) as conn:
+            for file_move in file_moves:
+                s3_key = conn.get_key(self._bucket_name, file_move.file.file_path)
+
+                self._move_file(s3_key, file_move.file, file_move.new_path)
+
+                file_move.file.file_path = file_move.new_path
+
+    def upload_files(self, volume_path, file_uploads):
+        """See :meth:`storage.brokers.broker.Broker.upload_files`"""
+
+        with BrokerConnection(self._credentials) as conn:
+            for file_upload in file_uploads:
+                bucket = conn.get_bucket(self._bucket_name)
+
+                s3_key = Key(bucket)
+                s3_key.key = file_upload.file.file_path
+                s3_key.storage_class = settings.S3_STORAGE_CLASS
+                s3_key.encrypted = settings.S3_ENCRYPTED
+
+                self._upload_file(s3_key, file_upload.file, file_upload.local_path)
+
+    def validate_configuration(self, config):
+        """See :meth:`storage.brokers.broker.Broker.validate_configuration`"""
+
+        warnings = []
+        if 'bucket_name' not in config or not config['bucket_name']:
+            raise InvalidBrokerConfiguration('S3 broker requires "bucket_name" to be populated')
+
+        if 'credentials' not in config or not config['credentials']:
+            raise InvalidBrokerConfiguration('S3 broker requires "credentials" to be populated')
+
+        credentials_dict = config['credentials']
+        if 'access_key_id' not in credentials_dict or not credentials_dict['access_key_id']:
+            raise InvalidBrokerConfiguration('S3 broker requires "access_key_id" to be populated')
+        if 'secret_access_key' not in credentials_dict or not credentials_dict['secret_access_key']:
+            raise InvalidBrokerConfiguration('S3 broker requires "secret_access_key" to be populated')
+
+        # Check whether the bucket can actually be accessed
+        credentials = S3Credentials(credentials_dict['access_key_id'], credentials_dict['secret_access_key'])
+        with BrokerConnection(credentials) as conn:
+            try:
+                conn.get_bucket(config['bucket_name'], True)
+            except S3ResponseError:
+                warnings.append(ValidationWarning('bucket_access',
+                                                  'Unable to access bucket. Check the bucket name and credentials.'))
+
+        return warnings
+
+    def _delete_file(self, s3_key, scale_file, retries=settings.S3_RETRY_COUNT):
+        """Deletes a file from the S3 file system.
+
+        This method will attempt to retry the delete if :class:`ssl.SSLError` is raised up to a number of retries given.
+
+        :param s3_key: The S3 key representing the file to delete.
+        :type s3_key: :class:`boto.s3.key.Key`
+        :param scale_file: The model associated with the file to delete.
+        :type scale_file: :class:`storage.models.ScaleFile`
+        """
+
+        logger.info('Deleting %s', scale_file.file_path)
+        for attempt in range(retries):
+            try:
+                s3_key.delete()
+                return
+            except ssl.SSLError:
+                if attempt >= retries:
+                    raise
+                time.sleep(settings.S3_RETRY_DELAY * attempt)
+                logger.exception('Retrying S3 delete attempt: %i', attempt + 1)
+
+    def _download_file(self, s3_key, scale_file, path, retries=settings.S3_RETRY_COUNT):
+        """Downloads a file in S3 storage to the local file system.
+
+        This method will attempt to retry the delete if :class:`ssl.SSLError` is raised up to a number of retries given.
+
+        :param s3_key: The S3 key representing the file to download.
+        :type s3_key: :class:`boto.s3.key.Key`
+        :param scale_file: The model associated with the file to download.
+        :type scale_file: :class:`storage.models.ScaleFile`
+        :param path: The destination path for the file download.
+        :type path: string
+        """
+
+        logger.info('Downloading %s -> %s', scale_file.file_path, path)
+        for attempt in range(retries):
+            try:
+                with open(path, 'wb') as fp:
+                    s3_key.get_contents_to_file(fp)
+                    return
+            except ssl.SSLError:
+                if attempt >= retries:
+                    raise
+                time.sleep(settings.S3_RETRY_DELAY * attempt)
+                logger.exception('Retrying S3 download attempt: %i', attempt + 1)
+
+    def _move_file(self, s3_key, scale_file, path, retries=settings.S3_RETRY_COUNT):
+        """Moves a file within the S3 file system.
+
+        Note that S3 does not support an atomic move, so this operation is implemented as a copy and delete.
+
+        This method will attempt to retry the move if :class:`ssl.SSLError` is raised up to a number of retries given.
+        Note that since S3 does not support an atomic move, this method copies the file to the new destination and then
+        attempts to delete the original file content.
+
+        :param s3_key: The S3 key representing the file to move.
+        :type s3_key: :class:`boto.s3.key.Key`
+        :param scale_file: The model associated with the file to move.
+        :type scale_file: :class:`storage.models.ScaleFile`
+        :param path: The destination path for the file move.
+        :type path: string
+        """
+
+        logger.info('Copying %s -> %s', scale_file.file_path, path)
+        for attempt in range(retries):
+            try:
+                s3_key.copy(self._bucket_name, path,
+                            reduced_redundancy=(settings.S3_STORAGE_CLASS == 'REDUCED_REDUNDANCY'),
+                            encrypt_key=settings.S3_ENCRYPTED, preserve_acl=True, validate_dst_bucket=False)
+                break
+            except ssl.SSLError:
+                if attempt >= retries:
+                    raise
+                time.sleep(settings.S3_RETRY_DELAY * attempt)
+                logger.exception('Retrying S3 copy attempt: %i', attempt + 1)
+
+        self._delete_file(s3_key, scale_file)
+
+    def _upload_file(self, s3_key, scale_file, path, retries=settings.S3_RETRY_COUNT):
+        """Uploads a file in local storage to the S3 remote file system.
+
+        This method will attempt to retry the delete if :class:`ssl.SSLError` is raised up to a number of retries given.
+
+        :param s3_key: The S3 key representing the file to upload.
+        :type s3_key: :class:`boto.s3.key.Key`
+        :param scale_file: The model associated with the file to upload.
+        :type scale_file: :class:`storage.models.ScaleFile`
+        :param path: The source path for the file upload.
+        :type path: string
+        """
+
+        # Determine the proper mime-type for the file
+        headers = dict()
+        if scale_file.media_type:
+            headers['Content-Type'] = scale_file.media_type
+
+        logger.info('Uploading %s -> %s', path, scale_file.file_path)
+        for attempt in range(retries):
+            try:
+                with open(path, 'rb') as fp:
+                    s3_key.set_contents_from_file(fp, headers)
+                    return
+            except ssl.SSLError:
+                if attempt >= retries:
+                    raise
+                time.sleep(settings.S3_RETRY_DELAY * attempt)
+                logger.exception('Retrying S3 upload attempt: %i', attempt + 1)
+
+
+class BrokerConnection(object):
+    """Manages automatically opening and closing connections to the S3 service."""
+
+    def __init__(self, credentials):
+        """Constructor
+
+        :param credentials: Authentication values needed to access S3 storage.
+        :type credentials: :class:`storage.brokers.s3_broker.S3Credentials`
+        """
+
+        self.credentials = credentials
+        self._connection = None
+
+        # Check whether to use a local mock S3 or the real services
+        if settings.S3_CALLING_FORMAT:
+            self._calling_format = settings.S3_CALLING_FORMAT
+        else:
+            self._calling_format = boto.config.get(
+                's3', 'calling_format',
+                'boto.s3.connection.OrdinaryCallingFormat'
+            )
+
+    def __enter__(self):
+        """Callback handles opening a new connection to S3."""
+
+        host = settings.S3_HOST or S3Connection.DefaultHost
+        logger.debug('Connecting to S3 host: %s', host)
+        self._connection = boto.connect_s3(
+            self.credentials.access_key_id, self.credentials.secret_access_key,
+            calling_format=self._calling_format, is_secure=settings.S3_SECURE,
+            host=host, port=settings.S3_PORT,
+        )
+        return self
+
+    def __exit__(self, type, value, traceback):
+        """Callback handles closing an existing connection to S3."""
+
+        if self._connection:
+            self._connection.close()
+
+    def get_bucket(self, bucket_name, validate=False):
+        """Gets a reference to an S3 bucket with the given identifier.
+
+        :param bucket_name: The unique name of the bucket to retrieve.
+        :type bucket_name: string
+        :param validate: Whether to perform a request that verifies the bucket actually exists.
+        :type validate: bool
+        :returns: The bucket object for the given name.
+        :rtype: :class:`boto.s3.bucket.Bucket`
+
+        :raises :class:`boto.exceptions.S3ResponseError`: If the bucket fails to validate.
+        """
+
+        logger.debug('Accessing S3 bucket: %s', bucket_name)
+        return self._connection.get_bucket(bucket_name, validate=validate)
+
+    def get_key(self, bucket_name, key_name):
+        """Gets a reference to an S3 key with the given identifier.
+
+        :param bucket_name: The unique name of the bucket to retrieve.
+        :type bucket_name: string
+        :param key_name: The unique name of the key to retrieve that is associated with a file.
+        :type key_name: string
+        :returns: The key object for the given name.
+        :rtype: :class:`boto.s3.key.Key`
+
+        :raises :class:`boto.exceptions.S3ResponseError`: If the bucket fails to validate.
+        :raises :class:`storage.exceptions.FileDoesNotExist`: If the file is not found in the bucket.
+        """
+
+        bucket = self.get_bucket(bucket_name)
+
+        s3_key = bucket.get_key(key_name)
+        if not s3_key:
+            raise FileDoesNotExist('Unable to access remote file: %s %s' % (bucket_name, key_name))
+        return s3_key

--- a/scale/storage/configuration/workspace_configuration.py
+++ b/scale/storage/configuration/workspace_configuration.py
@@ -26,11 +26,11 @@ WORKSPACE_CONFIGURATION_SCHEMA = {
             'properties': {
                 'type': {
                     'type': 'string',
-                    'enum': ['host', 'nfs'],
+                    'enum': ['host', 'nfs', 's3'],
                 },
-            }
-        }
-    }
+            },
+        },
+    },
 }
 
 

--- a/scale/storage/exceptions.py
+++ b/scale/storage/exceptions.py
@@ -24,6 +24,13 @@ class DuplicateFile(Exception):
     pass
 
 
+class FileDoesNotExist(Exception):
+    """Exception indicating an attempt was made to access a file that no longer exists
+    """
+
+    pass
+
+
 class InvalidDataTypeTag(Exception):
     """Exception indicating an attempt to add an invalid data type tag to a file
     """

--- a/scale/storage/management/commands/scale_delete_file.py
+++ b/scale/storage/management/commands/scale_delete_file.py
@@ -33,7 +33,6 @@ class Command(BaseCommand):
 
         try:
             ScaleFile.objects.delete_files([scale_file])
-            scale_file.save()
         except:
             logger.exception('Unknown error occurred, exit code 1 returning')
             sys.exit(1)

--- a/scale/storage/management/commands/scale_delete_file.py
+++ b/scale/storage/management/commands/scale_delete_file.py
@@ -1,0 +1,40 @@
+"""Defines the command line method for deleting a file"""
+from __future__ import unicode_literals
+
+import logging
+import sys
+
+from django.core.management.base import BaseCommand
+
+from storage.models import ScaleFile
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Command that deletes a stored file from the remote file system."""
+
+    help = 'Deletes a stored file from the remote file system'
+
+    def handle(self, file_id, **options):
+        """See :meth:`django.core.management.base.BaseCommand.handle`.
+
+        This method starts the file delete process.
+        """
+
+        logger.info('Command starting: scale_delete_file')
+
+        # Attempt to fetch the file model
+        try:
+            scale_file = ScaleFile.objects.get(pk=file_id)
+        except ScaleFile.DoesNotExist:
+            logger.exception('Stored file does not exist: %s', file_id)
+            sys.exit(1)
+
+        try:
+            ScaleFile.objects.delete_files([scale_file])
+            scale_file.save()
+        except:
+            logger.exception('Unknown error occurred, exit code 1 returning')
+            sys.exit(1)
+        logger.info('Command completed: scale_delete_file')

--- a/scale/storage/management/commands/scale_download_file.py
+++ b/scale/storage/management/commands/scale_download_file.py
@@ -1,0 +1,46 @@
+"""Defines the command line method for downloading a file"""
+from __future__ import unicode_literals
+
+import logging
+import os
+import sys
+
+from django.core.management.base import BaseCommand
+
+from storage.brokers.broker import FileDownload
+from storage.models import ScaleFile
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Command that downloads a stored file to the local file system."""
+
+    help = 'Downloads a stored file to the local file system'
+
+    def handle(self, file_id, local_path, **options):
+        """See :meth:`django.core.management.base.BaseCommand.handle`.
+
+        This method starts the file download process.
+        """
+
+        logger.info('Command starting: scale_download_file')
+
+        # Validate the file paths
+        if os.path.exists(local_path):
+            logger.exception('Local file already exists: %s', local_path)
+            sys.exit(1)
+
+        # Attempt to fetch the file model
+        try:
+            scale_file = ScaleFile.objects.get(pk=file_id)
+        except ScaleFile.DoesNotExist:
+            logger.exception('Stored file does not exist: %s', file_id)
+            sys.exit(1)
+
+        try:
+            ScaleFile.objects.download_files([FileDownload(scale_file, local_path)])
+        except:
+            logger.exception('Unknown error occurred, exit code 1 returning')
+            sys.exit(1)
+        logger.info('Command completed: scale_download_file')

--- a/scale/storage/management/commands/scale_move_file.py
+++ b/scale/storage/management/commands/scale_move_file.py
@@ -34,7 +34,6 @@ class Command(BaseCommand):
 
         try:
             ScaleFile.objects.move_files([FileMove(scale_file, remote_path)])
-            scale_file.save()
         except:
             logger.exception('Unknown error occurred, exit code 1 returning')
             sys.exit(1)

--- a/scale/storage/management/commands/scale_move_file.py
+++ b/scale/storage/management/commands/scale_move_file.py
@@ -1,0 +1,41 @@
+"""Defines the command line method for moving a file"""
+from __future__ import unicode_literals
+
+import logging
+import sys
+
+from django.core.management.base import BaseCommand
+
+from storage.brokers.broker import FileMove
+from storage.models import ScaleFile
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Command that moves a stored file to a new remote path."""
+
+    help = 'Moves a stored file to a new remote path'
+
+    def handle(self, file_id, remote_path, **options):
+        """See :meth:`django.core.management.base.BaseCommand.handle`.
+
+        This method starts the file move process.
+        """
+
+        logger.info('Command starting: scale_move_file')
+
+        # Attempt to fetch the file model
+        try:
+            scale_file = ScaleFile.objects.get(pk=file_id)
+        except ScaleFile.DoesNotExist:
+            logger.exception('Stored file does not exist: %s', file_id)
+            sys.exit(1)
+
+        try:
+            ScaleFile.objects.move_files([FileMove(scale_file, remote_path)])
+            scale_file.save()
+        except:
+            logger.exception('Unknown error occurred, exit code 1 returning')
+            sys.exit(1)
+        logger.info('Command completed: scale_move_file')

--- a/scale/storage/management/commands/scale_upload_file.py
+++ b/scale/storage/management/commands/scale_upload_file.py
@@ -1,0 +1,64 @@
+"""Defines the command line method for uploading a file"""
+from __future__ import unicode_literals
+
+import logging
+import os
+import sys
+from optparse import make_option
+
+from django.core.management.base import BaseCommand
+
+from storage.brokers.broker import FileUpload
+from storage.models import ScaleFile, Workspace
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Command that uploads a local file to the storage system."""
+
+    option_list = BaseCommand.option_list + (
+        make_option('-w', '--workspace', action='store', type='str',
+                    help='The name of the workspace used to store the file'),
+    )
+
+    help = 'Uploads a local file to the storage system'
+
+    def handle(self, local_path, remote_path, **options):
+        """See :meth:`django.core.management.base.BaseCommand.handle`.
+
+        This method starts the file upload process.
+        """
+
+        workspace_name = options.get('workspace')
+
+        logger.info('Command starting: scale_upload_file')
+        logger.info(' - Workspace: %s', workspace_name)
+
+        # Validate the file paths
+        file_name = os.path.basename(local_path)
+        if not os.path.exists(local_path):
+            logger.exception('Local file does not exist: %s', local_path)
+            sys.exit(1)
+
+        # Attempt to fetch the workspace model
+        try:
+            workspace = Workspace.objects.get(name=workspace_name)
+        except Workspace.DoesNotExist:
+            logger.exception('Workspace does not exist: %s', workspace_name)
+            sys.exit(1)
+
+        # Attempt to set up a file model
+        try:
+            scale_file = ScaleFile.objects.get(file_name=file_name)
+        except ScaleFile.DoesNotExist:
+            scale_file = ScaleFile()
+            scale_file.update_uuid(file_name)
+        scale_file.file_path = remote_path
+
+        try:
+            ScaleFile.objects.upload_files(workspace, [FileUpload(scale_file, local_path)])
+        except:
+            logger.exception('Unknown error occurred, exit code 1 returning')
+            sys.exit(1)
+        logger.info('Command completed: scale_upload_file')

--- a/scale/storage/settings.py
+++ b/scale/storage/settings.py
@@ -1,0 +1,26 @@
+"""Defines all the custom settings used by this application."""
+
+import os
+
+from django.conf import settings
+
+_aws_access_key_id = os.environ['AWS_ACCESS_KEY_ID'] if 'AWS_ACCESS_KEY_ID' in os.environ else None
+S3_ACCESS_KEY_ID_DEFAULT = getattr(settings, 'S3_ACCESS_KEY_ID_DEFAULT', _aws_access_key_id)
+_aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY'] if 'AWS_SECRET_ACCESS_KEY' in os.environ else None
+S3_SECRET_ACCESS_KEY_DEFAULT = getattr(settings, 'S3_SECRET_ACCESS_KEY_DEFAULT', _aws_secret_access_key)
+
+# S3 file storage options
+S3_STORAGE_CLASS = getattr(settings, 'S3_STORAGE_CLASS', 'STANDARD')
+S3_ENCRYPTED = getattr(settings, 'S3_ENCRYPTED', False)
+
+# Defined to allow local mock S3 service
+S3_CALLING_FORMAT = getattr(settings, 'S3_CALLING_FORMAT', None)
+S3_SECURE = getattr(settings, 'S3_SECURE', True)
+S3_HOST = getattr(settings, 'S3_HOST', None)
+S3_PORT = getattr(settings, 'S3_PORT', None)
+
+# Max number of retries for recoverable download errors
+S3_RETRY_COUNT = getattr(settings, 'S3_RETRY_COUNT', 3)
+
+# The delay between retry attempts
+S3_RETRY_DELAY = getattr(settings, 'S3_RETRY_DELAY', 60)  # 1 minute

--- a/scale/storage/test/brokers/test_host_broker.py
+++ b/scale/storage/test/brokers/test_host_broker.py
@@ -47,6 +47,11 @@ class TestHostBrokerDeleteFiles(TestCase):
         two_calls = [call(full_path_file_1), call(full_path_file_2)]
         mock_remove.assert_has_calls(two_calls)
 
+        self.assertTrue(file_1.is_deleted)
+        self.assertIsNotNone(file_1.deleted)
+        self.assertTrue(file_2.is_deleted)
+        self.assertIsNotNone(file_2.deleted)
+
 
 class TestHostBrokerDownloadFiles(TestCase):
 
@@ -159,6 +164,9 @@ class TestHostBrokerMoveFiles(TestCase):
         mock_move.assert_has_calls(two_calls)
         two_calls = [call(full_new_workspace_path_1, 0644), call(full_new_workspace_path_2, 0644)]
         mock_chmod.assert_has_calls(two_calls)
+
+        self.assertEqual(file_1.file_path, new_workspace_path_1)
+        self.assertEqual(file_2.file_path, new_workspace_path_2)
 
 
 class TestHostBrokerUploadFiles(TestCase):

--- a/scale/storage/test/brokers/test_host_broker.py
+++ b/scale/storage/test/brokers/test_host_broker.py
@@ -6,10 +6,10 @@ import django
 from django.test import TestCase
 from mock import call, patch
 
+import storage.test.utils as storage_test_utils
 from storage.brokers.broker import FileDownload, FileMove, FileUpload
 from storage.brokers.exceptions import InvalidBrokerConfiguration
 from storage.brokers.host_broker import HostBroker
-from storage.models import ScaleFile
 
 
 class TestHostBrokerDeleteFiles(TestCase):
@@ -35,10 +35,8 @@ class TestHostBrokerDeleteFiles(TestCase):
         full_path_file_1 = os.path.join(volume_path, file_path_1)
         full_path_file_2 = os.path.join(volume_path, file_path_2)
 
-        file_1 = ScaleFile()
-        file_1.file_path = file_path_1
-        file_2 = ScaleFile()
-        file_2.file_path = file_path_2
+        file_1 = storage_test_utils.create_file(file_path=file_path_1)
+        file_2 = storage_test_utils.create_file(file_path=file_path_2)
 
         # Call method to test
         self.broker.delete_files(volume_path, [file_1, file_2])
@@ -79,10 +77,9 @@ class TestHostBrokerDownloadFiles(TestCase):
         workspace_path_file_2 = os.path.join('my_wrk_dir_2', file_name_2)
         full_workspace_path_file_1 = os.path.join(volume_path, workspace_path_file_1)
         full_workspace_path_file_2 = os.path.join(volume_path, workspace_path_file_2)
-        file_1 = ScaleFile()
-        file_1.file_path = workspace_path_file_1
-        file_2 = ScaleFile()
-        file_2.file_path = workspace_path_file_2
+
+        file_1 = storage_test_utils.create_file(file_path=workspace_path_file_1)
+        file_2 = storage_test_utils.create_file(file_path=workspace_path_file_2)
         file_1_dl = FileDownload(file_1, local_path_file_1)
         file_2_dl = FileDownload(file_2, local_path_file_2)
 
@@ -145,10 +142,9 @@ class TestHostBrokerMoveFiles(TestCase):
         full_old_workspace_path_2 = os.path.join(volume_path, old_workspace_path_2)
         full_new_workspace_path_1 = os.path.join(volume_path, new_workspace_path_1)
         full_new_workspace_path_2 = os.path.join(volume_path, new_workspace_path_2)
-        file_1 = ScaleFile()
-        file_1.file_path = old_workspace_path_1
-        file_2 = ScaleFile()
-        file_2.file_path = old_workspace_path_2
+
+        file_1 = storage_test_utils.create_file(file_path=old_workspace_path_1)
+        file_2 = storage_test_utils.create_file(file_path=old_workspace_path_2)
         file_1_mv = FileMove(file_1, new_workspace_path_1)
         file_2_mv = FileMove(file_2, new_workspace_path_2)
 
@@ -197,10 +193,9 @@ class TestHostBrokerUploadFiles(TestCase):
         workspace_path_file_2 = os.path.join('my_wrk_dir_2', file_name_2)
         full_workspace_path_file_1 = os.path.join(volume_path, workspace_path_file_1)
         full_workspace_path_file_2 = os.path.join(volume_path, workspace_path_file_2)
-        file_1 = ScaleFile()
-        file_1.file_path = workspace_path_file_1
-        file_2 = ScaleFile()
-        file_2.file_path = workspace_path_file_2
+
+        file_1 = storage_test_utils.create_file(file_path=workspace_path_file_1)
+        file_2 = storage_test_utils.create_file(file_path=workspace_path_file_2)
         file_1_up = FileUpload(file_1, local_path_file_1)
         file_2_up = FileUpload(file_2, local_path_file_2)
 

--- a/scale/storage/test/brokers/test_nfs_broker.py
+++ b/scale/storage/test/brokers/test_nfs_broker.py
@@ -47,6 +47,11 @@ class TestNfsBrokerDeleteFiles(TestCase):
         two_calls = [call(full_path_file_1), call(full_path_file_2)]
         mock_remove.assert_has_calls(two_calls)
 
+        self.assertTrue(file_1.is_deleted)
+        self.assertIsNotNone(file_1.deleted)
+        self.assertTrue(file_2.is_deleted)
+        self.assertIsNotNone(file_2.deleted)
+
 
 class TestNfsBrokerDownloadFiles(TestCase):
 
@@ -159,6 +164,9 @@ class TestNfsBrokerMoveFiles(TestCase):
         mock_move.assert_has_calls(two_calls)
         two_calls = [call(full_new_workspace_path_1, 0644), call(full_new_workspace_path_2, 0644)]
         mock_chmod.assert_has_calls(two_calls)
+
+        self.assertEqual(file_1.file_path, new_workspace_path_1)
+        self.assertEqual(file_2.file_path, new_workspace_path_2)
 
 
 class TestNfsBrokerUploadFiles(TestCase):

--- a/scale/storage/test/brokers/test_nfs_broker.py
+++ b/scale/storage/test/brokers/test_nfs_broker.py
@@ -6,10 +6,10 @@ import django
 from django.test import TestCase
 from mock import call, patch, mock_open
 
+import storage.test.utils as storage_test_utils
 from storage.brokers.broker import FileDownload, FileMove, FileUpload
 from storage.brokers.exceptions import InvalidBrokerConfiguration
 from storage.brokers.nfs_broker import NfsBroker
-from storage.models import ScaleFile
 
 
 class TestNfsBrokerDeleteFiles(TestCase):
@@ -35,10 +35,8 @@ class TestNfsBrokerDeleteFiles(TestCase):
         full_path_file_1 = os.path.join(volume_path, file_path_1)
         full_path_file_2 = os.path.join(volume_path, file_path_2)
 
-        file_1 = ScaleFile()
-        file_1.file_path = file_path_1
-        file_2 = ScaleFile()
-        file_2.file_path = file_path_2
+        file_1 = storage_test_utils.create_file(file_path=file_path_1)
+        file_2 = storage_test_utils.create_file(file_path=file_path_2)
 
         # Call method to test
         self.broker.delete_files(volume_path, [file_1, file_2])
@@ -79,10 +77,9 @@ class TestNfsBrokerDownloadFiles(TestCase):
         workspace_path_file_2 = os.path.join('my_wrk_dir_2', file_name_2)
         full_workspace_path_file_1 = os.path.join(volume_path, workspace_path_file_1)
         full_workspace_path_file_2 = os.path.join(volume_path, workspace_path_file_2)
-        file_1 = ScaleFile()
-        file_1.file_path = workspace_path_file_1
-        file_2 = ScaleFile()
-        file_2.file_path = workspace_path_file_2
+
+        file_1 = storage_test_utils.create_file(file_path=workspace_path_file_1)
+        file_2 = storage_test_utils.create_file(file_path=workspace_path_file_2)
         file_1_dl = FileDownload(file_1, local_path_file_1)
         file_2_dl = FileDownload(file_2, local_path_file_2)
 
@@ -145,10 +142,9 @@ class TestNfsBrokerMoveFiles(TestCase):
         full_old_workspace_path_2 = os.path.join(volume_path, old_workspace_path_2)
         full_new_workspace_path_1 = os.path.join(volume_path, new_workspace_path_1)
         full_new_workspace_path_2 = os.path.join(volume_path, new_workspace_path_2)
-        file_1 = ScaleFile()
-        file_1.file_path = old_workspace_path_1
-        file_2 = ScaleFile()
-        file_2.file_path = old_workspace_path_2
+
+        file_1 = storage_test_utils.create_file(file_path=old_workspace_path_1)
+        file_2 = storage_test_utils.create_file(file_path=old_workspace_path_2)
         file_1_mv = FileMove(file_1, new_workspace_path_1)
         file_2_mv = FileMove(file_2, new_workspace_path_2)
 
@@ -197,10 +193,9 @@ class TestNfsBrokerUploadFiles(TestCase):
         workspace_path_file_2 = os.path.join('my_wrk_dir_2', file_name_2)
         full_workspace_path_file_1 = os.path.join(volume_path, workspace_path_file_1)
         full_workspace_path_file_2 = os.path.join(volume_path, workspace_path_file_2)
-        file_1 = ScaleFile()
-        file_1.file_path = workspace_path_file_1
-        file_2 = ScaleFile()
-        file_2.file_path = workspace_path_file_2
+
+        file_1 = storage_test_utils.create_file(file_path=workspace_path_file_1)
+        file_2 = storage_test_utils.create_file(file_path=workspace_path_file_2)
         file_1_up = FileUpload(file_1, local_path_file_1)
         file_2_up = FileUpload(file_2, local_path_file_2)
 

--- a/scale/storage/test/brokers/test_s3_broker.py
+++ b/scale/storage/test/brokers/test_s3_broker.py
@@ -7,10 +7,10 @@ from boto.s3.key import Key
 from django.test import TestCase
 from mock import MagicMock, Mock, mock_open, patch
 
+import storage.test.utils as storage_test_utils
 from storage.brokers.broker import FileDownload, FileMove, FileUpload
 from storage.brokers.exceptions import InvalidBrokerConfiguration
 from storage.brokers.s3_broker import S3Broker, BrokerConnection
-from storage.models import ScaleFile
 
 
 class TestS3Broker(TestCase):
@@ -41,8 +41,8 @@ class TestS3Broker(TestCase):
         file_path_1 = os.path.join('my_dir', 'my_file.txt')
         file_path_2 = os.path.join('my_dir', 'my_file.json')
 
-        file_1 = ScaleFile(file_path=file_path_1)
-        file_2 = ScaleFile(file_path=file_path_2)
+        file_1 = storage_test_utils.create_file(file_path=file_path_1)
+        file_2 = storage_test_utils.create_file(file_path=file_path_2)
 
         # Call method to test
         self.broker.delete_files(None, [file_1, file_2])
@@ -72,8 +72,8 @@ class TestS3Broker(TestCase):
         workspace_path_file_1 = os.path.join('my_wrk_dir_1', file_name_1)
         workspace_path_file_2 = os.path.join('my_wrk_dir_2', file_name_2)
 
-        file_1 = ScaleFile(file_path=workspace_path_file_1)
-        file_2 = ScaleFile(file_path=workspace_path_file_2)
+        file_1 = storage_test_utils.create_file(file_path=workspace_path_file_1)
+        file_2 = storage_test_utils.create_file(file_path=workspace_path_file_2)
         file_1_dl = FileDownload(file_1, local_path_file_1)
         file_2_dl = FileDownload(file_2, local_path_file_2)
 
@@ -121,8 +121,8 @@ class TestS3Broker(TestCase):
         new_workspace_path_1 = os.path.join('my_new_dir_1', file_name_1)
         new_workspace_path_2 = os.path.join('my_new_dir_2', file_name_2)
 
-        file_1 = ScaleFile(file_path=old_workspace_path_1)
-        file_2 = ScaleFile(file_path=old_workspace_path_2)
+        file_1 = storage_test_utils.create_file(file_path=old_workspace_path_1)
+        file_2 = storage_test_utils.create_file(file_path=old_workspace_path_2)
         file_1_mv = FileMove(file_1, new_workspace_path_1)
         file_2_mv = FileMove(file_2, new_workspace_path_2)
 
@@ -152,8 +152,8 @@ class TestS3Broker(TestCase):
         workspace_path_file_1 = os.path.join('my_wrk_dir_1', file_name_1)
         workspace_path_file_2 = os.path.join('my_wrk_dir_2', file_name_2)
 
-        file_1 = ScaleFile(file_path=workspace_path_file_1, media_type='text/plain')
-        file_2 = ScaleFile(file_path=workspace_path_file_2, media_type='application/json')
+        file_1 = storage_test_utils.create_file(file_path=workspace_path_file_1, media_type='text/plain')
+        file_2 = storage_test_utils.create_file(file_path=workspace_path_file_2, media_type='application/json')
         file_1_up = FileUpload(file_1, local_path_file_1)
         file_2_up = FileUpload(file_2, local_path_file_2)
 

--- a/scale/storage/test/brokers/test_s3_broker.py
+++ b/scale/storage/test/brokers/test_s3_broker.py
@@ -1,0 +1,195 @@
+from __future__ import unicode_literals
+
+import os
+
+import django
+from boto.s3.key import Key
+from django.test import TestCase
+from mock import MagicMock, Mock, mock_open, patch
+
+from storage.brokers.broker import FileDownload, FileMove, FileUpload
+from storage.brokers.exceptions import InvalidBrokerConfiguration
+from storage.brokers.s3_broker import S3Broker, BrokerConnection
+from storage.models import ScaleFile
+
+
+class TestS3Broker(TestCase):
+
+    def setUp(self):
+        django.setup()
+
+        self.broker = S3Broker()
+        self.broker.load_configuration({
+            'type': S3Broker().broker_type,
+            'bucket_name': 'my_bucket.domain.com',
+            'credentials': {
+                'access_key_id': 'ABC',
+                'secret_access_key': '123',
+            },
+        })
+
+    @patch('storage.brokers.s3_broker.BrokerConnection')
+    def test_delete_files(self, mock_conn_class):
+        """Tests deleting files successfully"""
+
+        s3_key_1 = MagicMock(Key)
+        s3_key_2 = MagicMock(Key)
+        mock_conn = MagicMock(BrokerConnection)
+        mock_conn.get_key.side_effect = [s3_key_1, s3_key_2]
+        mock_conn_class.return_value.__enter__ = Mock(return_value=mock_conn)
+
+        file_path_1 = os.path.join('my_dir', 'my_file.txt')
+        file_path_2 = os.path.join('my_dir', 'my_file.json')
+
+        file_1 = ScaleFile(file_path=file_path_1)
+        file_2 = ScaleFile(file_path=file_path_2)
+
+        # Call method to test
+        self.broker.delete_files(None, [file_1, file_2])
+
+        # Check results
+        self.assertTrue(s3_key_1.delete.called)
+        self.assertTrue(s3_key_2.delete.called)
+        self.assertTrue(file_1.is_deleted)
+        self.assertIsNotNone(file_1.deleted)
+        self.assertTrue(file_2.is_deleted)
+        self.assertIsNotNone(file_2.deleted)
+
+    @patch('storage.brokers.s3_broker.BrokerConnection')
+    def test_download_files(self, mock_conn_class):
+        """Tests downloading files successfully"""
+
+        s3_key_1 = MagicMock(Key)
+        s3_key_2 = MagicMock(Key)
+        mock_conn = MagicMock(BrokerConnection)
+        mock_conn.get_key.side_effect = [s3_key_1, s3_key_2]
+        mock_conn_class.return_value.__enter__ = Mock(return_value=mock_conn)
+
+        file_name_1 = 'my_file.txt'
+        file_name_2 = 'my_file.json'
+        local_path_file_1 = os.path.join('my_dir_1', file_name_1)
+        local_path_file_2 = os.path.join('my_dir_2', file_name_2)
+        workspace_path_file_1 = os.path.join('my_wrk_dir_1', file_name_1)
+        workspace_path_file_2 = os.path.join('my_wrk_dir_2', file_name_2)
+
+        file_1 = ScaleFile(file_path=workspace_path_file_1)
+        file_2 = ScaleFile(file_path=workspace_path_file_2)
+        file_1_dl = FileDownload(file_1, local_path_file_1)
+        file_2_dl = FileDownload(file_2, local_path_file_2)
+
+        # Call method to test
+        mo = mock_open()
+        with patch('__builtin__.open', mo, create=True):
+            self.broker.download_files(None, [file_1_dl, file_2_dl])
+
+        # Check results
+        self.assertTrue(s3_key_1.get_contents_to_file.called)
+        self.assertTrue(s3_key_2.get_contents_to_file.called)
+
+    def test_load_configuration(self):
+        """Tests loading a valid configuration successfully"""
+
+        json_config = {
+            'type': S3Broker().broker_type,
+            'bucket_name': 'my_bucket.domain.com',
+            'credentials': {
+                'access_key_id': 'ABC',
+                'secret_access_key': '123',
+            },
+        }
+        broker = S3Broker()
+        broker.load_configuration(json_config)
+
+        self.assertEqual(broker._bucket_name, 'my_bucket.domain.com')
+        self.assertEqual(broker._credentials.access_key_id, 'ABC')
+        self.assertEqual(broker._credentials.secret_access_key, '123')
+
+    @patch('storage.brokers.s3_broker.BrokerConnection')
+    def test_move_files(self, mock_conn_class):
+        """Tests moving files successfully"""
+
+        s3_key_1 = MagicMock(Key)
+        s3_key_2 = MagicMock(Key)
+        mock_conn = MagicMock(BrokerConnection)
+        mock_conn.get_key.side_effect = [s3_key_1, s3_key_2]
+        mock_conn_class.return_value.__enter__ = Mock(return_value=mock_conn)
+
+        file_name_1 = 'my_file.txt'
+        file_name_2 = 'my_file.json'
+        old_workspace_path_1 = os.path.join('my_dir_1', file_name_1)
+        old_workspace_path_2 = os.path.join('my_dir_2', file_name_2)
+        new_workspace_path_1 = os.path.join('my_new_dir_1', file_name_1)
+        new_workspace_path_2 = os.path.join('my_new_dir_2', file_name_2)
+
+        file_1 = ScaleFile(file_path=old_workspace_path_1)
+        file_2 = ScaleFile(file_path=old_workspace_path_2)
+        file_1_mv = FileMove(file_1, new_workspace_path_1)
+        file_2_mv = FileMove(file_2, new_workspace_path_2)
+
+        # Call method to test
+        self.broker.move_files(None, [file_1_mv, file_2_mv])
+
+        # Check results
+        self.assertTrue(s3_key_1.copy.called)
+        self.assertTrue(s3_key_2.copy.called)
+        self.assertEqual(file_1.file_path, new_workspace_path_1)
+        self.assertEqual(file_2.file_path, new_workspace_path_2)
+
+    @patch('storage.brokers.s3_broker.BrokerConnection')
+    def test_upload_files(self, mock_conn_class):
+        """Tests uploading files successfully"""
+
+        s3_key_1 = MagicMock(Key)
+        s3_key_2 = MagicMock(Key)
+        mock_conn = MagicMock(BrokerConnection)
+        mock_conn.get_key.side_effect = [s3_key_1, s3_key_2]
+        mock_conn_class.return_value.__enter__ = Mock(return_value=mock_conn)
+
+        file_name_1 = 'my_file.txt'
+        file_name_2 = 'my_file.json'
+        local_path_file_1 = os.path.join('my_dir_1', file_name_1)
+        local_path_file_2 = os.path.join('my_dir_2', file_name_2)
+        workspace_path_file_1 = os.path.join('my_wrk_dir_1', file_name_1)
+        workspace_path_file_2 = os.path.join('my_wrk_dir_2', file_name_2)
+
+        file_1 = ScaleFile(file_path=workspace_path_file_1, media_type='text/plain')
+        file_2 = ScaleFile(file_path=workspace_path_file_2, media_type='application/json')
+        file_1_up = FileUpload(file_1, local_path_file_1)
+        file_2_up = FileUpload(file_2, local_path_file_2)
+
+        # Call method to test
+        mo = mock_open()
+        with patch('__builtin__.open', mo, create=True):
+            self.broker.upload_files(None, [file_1_up, file_2_up])
+
+        # Check results
+        self.assertTrue(s3_key_1.set_contents_from_file.called)
+        self.assertTrue(s3_key_2.set_contents_from_file.called)
+        self.assertEqual(s3_key_1.set_contents_from_file.call_args[0][1]['Content-Type'], 'text/plain')
+        self.assertEqual(s3_key_2.set_contents_from_file.call_args[0][1]['Content-Type'], 'application/json')
+
+    def test_validate_configuration(self):
+        """Tests validating a configuration successfully"""
+
+        json_config = {
+            'type': S3Broker().broker_type,
+            'bucket_name': 'my_bucket.domain.com',
+            'credentials': {
+                'access_key_id': 'ABC',
+                'secret_access_key': '123',
+            },
+        }
+        broker = S3Broker()
+
+        # No exception is success
+        broker.load_configuration(json_config)
+
+    def test_validate_configuration_missing(self):
+        """Tests validating a configuration with missing attributes"""
+
+        json_config = {
+            'type': S3Broker().broker_type,
+        }
+        broker = S3Broker()
+
+        self.assertRaises(InvalidBrokerConfiguration, broker.validate_configuration, json_config)

--- a/scale/storage/test/test_models.py
+++ b/scale/storage/test/test_models.py
@@ -471,6 +471,15 @@ class TestScaleFile(TestCase):
         self.assertIn('TC', tmp)
         self.assertIn('TT', tmp)
 
+    def test_set_deleted(self):
+        """Tests marking a file as deleted."""
+        scale_file = storage_test_utils.create_file()
+
+        scale_file.set_deleted()
+
+        self.assertTrue(scale_file.is_deleted)
+        self.assertIsNotNone(scale_file.deleted)
+
 
 class TestCountryData(TestCase):
 

--- a/scale/storage/test/utils.py
+++ b/scale/storage/test/utils.py
@@ -33,7 +33,7 @@ def create_country(name=None, fips='TT', gmi='TT', iso2='TT', iso3='TST', iso_nu
 
 
 def create_file(file_name='my_test_file.txt', media_type='text/plain', file_size=100, file_path=None, workspace=None,
-                countries=None):
+                countries=None, is_deleted=False):
     """Creates a Scale file model for unit testing
 
     :returns: The file model
@@ -42,8 +42,14 @@ def create_file(file_name='my_test_file.txt', media_type='text/plain', file_size
 
     if not workspace:
         workspace = create_workspace()
+
+    deleted = None
+    if is_deleted:
+        deleted = timezone.now()
+
     scale_file = ScaleFile.objects.create(file_name=file_name, media_type=media_type, file_size=file_size,
-                                          file_path=file_path or 'file/path/' + file_name, workspace=workspace)
+                                          file_path=file_path or 'file/path/' + file_name, workspace=workspace,
+                                          is_deleted=is_deleted, deleted=deleted)
     if countries:
         scale_file.countries = countries
         scale_file.save()
@@ -65,6 +71,14 @@ def create_workspace(name=None, title=None, json_config=None, base_url=None, is_
         global WORKSPACE_TITLE_COUNTER
         title = 'Test Workspace %i' % WORKSPACE_TITLE_COUNTER
         WORKSPACE_TITLE_COUNTER += 1
+    if not json_config:
+        json_config = {
+            'version': '1.0',
+            'broker': {
+                'type': 'nfs',
+                'nfs_path': '/host/path',
+            }
+        }
     if is_active is False and not archived:
         archived = timezone.now()
 


### PR DESCRIPTION
- Adds an initial implementation of the S3 storage system broker.
- Supports standard delete, download, move, and upload.
- S3 does not support an atomic move, so that must be implemented as a copy + delete.
- S3 operations can momentarily fail or timeout, so this broker includes support for a few retry attempts.
- Currently, requires AWS credentials to be hard-coded into the workspace JSON config in plain text. A future issue will need to change this to an encrypted store of some kind.
- Added management commands to make it easy to test broker implementations without running all of scale.
- Refactored how broker implementations are registered to avoid circular dependency problems.
- It looks like file models are not updated on a delete the way other operations were, so I added that to existing brokers and model methods.
- It looks like workspace JSON was not validated upon first use with brokers, so I added that.
- Added custom local settings that can control some of the S3 features.
