### PR TITLE
Issue #316 - Accommodate larger amount of job types on Overview page

### DIFF
--- a/scale-ui/app/modules/jobs/directives/jobHealthDirective.js
+++ b/scale-ui/app/modules/jobs/directives/jobHealthDirective.js
@@ -8,7 +8,7 @@
         $scope.jobHealth = {};
 
         var getJobTypeStatus = function () {
-            jobTypeService.getJobTypeStatus(null, null, $scope.duration, null).then(null, null, function (data) {
+            jobTypeService.getJobTypeStatus(null, 1000, $scope.duration, null).then(null, null, function (data) {
                 if (data.$resolved) {
                     $scope.jobHealthError = null;
                     $scope.jobTypeStatus = data.results;


### PR DESCRIPTION
Increased the page size for now to address the job status part of issue #316.  This will only work until there are >1000 job types, so more work needs to be done in order to arrive at a more permanent solution.  For now though this should be merged in to fix a bug that's hindering users on-site.