### PR TITLE
Issue 355 - Fix Task Launch Detection

### DIFF
--- a/scale/job/execution/running/tasks/base_task.py
+++ b/scale/job/execution/running/tasks/base_task.py
@@ -181,7 +181,7 @@ class Task(object):
         :rtype: :class:`error.models.Error`
         """
 
-        if not self.is_running and not task_results.exit_code:
+        if not self.is_running:
             if self.uses_docker:
                 return Error.objects.get_builtin_error('docker-task-launch')
             else:

--- a/scale/job/execution/running/tasks/job_task.py
+++ b/scale/job/execution/running/tasks/job_task.py
@@ -57,8 +57,8 @@ class JobTask(Task):
         if self._task_id != task_results.task_id:
             return None
 
-        if not error:
-            # Use job's error mapping here to determine error
+        if not error and self.is_running:
+            # If the task successfully started, use job's error mapping here to determine error
             error = self._error_mapping.get_error(task_results.exit_code)
         if not error:
             error = self.consider_general_error(task_results)

--- a/scale/job/execution/running/tasks/post_task.py
+++ b/scale/job/execution/running/tasks/post_task.py
@@ -53,7 +53,7 @@ class PostTask(Task):
         if self._task_id != task_results.task_id:
             return None
 
-        if not error:
+        if not error and self.is_running:
             # Check scale_post_steps command to see if exit code maps to a specific error
             if task_results.exit_code and task_results.exit_code in POST_EXIT_CODE_DICT:
                 error = POST_EXIT_CODE_DICT[task_results.exit_code]()

--- a/scale/job/execution/running/tasks/pre_task.py
+++ b/scale/job/execution/running/tasks/pre_task.py
@@ -52,7 +52,7 @@ class PreTask(Task):
         if self._task_id != task_results.task_id:
             return None
 
-        if not error:
+        if not error and self.is_running:
             # Check scale_pre_steps command to see if exit code maps to a specific error
             if task_results.exit_code and task_results.exit_code in PRE_EXIT_CODE_DICT:
                 error = PRE_EXIT_CODE_DICT[task_results.exit_code]()

--- a/scale/job/test/execution/running/test_job_exe.py
+++ b/scale/job/test/execution/running/test_job_exe.py
@@ -255,6 +255,7 @@ class TestRunningJobExecution(TestCase):
 
         # Pre-task fails to launch
         pre_task_results = TaskResults(pre_task_id)
+        pre_task_results.exit_code = 1
         pre_task_results.when = now()
         running_job_exe.task_fail(pre_task_results)
 
@@ -293,6 +294,7 @@ class TestRunningJobExecution(TestCase):
 
         # Job-task fails to launch
         job_task_results = TaskResults(job_task_id)
+        job_task_results.exit_code = 1
         job_task_results.when = now()
         running_job_exe.task_fail(job_task_results)
 
@@ -346,6 +348,7 @@ class TestRunningJobExecution(TestCase):
 
         # Post-task fails to launch
         post_task_results = TaskResults(post_task_id)
+        post_task_results.exit_code = 1
         post_task_results.when = now()
         running_job_exe.task_fail(post_task_results)
 


### PR DESCRIPTION
Right now we expect there to not be an exit code when a task launch fails. It appears that Mesos is now returning an exit code of 1 when a task launch fails.

Remove the requirement for no exit code when detecting a task launch. Basically remove

> and not task_results.exit_code:

from line 184 of base_task.py and update applicable unit tests.
Make sure that task launch errors are triggered even when an exit code is returned.

I also had to add checks to make sure the task started running before looking at the exit code to determine the error.