### PR TITLE
Issue 364 - Upgrade S3 broker to use boto3

### DIFF
--- a/scale/pip/build_linux.txt
+++ b/scale/pip/build_linux.txt
@@ -2,7 +2,7 @@
 # Use command: pip install -r build_linux.txt
 
 # Main requirements
-boto>=2.40.0,<2.41.0
+boto3>=1.3.0,<1.4.0
 Django>=1.7.3,<1.8.0
 django-filter>=0.7,<=0.8
 djangorestframework>=3.3.0,<3.4.0

--- a/scale/pip/dev_win.txt
+++ b/scale/pip/dev_win.txt
@@ -2,7 +2,7 @@
 # Use command: pip install -r dev_win.txt --upgrade
 
 # Main requirements
-boto>=2.40.0,<2.41.0
+boto3>=1.3.0,<1.4.0
 Django>=1.7.3,<1.8.0
 django-filter>=0.7,<=0.8
 djangorestframework>=3.3.0,<3.4.0

--- a/scale/pip/prod_linux.txt
+++ b/scale/pip/prod_linux.txt
@@ -2,7 +2,7 @@
 # Use command: pip install -r prod_linux.txt
 
 # Main requirements
-boto>=2.40.0,<2.41.0
+boto3>=1.3.0,<1.4.0
 Django>=1.7.3,<1.8.0
 django-filter>=0.7,<=0.8
 djangorestframework>=3.3.0,<3.4.0

--- a/scale/storage/settings.py
+++ b/scale/storage/settings.py
@@ -1,23 +1,14 @@
 """Defines all the custom settings used by this application."""
 
-import os
-
 from django.conf import settings
 
-_aws_access_key_id = os.environ['AWS_ACCESS_KEY_ID'] if 'AWS_ACCESS_KEY_ID' in os.environ else None
-S3_ACCESS_KEY_ID_DEFAULT = getattr(settings, 'S3_ACCESS_KEY_ID_DEFAULT', _aws_access_key_id)
-_aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY'] if 'AWS_SECRET_ACCESS_KEY' in os.environ else None
-S3_SECRET_ACCESS_KEY_DEFAULT = getattr(settings, 'S3_SECRET_ACCESS_KEY_DEFAULT', _aws_secret_access_key)
-
 # S3 file storage options
-S3_STORAGE_CLASS = getattr(settings, 'S3_STORAGE_CLASS', 'STANDARD')
-S3_ENCRYPTED = getattr(settings, 'S3_ENCRYPTED', False)
+S3_STORAGE_CLASS = getattr(settings, 'S3_STORAGE_CLASS', 'STANDARD')  # (STANDARD, REDUCED_REDUNDANCY)
+S3_SERVER_SIDE_ENCRYPTION = getattr(settings, 'S3_SERVER_SIDE_ENCRYPTION', None)  # (None, AES256)
 
 # Defined to allow local mock S3 service
-S3_CALLING_FORMAT = getattr(settings, 'S3_CALLING_FORMAT', None)
-S3_SECURE = getattr(settings, 'S3_SECURE', True)
-S3_HOST = getattr(settings, 'S3_HOST', None)
-S3_PORT = getattr(settings, 'S3_PORT', None)
+S3_REGION = getattr(settings, 'S3_REGION', None)  # (us-east-1, us-west-1, us-west-2)
+S3_ADDRESSING_STYLE = getattr(settings, 'S3_ADDRESSING_STYLE', 'auto')
 
 # Max number of retries for recoverable download errors
 S3_RETRY_COUNT = getattr(settings, 'S3_RETRY_COUNT', 3)

--- a/scale/storage/test/brokers/test_s3_broker.py
+++ b/scale/storage/test/brokers/test_s3_broker.py
@@ -3,14 +3,13 @@ from __future__ import unicode_literals
 import os
 
 import django
-from boto.s3.key import Key
 from django.test import TestCase
 from mock import MagicMock, Mock, mock_open, patch
 
 import storage.test.utils as storage_test_utils
 from storage.brokers.broker import FileDownload, FileMove, FileUpload
 from storage.brokers.exceptions import InvalidBrokerConfiguration
-from storage.brokers.s3_broker import S3Broker, BrokerConnection
+from storage.brokers.s3_broker import S3Broker, S3Client
 
 
 class TestS3Broker(TestCase):
@@ -28,15 +27,15 @@ class TestS3Broker(TestCase):
             },
         })
 
-    @patch('storage.brokers.s3_broker.BrokerConnection')
-    def test_delete_files(self, mock_conn_class):
+    @patch('storage.brokers.s3_broker.S3Client')
+    def test_delete_files(self, mock_client_class):
         """Tests deleting files successfully"""
 
-        s3_key_1 = MagicMock(Key)
-        s3_key_2 = MagicMock(Key)
-        mock_conn = MagicMock(BrokerConnection)
-        mock_conn.get_key.side_effect = [s3_key_1, s3_key_2]
-        mock_conn_class.return_value.__enter__ = Mock(return_value=mock_conn)
+        s3_object_1 = MagicMock()
+        s3_object_2 = MagicMock()
+        mock_client = MagicMock(S3Client)
+        mock_client.get_object.side_effect = [s3_object_1, s3_object_2]
+        mock_client_class.return_value.__enter__ = Mock(return_value=mock_client)
 
         file_path_1 = os.path.join('my_dir', 'my_file.txt')
         file_path_2 = os.path.join('my_dir', 'my_file.json')
@@ -48,22 +47,22 @@ class TestS3Broker(TestCase):
         self.broker.delete_files(None, [file_1, file_2])
 
         # Check results
-        self.assertTrue(s3_key_1.delete.called)
-        self.assertTrue(s3_key_2.delete.called)
+        self.assertTrue(s3_object_1.delete.called)
+        self.assertTrue(s3_object_2.delete.called)
         self.assertTrue(file_1.is_deleted)
         self.assertIsNotNone(file_1.deleted)
         self.assertTrue(file_2.is_deleted)
         self.assertIsNotNone(file_2.deleted)
 
-    @patch('storage.brokers.s3_broker.BrokerConnection')
-    def test_download_files(self, mock_conn_class):
+    @patch('storage.brokers.s3_broker.S3Client')
+    def test_download_files(self, mock_client_class):
         """Tests downloading files successfully"""
 
-        s3_key_1 = MagicMock(Key)
-        s3_key_2 = MagicMock(Key)
-        mock_conn = MagicMock(BrokerConnection)
-        mock_conn.get_key.side_effect = [s3_key_1, s3_key_2]
-        mock_conn_class.return_value.__enter__ = Mock(return_value=mock_conn)
+        s3_object_1 = MagicMock()
+        s3_object_2 = MagicMock()
+        mock_client = MagicMock(S3Client)
+        mock_client.get_object.side_effect = [s3_object_1, s3_object_2]
+        mock_client_class.return_value.__enter__ = Mock(return_value=mock_client)
 
         file_name_1 = 'my_file.txt'
         file_name_2 = 'my_file.json'
@@ -83,8 +82,8 @@ class TestS3Broker(TestCase):
             self.broker.download_files(None, [file_1_dl, file_2_dl])
 
         # Check results
-        self.assertTrue(s3_key_1.get_contents_to_file.called)
-        self.assertTrue(s3_key_2.get_contents_to_file.called)
+        self.assertTrue(s3_object_1.download_file.called)
+        self.assertTrue(s3_object_2.download_file.called)
 
     def test_load_configuration(self):
         """Tests loading a valid configuration successfully"""
@@ -104,15 +103,17 @@ class TestS3Broker(TestCase):
         self.assertEqual(broker._credentials.access_key_id, 'ABC')
         self.assertEqual(broker._credentials.secret_access_key, '123')
 
-    @patch('storage.brokers.s3_broker.BrokerConnection')
-    def test_move_files(self, mock_conn_class):
+    @patch('storage.brokers.s3_broker.S3Client')
+    def test_move_files(self, mock_client_class):
         """Tests moving files successfully"""
 
-        s3_key_1 = MagicMock(Key)
-        s3_key_2 = MagicMock(Key)
-        mock_conn = MagicMock(BrokerConnection)
-        mock_conn.get_key.side_effect = [s3_key_1, s3_key_2]
-        mock_conn_class.return_value.__enter__ = Mock(return_value=mock_conn)
+        s3_object_1a = MagicMock()
+        s3_object_1b = MagicMock()
+        s3_object_2a = MagicMock()
+        s3_object_2b = MagicMock()
+        mock_client = MagicMock(S3Client)
+        mock_client.get_object.side_effect = [s3_object_1a, s3_object_1b, s3_object_2a, s3_object_2b]
+        mock_client_class.return_value.__enter__ = Mock(return_value=mock_client)
 
         file_name_1 = 'my_file.txt'
         file_name_2 = 'my_file.json'
@@ -130,20 +131,22 @@ class TestS3Broker(TestCase):
         self.broker.move_files(None, [file_1_mv, file_2_mv])
 
         # Check results
-        self.assertTrue(s3_key_1.copy.called)
-        self.assertTrue(s3_key_2.copy.called)
+        self.assertTrue(s3_object_1b.copy_from.called)
+        self.assertTrue(s3_object_1a.delete.called)
+        self.assertTrue(s3_object_2b.copy_from.called)
+        self.assertTrue(s3_object_2a.delete.called)
         self.assertEqual(file_1.file_path, new_workspace_path_1)
         self.assertEqual(file_2.file_path, new_workspace_path_2)
 
-    @patch('storage.brokers.s3_broker.BrokerConnection')
-    def test_upload_files(self, mock_conn_class):
+    @patch('storage.brokers.s3_broker.S3Client')
+    def test_upload_files(self, mock_client_class):
         """Tests uploading files successfully"""
 
-        s3_key_1 = MagicMock(Key)
-        s3_key_2 = MagicMock(Key)
-        mock_conn = MagicMock(BrokerConnection)
-        mock_conn.get_key.side_effect = [s3_key_1, s3_key_2]
-        mock_conn_class.return_value.__enter__ = Mock(return_value=mock_conn)
+        s3_object_1 = MagicMock()
+        s3_object_2 = MagicMock()
+        mock_client = MagicMock(S3Client)
+        mock_client.get_object.side_effect = [s3_object_1, s3_object_2]
+        mock_client_class.return_value.__enter__ = Mock(return_value=mock_client)
 
         file_name_1 = 'my_file.txt'
         file_name_2 = 'my_file.json'
@@ -163,10 +166,10 @@ class TestS3Broker(TestCase):
             self.broker.upload_files(None, [file_1_up, file_2_up])
 
         # Check results
-        self.assertTrue(s3_key_1.set_contents_from_file.called)
-        self.assertTrue(s3_key_2.set_contents_from_file.called)
-        self.assertEqual(s3_key_1.set_contents_from_file.call_args[0][1]['Content-Type'], 'text/plain')
-        self.assertEqual(s3_key_2.set_contents_from_file.call_args[0][1]['Content-Type'], 'application/json')
+        self.assertTrue(s3_object_1.upload_file.called)
+        self.assertTrue(s3_object_2.upload_file.called)
+        self.assertEqual(s3_object_1.upload_file.call_args[0][1]['ContentType'], 'text/plain')
+        self.assertEqual(s3_object_2.upload_file.call_args[0][1]['ContentType'], 'application/json')
 
     def test_validate_configuration_roles(self):
         """Tests validating a configuration based on IAM roles successfully"""


### PR DESCRIPTION
This version should now work with any configuration method supported by boto3, such as the EC2 IAM role, AWS credentials file, AWS config file, or environment variables. The existing solution to have hard-coded credentials in the workspace config should also continue to work for ease of testing.

See here for more information:
http://boto3.readthedocs.io/en/latest/guide/configuration.html

I'm not sure if this code will work for custom boto3 builds on other networks yet.