### PR TITLE
Issue #376 - Datagrids disappear when no data is returned

### DIFF
--- a/scale-ui/app/modules/feed/partials/ingestRecordsTemplate.html
+++ b/scale-ui/app/modules/feed/partials/ingestRecordsTemplate.html
@@ -13,7 +13,7 @@
         <input id="lastModifiedStop" type="text" class="form-control" aria-describedby="to-input" uib-datepicker-popup="yyyy-MM-dd" ng-model="vm.lastModifiedStop" ng-model-options="vm.dateModelOptions" is-open="vm.lastModifiedStopPopup.opened" close-text="Close" datepicker-append-to-body="true" ng-click="vm.openLastModifiedStopPopup($event)" />
     </div>
 </div>
-<div class="row" ng-if="vm.gridOptions.data.length > 0">
+<div class="row">
     <div class="col-xs-12">
         <div class="grid-container">
             <div ui-grid="vm.gridOptions" ui-grid-selection ui-grid-pagination ui-grid-resize-columns class="scale-grid"></div>

--- a/scale-ui/app/modules/jobs/partials/jobTypesFailureRatesTemplate.html
+++ b/scale-ui/app/modules/jobs/partials/jobTypesFailureRatesTemplate.html
@@ -1,5 +1,5 @@
 <ais-header name="'Failure Rates'" show-subnav="true" subnav-links="vm.subnavLinks" loading="vm.loading"></ais-header>
-<div class="grid-container job-type-error-rates-grid" ng-if="vm.gridOptions.data.length > 0">
+<div class="grid-container job-type-error-rates-grid">
     <div ui-grid="vm.gridOptions" ui-grid-selection ui-grid-resize-columns class="scale-grid"></div>
 </div>
 

--- a/scale-ui/app/modules/jobs/partials/jobsTemplate.html
+++ b/scale-ui/app/modules/jobs/partials/jobsTemplate.html
@@ -22,7 +22,7 @@
         <input id="lastModifiedStop" type="text" class="form-control" aria-describedby="to-input" uib-datepicker-popup="yyyy-MM-dd" ng-model="vm.lastModifiedStop" ng-model-options="vm.dateModelOptions" is-open="vm.lastModifiedStopPopup.opened" close-text="Close" datepicker-append-to-body="true" ng-click="vm.openLastModifiedStopPopup($event)" />
     </div>
 </div>
-<div class="row" ng-if="vm.gridOptions.data.length > 0">
+<div class="row">
     <div class="col-xs-12">
         <div class="grid-container">
             <div ui-grid="vm.gridOptions" ui-grid-selection ui-grid-pagination ui-grid-resize-columns class="scale-grid"></div>

--- a/scale-ui/app/modules/load/partials/loadTemplate.html
+++ b/scale-ui/app/modules/load/partials/loadTemplate.html
@@ -1,12 +1,10 @@
 <ais-header name="'Queued (' + vm.totalQueued + ' jobs; ' + vm.gridOptions.totalItems + ' job types)'" loading="vm.loading" show-subnav="true" subnav-links="vm.subnavLinks"></ais-header>
 
 
-<div ng-if="vm.gridOptions.data.length > 0">
-    <div class="grid-container">
-        <div ng-show="vm.queueStatusError" class="alert alert-danger text-center"><strong>{{ vm.queueStatusError }}</strong> {{ vm.queueStatusErrorStatus }}</div>
-        <div ng-show="!vm.queueStatusError">
-            <div ui-grid="vm.gridOptions" ui-grid-selection ui-grid-pagination ui-grid-resize-columns class="scale-grid"></div>
-        </div>
+<div class="grid-container">
+    <div ng-show="vm.queueStatusError" class="alert alert-danger text-center"><strong>{{ vm.queueStatusError }}</strong> {{ vm.queueStatusErrorStatus }}</div>
+    <div ng-show="!vm.queueStatusError">
+        <div ui-grid="vm.gridOptions" ui-grid-selection ui-grid-pagination ui-grid-resize-columns class="scale-grid"></div>
     </div>
-    <ais-grid-pagination></ais-grid-pagination>
 </div>
+<ais-grid-pagination></ais-grid-pagination>

--- a/scale-ui/app/modules/load/partials/queueRunningTemplate.html
+++ b/scale-ui/app/modules/load/partials/queueRunningTemplate.html
@@ -1,11 +1,9 @@
 <ais-header name="'Running (' + vm.totalRunning + ' jobs; ' + vm.gridOptions.totalItems + ' job types)'" loading="vm.loading" show-subnav="true" subnav-links="vm.subnavLinks"></ais-header>
 
-<div ng-if="vm.gridOptions.data.length > 0">
-    <div class="grid-container">
-        <div ng-show="vm.runningJobsError" class="alert alert-danger text-center"><strong>{{ vm.runningJobsError }}</strong> {{ vm.runningJobsErrorStatus }}</div>
-        <div ng-show="!vm.runningJobsError">
-            <div ui-grid="vm.gridOptions" ui-grid-selection ui-grid-pagination ui-grid-resize-columns class="scale-grid"></div>
-        </div>
+<div class="grid-container">
+    <div ng-show="vm.runningJobsError" class="alert alert-danger text-center"><strong>{{ vm.runningJobsError }}</strong> {{ vm.runningJobsErrorStatus }}</div>
+    <div ng-show="!vm.runningJobsError">
+        <div ui-grid="vm.gridOptions" ui-grid-selection ui-grid-pagination ui-grid-resize-columns class="scale-grid"></div>
     </div>
-    <ais-grid-pagination></ais-grid-pagination>
 </div>
+<ais-grid-pagination></ais-grid-pagination>

--- a/scale-ui/app/modules/recipes/partials/recipesTemplate.html
+++ b/scale-ui/app/modules/recipes/partials/recipesTemplate.html
@@ -14,7 +14,7 @@
         <input id="lastModifiedStop" type="text" class="form-control" aria-describedby="to-input" uib-datepicker-popup="yyyy-MM-dd" ng-model="vm.lastModifiedStop" ng-model-options="vm.dateModelOptions" is-open="vm.lastModifiedStopPopup.opened" close-text="Close" datepicker-append-to-body="true" ng-click="vm.openLastModifiedStopPopup($event)" />
     </div>
 </div>
-<div class="row" ng-if="vm.gridOptions.data.length > 0">
+<div class="row">
     <div class="col-xs-12">
         <div class="grid-container">
             <div ui-grid="vm.gridOptions" ui-grid-selection ui-grid-pagination ui-grid-resize-columns class="scale-grid"></div>

--- a/scale-ui/app/test/scripts/backendStubs.js
+++ b/scale-ui/app/test/scripts/backendStubs.js
@@ -109,6 +109,12 @@
                 }
             }
 
+            if (urlParams.status) {
+                ingests.results = _.filter(ingests.results, function (ingest) {
+                    return ingest.status === urlParams.status[0];
+                });
+            }
+
             returnObj[1] = JSON.stringify(ingests);
 
             return returnObj;
@@ -209,6 +215,12 @@
                 });
 
                 jobs.results = _.sortByOrder(jobs.results, fields, orders);
+            }
+
+            if (urlParams.status) {
+                jobs.results = _.filter(jobs.results, function (job) {
+                    return job.status === urlParams.status[0];
+                });
             }
 
             returnObj[1] = JSON.stringify(jobs);


### PR DESCRIPTION
Removed the `ng-if="vm.gridOptions.data.length > 0"` statement from all grids.  That was originally there to ensure that they render properly without internal scrollbars, but from my testing it seems as though it's not required to accomplish this.  So when reviewing this PR, just ensure that all the grid rows render as expected, without internal scrollbars, and that page scrolling is not adversely affected in any way.

Both the Jobs and Ingests grids will filter on status when running the static build.

Fixes #376 