### PR TITLE
Issue 59 - Add Superseded Info to Recipe Detail API

### DIFF
--- a/scale/docs/rest/recipe.rst
+++ b/scale/docs/rest/recipe.rst
@@ -2,7 +2,7 @@
 .. _rest_recipe:
 
 Recipe Services
-===========================================================================================================================
+===============
 
 These services provide access to information about recipes.
 
@@ -47,35 +47,48 @@ These services provide access to information about recipes.
 | **Content Type**   | *application/json*                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **JSON Fields**                                                                                                         |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| count              | Integer           | The total number of results that match the query parameters.                   |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| next               | URL               | A URL to the next page of results.                                             |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| previous           | URL               | A URL to the previous page of results.                                         |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| results            | Array             | List of result JSON objects that match the query parameters.                   |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .id                | Integer           | The unique identifier of the model. Can be passed to the details API call.     |
-|                    |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                              |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .recipe_type       | JSON Object       | The recipe type that is associated with the recipe.                            |
-|                    |                   | This represents the latest version of the definition.                          |
-|                    |                   | (See :ref:`Recipe Type Details <rest_recipe_type_details>`)                    |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .recipe_type_rev   | JSON Object       | The recipe type revision that is associated with the recipe.                   |
-|                    |                   | This represents the definition at the time the recipe was scheduled.           |
-|                    |                   | (See :ref:`Recipe Type Revision Details <rest_recipe_type_rev_details>`)       |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .event             | JSON Object       | The trigger event that is associated with the recipe.                          |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .created           | ISO-8601 Datetime | When the associated database model was initially created.                      |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .completed         | ISO-8601 Datetime | When every job in the recipe was completed successfully.                       |
-|                    |                   | This field will remain null if a job in the recipe is blocked or failed.       |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .last_modified     | ISO-8601 Datetime | When the associated database model was last saved.                             |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
++------------------------+-------------------+----------------------------------------------------------------------------+
+| count                  | Integer           | The total number of results that match the query parameters.               |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| next                   | URL               | A URL to the next page of results.                                         |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| previous               | URL               | A URL to the previous page of results.                                     |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| results                | Array             | List of result JSON objects that match the query parameters.               |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| .id                    | Integer           | The unique identifier of the model. Can be passed to the details API call. |
+|                        |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                          |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| .recipe_type           | JSON Object       | The recipe type that is associated with the recipe.                        |
+|                        |                   | This represents the latest version of the definition.                      |
+|                        |                   | (See :ref:`Recipe Type Details <rest_recipe_type_details>`)                |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| .recipe_type_rev       | JSON Object       | The recipe type revision that is associated with the recipe.               |
+|                        |                   | This represents the definition at the time the recipe was scheduled.       |
+|                        |                   | (See :ref:`Recipe Type Revision Details <rest_recipe_type_rev_details>`)   |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| .event                 | JSON Object       | The trigger event that is associated with the recipe.                      |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| .is_superseded         | Boolean           | Whether this recipe has been replaced and is now obsolete.                 |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| .root_superseded_recipe| JSON Object       | The first recipe in the current chain of superseded recipes.               |
+|                        |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                          |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| .superseded_recipe     | JSON Object       | The previous recipe in the chain that was superseded by this recipe.       |
+|                        |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                          |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| .superseded_by_recipe  | JSON Object       | The next recipe in the chain that superseded this recipe.                  |
+|                        |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                          |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| .created               | ISO-8601 Datetime | When the associated database model was initially created.                  |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| .completed             | ISO-8601 Datetime | When every job in the recipe was completed successfully.                   |
+|                        |                   | This field will remain null if a job in the recipe is blocked or failed.   |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| .superseded            | ISO-8601 Datetime | When the the recipe became superseded by another recipe.                   |
++------------------------+-------------------+----------------------------------------------------------------------------+
+| .last_modified         | ISO-8601 Datetime | When the associated database model was last saved.                         |
++------------------------+-------------------+----------------------------------------------------------------------------+
 | .. code-block:: javascript                                                                                              |
 |                                                                                                                         |
 |    {                                                                                                                    |
@@ -106,8 +119,13 @@ These services provide access to information about recipes.
 |                    },                                                                                                   |
 |                    "occurred": "2015-06-15T19:03:26.346Z"                                                               |
 |                },                                                                                                       |
+|                "is_superseded": false,                                                                                  |
+|                "root_superseded_recipe": null,                                                                          |
+|                "superseded_recipe": null,                                                                               |
+|                "superseded_by_recipe": null,                                                                            |
 |                "created": "2015-06-15T19:03:26.346Z",                                                                   |
 |                "completed": "2015-06-15T19:05:26.346Z",                                                                 |
+|                "superseded": null,                                                                                      |
 |                "last_modified": "2015-06-15T19:05:26.346Z"                                                              |
 |            },                                                                                                           |
 |            ...                                                                                                          |
@@ -132,38 +150,53 @@ These services provide access to information about recipes.
 | **Content Type**   | *application/json*                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **JSON Fields**                                                                                                         |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| id                 | Integer           | The unique identifier of the model.                                            |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| recipe_type        | JSON Object       | The recipe type that is associated with the recipe.                            |
-|                    |                   | (See :ref:`Recipe Type Details <rest_recipe_type_details>`)                    |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| recipe_type_rev    | JSON Object       | The recipe type revision that is associated with the recipe.                   |
-|                    |                   | This represents the definition at the time the recipe was scheduled.           |
-|                    |                   | (See :ref:`Recipe Type Revision Details <rest_recipe_type_rev_details>`)       |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| event              | JSON Object       | The trigger event that is associated with the recipe.                          |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| created            | ISO-8601 Datetime | When the associated database model was initially created.                      |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| completed          | ISO-8601 Datetime | When every job in the recipe was completed successfully.                       |
-|                    |                   | This field will remain null if a job in the recipe is blocked or failed.       |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| last_modified      | ISO-8601 Datetime | When the associated database model was last saved.                             |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| data               | JSON Object       | JSON description defining the data used to execute a recipe instance.          |
-|                    |                   | (See :ref:`architecture_jobs_recipe_data_spec`)                                |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| input_files        | JSON Object       | A list of files that the recipe used as input.                                 |
-|                    |                   | (See :ref:`Scale File Details <rest_scale_file_details>`)                      |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| jobs               | Array             | The jobs associated with this recipe.                                          |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .job_name          | String            | The name of the job for this recipe.                                           |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .job               | JSON Object       | The job that is associated with the recipe.                                    |
-|                    |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| id                    | Integer           | The unique identifier of the model.                                         |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| recipe_type           | JSON Object       | The recipe type that is associated with the recipe.                         |
+|                       |                   | (See :ref:`Recipe Type Details <rest_recipe_type_details>`)                 |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| recipe_type_rev       | JSON Object       | The recipe type revision that is associated with the recipe.                |
+|                       |                   | This represents the definition at the time the recipe was scheduled.        |
+|                       |                   | (See :ref:`Recipe Type Revision Details <rest_recipe_type_rev_details>`)    |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| event                 | JSON Object       | The trigger event that is associated with the recipe.                       |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| is_superseded         | Boolean           | Whether this recipe has been replaced and is now obsolete.                  |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| root_superseded_recipe| JSON Object       | The first recipe in the current chain of superseded recipes.                |
+|                       |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                           |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| superseded_recipe     | JSON Object       | The previous recipe in the chain that was superseded by this recipe.        |
+|                       |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                           |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| superseded_by_recipe  | JSON Object       | The next recipe in the chain that superseded this recipe.                   |
+|                       |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                           |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| created               | ISO-8601 Datetime | When the associated database model was initially created.                   |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| completed             | ISO-8601 Datetime | When every job in the recipe was completed successfully.                    |
+|                       |                   | This field will remain null if a job in the recipe is blocked or failed.    |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| superseded            | ISO-8601 Datetime | When the the recipe became superseded by another recipe.                    |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| last_modified         | ISO-8601 Datetime | When the associated database model was last saved.                          |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| data                  | JSON Object       | JSON description defining the data used to execute a recipe instance.       |
+|                       |                   | (See :ref:`architecture_jobs_recipe_data_spec`)                             |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| input_files           | JSON Object       | A list of files that the recipe used as input.                              |
+|                       |                   | (See :ref:`Scale File Details <rest_scale_file_details>`)                   |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| jobs                  | Array             | The jobs associated with this recipe.                                       |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| .job_name             | String            | The name of the job for this recipe.                                        |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| .is_original          | Boolean           | Whether this is from the original recipe or copied from a superseded one.   |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
+| .job                  | JSON Object       | The job that is associated with the recipe.                                 |
+|                       |                   | (See :ref:`Job Details <rest_job_details>`)                                 |
++-----------------------+-------------------+-----------------------------------------------------------------------------+
 | .. code-block:: javascript                                                                                              |
 |                                                                                                                         |
 |    {                                                                                                                    |
@@ -267,8 +300,13 @@ These services provide access to information about recipes.
 |                "parse_id": 1                                                                                            |
 |            }                                                                                                            |
 |        },                                                                                                               |
+|        "is_superseded": false,                                                                                          |
+|        "root_superseded_recipe": null,                                                                                  |
+|        "superseded_recipe": null,                                                                                       |
+|        "superseded_by_recipe": null,                                                                                    |
 |        "created": "2015-06-15T19:03:26.346Z",                                                                           |
 |        "completed": "2015-06-15T19:05:26.346Z",                                                                         |
+|        "superseded": null,                                                                                              |
 |        "last_modified": "2015-06-15T19:05:26.346Z"                                                                      |
 |        "data": {                                                                                                        |
 |            "input_data": [                                                                                              |
@@ -307,6 +345,7 @@ These services provide access to information about recipes.
 |        "jobs": [                                                                                                        |
 |            {                                                                                                            |
 |                "job_name": "kml",                                                                                       |
+|                "is_original": true,                                                                                     |
 |                "job": {                                                                                                 |
 |                    "id": 7,                                                                                             |
 |                    "job_type": {                                                                                        |

--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -370,7 +370,7 @@ class QueueManager(models.Manager):
                 if jobs_to_queue:
                     self._queue_jobs(jobs_to_queue)
             if handler.is_completed():
-                Recipe.objects.complete(handler.recipe_id, when)
+                Recipe.objects.complete(handler.recipe.id, when)
 
     @transaction.atomic
     def handle_job_failure(self, job_exe_id, when, error=None):
@@ -512,7 +512,7 @@ class QueueManager(models.Manager):
         if jobs_to_queue:
             self._queue_jobs(jobs_to_queue)
 
-        return handler.recipe_id
+        return handler.recipe.id
 
     # TODO: once Django user auth is used, have the user information passed into here
     @transaction.atomic

--- a/scale/recipe/handlers/graph.py
+++ b/scale/recipe/handlers/graph.py
@@ -21,11 +21,11 @@ class RecipeGraph(object):
         """Adds a dependency that one job has upon another job
 
         :param parent_job_name: The name of the parent job
-        :type parent_job_name: str
+        :type parent_job_name: string
         :param child_job_name: The name of the child job
-        :type child_job_name: str
+        :type child_job_name: string
         :param connections: List of tuples where first item is parent output name and second item is child input name
-        :type connections: [(str, str)]
+        :type connections: [(string, string)]
         """
 
         parent_node = self.get_node(parent_job_name)
@@ -55,11 +55,11 @@ class RecipeGraph(object):
         """Adds a new job node to the graph
 
         :param job_name: The unique name of the job
-        :type job_name: str
+        :type job_name: string
         :param job_type_name: The name of the job's type
-        :type job_type_name: str
+        :type job_type_name: string
         :param job_type_version: The version of the job's type
-        :type job_type_version: str
+        :type job_type_version: string
         """
 
         if job_name in self._nodes:
@@ -73,11 +73,11 @@ class RecipeGraph(object):
         """Adds a recipe input connection from the given recipe input to the given job input
 
         :param recipe_input: The name of the recipe input
-        :type recipe_input: str
+        :type recipe_input: string
         :param job_name: The name of the job
-        :type job_name: str
+        :type job_name: string
         :param job_input: The name of the job input
-        :type job_input: str
+        :type job_input: string
         """
 
         if recipe_input not in self.inputs:
@@ -93,7 +93,7 @@ class RecipeGraph(object):
         """Returns the node with the given job_name
 
         :param job_name: The job name
-        :type job_name: str
+        :type job_name: string
         :returns: The node
         :rtype: :class:`recipe.handlers.node.RecipeNode`
         """
@@ -106,7 +106,7 @@ class RecipeGraph(object):
         """Returns the recipe job names in a valid topological ordering (dependency order)
 
         :returns: The list of job names in topological ordering
-        :rtype: [str]
+        :rtype: [string]
         """
 
         results = []

--- a/scale/recipe/handlers/handler.py
+++ b/scale/recipe/handlers/handler.py
@@ -16,7 +16,9 @@ class RecipeHandler(object):
         :type recipe_jobs: [:class:`recipe.models.RecipeJob`]
         """
 
-        self._recipe = recipe
+        self.recipe = recipe
+        self.recipe_jobs = recipe_jobs
+
         self._data = recipe.get_recipe_data()
         self._graph = recipe.get_recipe_definition().get_graph()
         self._jobs_by_id = {}  # {Job ID: Recipe Job}
@@ -25,16 +27,6 @@ class RecipeHandler(object):
         for recipe_job in recipe_jobs:
             self._jobs_by_id[recipe_job.job_id] = recipe_job
             self._jobs_by_name[recipe_job.job_name] = recipe_job
-
-    @property
-    def recipe_id(self):
-        """Returns the ID of the recipe for this handler
-
-        :returns: The recipe ID
-        :rtype: int
-        """
-
-        return self._recipe.id
 
     def get_blocked_jobs(self):
         """Returns the jobs within this recipe that should be updated to BLOCKED status

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -222,7 +222,7 @@ class RecipeManager(models.Manager):
         :param job_ids: The job IDs
         :type job_ids: [int]
         :returns: The recipe handlers
-        :rtype: :class:`recipe.handlers.handler.RecipeHandler`
+        :rtype: [:class:`recipe.handlers.handler.RecipeHandler`]
         """
 
         # Figure out the non-superseded recipe ID (if applicable) for each job ID

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -303,9 +303,13 @@ class RecipeManager(models.Manager):
         :returns: A recipe with additional information.
         :rtype: :class:`recipe.models.Recipe`
         """
-        recipe = Recipe.objects.all()
-        recipe = recipe.select_related('recipe_type', 'recipe_type_rev', 'event', 'event__rule')
-        recipe = recipe.get(pk=recipe_id)
+
+        # Attempt to fetch the requested recipe
+        recipe = Recipe.objects.select_related(
+            'recipe_type', 'recipe_type_rev', 'event', 'event__rule', 'root_superseded_recipe',
+            'root_superseded_recipe__recipe_type', 'superseded_recipe', 'superseded_recipe__recipe_type',
+            'superseded_by_recipe', 'superseded_by_recipe__recipe_type'
+        ).get(pk=recipe_id)
 
         # Update the recipe with source file models
         input_file_ids = recipe.get_recipe_data().get_input_file_ids()

--- a/scale/recipe/serializers.py
+++ b/scale/recipe/serializers.py
@@ -49,7 +49,7 @@ class RecipeTypeRevisionSerializer(RecipeTypeRevisionBaseSerializer):
 
 class RecipeBaseSerializer(ModelIdSerializer):
     """Converts recipe model fields to REST output."""
-    recipe_type = ModelIdSerializer()
+    recipe_type = RecipeTypeBaseSerializer()
     recipe_type_rev = ModelIdSerializer()
     event = ModelIdSerializer()
 
@@ -58,12 +58,17 @@ class RecipeSerializer(RecipeBaseSerializer):
     """Converts recipe model fields to REST output."""
     from trigger.serializers import TriggerEventBaseSerializer
 
-    recipe_type = RecipeTypeBaseSerializer()
     recipe_type_rev = RecipeTypeRevisionBaseSerializer()
     event = TriggerEventBaseSerializer()
 
+    is_superseded = serializers.BooleanField()
+    root_superseded_recipe = ModelIdSerializer()
+    superseded_recipe = ModelIdSerializer()
+    superseded_by_recipe = ModelIdSerializer()
+
     created = serializers.DateTimeField()
     completed = serializers.DateTimeField()
+    superseded = serializers.DateTimeField()
     last_modified = serializers.DateTimeField()
 
 
@@ -73,6 +78,7 @@ class RecipeJobsSerializer(serializers.Serializer):
 
     job = JobSerializer()
     job_name = serializers.CharField()
+    is_original = serializers.BooleanField()
     recipe = ModelIdSerializer()
 
 
@@ -95,3 +101,7 @@ class RecipeDetailsSerializer(RecipeSerializer):
 
     input_files = ScaleFileBaseSerializer(many=True)
     jobs = RecipeJobsDetailsSerializer(many=True)
+
+    root_superseded_recipe = RecipeBaseSerializer()
+    superseded_recipe = RecipeBaseSerializer()
+    superseded_by_recipe = RecipeBaseSerializer()

--- a/scale/recipe/test/handlers/test_handler.py
+++ b/scale/recipe/test/handlers/test_handler.py
@@ -203,7 +203,8 @@ class TestRecipeHandler(TestCase):
         }
         job_type_2 = job_test_utils.create_job_type(interface=interface_2)
         job_2 = job_test_utils.create_job(job_type=job_type_2)
-        file_1 = storage_test_utils.create_file(media_type='text/plain')
+        workspace = storage_test_utils.create_workspace()
+        file_1 = storage_test_utils.create_file(workspace=workspace, media_type='text/plain')
 
         definition = {
             'version': '1.0',
@@ -243,7 +244,7 @@ class TestRecipeHandler(TestCase):
                 'name': 'Recipe Input',
                 'file_id': file_1.id,
             }],
-            'workspace_id': 1,
+            'workspace_id': workspace.id,
         }
         recipe_type = recipe_test_utils.create_recipe_type(definition=definition)
         recipe = recipe_test_utils.create_recipe(recipe_type=recipe_type, data=data)
@@ -265,7 +266,7 @@ class TestRecipeHandler(TestCase):
             }],
             'output_data': [{
                 'name': output_name_1,
-                'workspace_id': 1,
+                'workspace_id': workspace.id,
             }],
         })
 

--- a/scale/recipe/test/test_models.py
+++ b/scale/recipe/test/test_models.py
@@ -118,7 +118,8 @@ class TestJobTypeManagerEditJobType(TransactionTestCase):
         change is made"""
 
         # Call test
-        self.assertRaises(InvalidDefinition, JobType.objects.edit_job_type, self.job_type.id, self.new_invalid_job_interface)
+        self.assertRaises(InvalidDefinition, JobType.objects.edit_job_type, self.job_type.id,
+                          self.new_invalid_job_interface)
 
         # Check results
         job_type = JobType.objects.get(pk=self.job_type.id)
@@ -227,8 +228,8 @@ class TestJobTypeManagerValidateJobType(TransactionTestCase):
         change is made"""
 
         # Call test
-        self.assertRaises(InvalidDefinition, JobType.objects.validate_job_type, self.job_type.name, self.job_type.version,
-                          self.new_invalid_job_interface)
+        self.assertRaises(InvalidDefinition, JobType.objects.validate_job_type, self.job_type.name,
+                          self.job_type.version, self.new_invalid_job_interface)
 
         # Check results
         job_type = JobType.objects.get(pk=self.job_type.id)
@@ -339,7 +340,7 @@ class TestRecipeManager(TransactionTestCase):
         self.assertEqual(len(handlers), 2)
         recipe_ids = set()
         for handler in handlers:
-            recipe_ids.add(handler.recipe_id)
+            recipe_ids.add(handler.recipe.id)
         self.assertSetEqual(recipe_ids, {self.recipe_a.id, self.recipe_b.id})
 
 
@@ -434,8 +435,8 @@ class TestRecipeManagerCreateRecipe(TransactionTestCase):
         handler = Recipe.objects.create_recipe(recipe_type=self.recipe_type, event=event, data=RecipeData(self.data))
 
         # Make sure the recipe jobs get created with the correct job types
-        recipe_job_1 = RecipeJob.objects.get(recipe_id=handler.recipe_id, job_name='Job 1')
-        recipe_job_2 = RecipeJob.objects.get(recipe_id=handler.recipe_id, job_name='Job 2')
+        recipe_job_1 = RecipeJob.objects.get(recipe_id=handler.recipe.id, job_name='Job 1')
+        recipe_job_2 = RecipeJob.objects.get(recipe_id=handler.recipe.id, job_name='Job 2')
         self.assertEqual(recipe_job_1.job.job_type.id, self.job_type_1.id)
         self.assertEqual(recipe_job_2.job.job_type.id, self.job_type_2.id)
         # Make sure the recipe jobs get created in the correct order
@@ -446,9 +447,9 @@ class TestRecipeManagerCreateRecipe(TransactionTestCase):
 
         event = trigger_test_utils.create_trigger_event()
         handler = Recipe.objects.create_recipe(recipe_type=self.recipe_type, event=event, data=RecipeData(self.data))
-        recipe = Recipe.objects.get(id=handler.recipe_id)
-        recipe_job_1 = RecipeJob.objects.select_related('job').get(recipe_id=handler.recipe_id, job_name='Job 1')
-        recipe_job_2 = RecipeJob.objects.select_related('job').get(recipe_id=handler.recipe_id, job_name='Job 2')
+        recipe = Recipe.objects.get(id=handler.recipe.id)
+        recipe_job_1 = RecipeJob.objects.select_related('job').get(recipe_id=handler.recipe.id, job_name='Job 1')
+        recipe_job_2 = RecipeJob.objects.select_related('job').get(recipe_id=handler.recipe.id, job_name='Job 2')
         superseded_jobs = {'Job 1': recipe_job_1.job, 'Job 2': recipe_job_2.job}
 
         # Create a new recipe of the same type where we want to reprocess Job 2
@@ -468,10 +469,10 @@ class TestRecipeManagerCreateRecipe(TransactionTestCase):
         self.assertTrue(job_2.is_superseded)
 
         # Check that new recipe supersedes the old one, job 1 is copied from old recipe, and job 2 supersedes old job 2
-        new_recipe = Recipe.objects.get(id=new_handler.recipe_id)
-        new_recipe_job_1 = RecipeJob.objects.select_related('job').get(recipe_id=new_handler.recipe_id,
+        new_recipe = Recipe.objects.get(id=new_handler.recipe.id)
+        new_recipe_job_1 = RecipeJob.objects.select_related('job').get(recipe_id=new_handler.recipe.id,
                                                                        job_name='Job 1')
-        new_recipe_job_2 = RecipeJob.objects.select_related('job').get(recipe_id=new_handler.recipe_id,
+        new_recipe_job_2 = RecipeJob.objects.select_related('job').get(recipe_id=new_handler.recipe.id,
                                                                        job_name='Job 2')
         self.assertEqual(new_recipe.superseded_recipe_id, recipe.id)
         self.assertEqual(new_recipe.root_superseded_recipe_id, recipe.id)
@@ -540,9 +541,9 @@ class TestRecipeManagerCreateRecipe(TransactionTestCase):
 
         event = trigger_test_utils.create_trigger_event()
         handler = Recipe.objects.create_recipe(recipe_type=self.recipe_type, event=event, data=RecipeData(self.data))
-        recipe = Recipe.objects.get(id=handler.recipe_id)
-        recipe_job_1 = RecipeJob.objects.select_related('job').get(recipe_id=handler.recipe_id, job_name='Job 1')
-        recipe_job_2 = RecipeJob.objects.select_related('job').get(recipe_id=handler.recipe_id, job_name='Job 2')
+        recipe = Recipe.objects.get(id=handler.recipe.id)
+        recipe_job_1 = RecipeJob.objects.select_related('job').get(recipe_id=handler.recipe.id, job_name='Job 1')
+        recipe_job_2 = RecipeJob.objects.select_related('job').get(recipe_id=handler.recipe.id, job_name='Job 2')
         job_exe_2 = job_test_utils.create_job_exe(job=recipe_job_2.job)
         try:
             from product.models import ProductFile
@@ -576,10 +577,10 @@ class TestRecipeManagerCreateRecipe(TransactionTestCase):
 
         # Check that new recipe supersedes the old one, job 1 is copied from old recipe, and job 2 is new and does not
         # supersede anything
-        new_recipe = Recipe.objects.get(id=new_handler.recipe_id)
-        new_recipe_job_1 = RecipeJob.objects.select_related('job').get(recipe_id=new_handler.recipe_id,
+        new_recipe = Recipe.objects.get(id=new_handler.recipe.id)
+        new_recipe_job_1 = RecipeJob.objects.select_related('job').get(recipe_id=new_handler.recipe.id,
                                                                        job_name='Job 1')
-        new_recipe_job_2 = RecipeJob.objects.select_related('job').get(recipe_id=new_handler.recipe_id,
+        new_recipe_job_2 = RecipeJob.objects.select_related('job').get(recipe_id=new_handler.recipe.id,
                                                                        job_name='Job 3')
         self.assertEqual(new_recipe.superseded_recipe_id, recipe.id)
         self.assertEqual(new_recipe.root_superseded_recipe_id, recipe.id)
@@ -978,7 +979,7 @@ class TestRecipeTypeManagerEditRecipeType(TransactionTestCase):
         self.assertEqual(num_of_revs, 1)
 
     def test_change_to_both(self):
-        """Tests calling RecipeTypeManager.edit_recipe_type() with a change to both the definition and the trigger rule"""
+        """Tests calling RecipeTypeManager.edit_recipe_type() with a change to both the definition and trigger rule"""
 
         # Create recipe_type
         name = 'test-recipe'
@@ -995,7 +996,8 @@ class TestRecipeTypeManagerEditRecipeType(TransactionTestCase):
         with transaction.atomic():
             recipe_type = RecipeType.objects.select_for_update().get(pk=recipe_type.id)
             # Edit the recipe
-            RecipeType.objects.edit_recipe_type(recipe_type.id, None, None, self.new_recipe_def, new_trigger_rule, False)
+            RecipeType.objects.edit_recipe_type(recipe_type.id, None, None, self.new_recipe_def, new_trigger_rule,
+                                                False)
         recipe_type = RecipeType.objects.select_related('trigger_rule').get(pk=recipe_type.id)
 
         # Check results

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -1,4 +1,3 @@
-#@PydevCodeAnalysisIgnore
 from __future__ import unicode_literals
 
 import django
@@ -15,19 +14,17 @@ from rest_framework import status
 
 
 class TestRecipeTypesView(TransactionTestCase):
-    '''Tests related to the recipe-types base endpoint'''
+    """Tests related to the recipe-types base endpoint"""
 
     def setUp(self):
         django.setup()
 
         self.workspace = storage_test_utils.create_workspace()
-        self.recipe_type_1 = RecipeType.objects.create(name='Recipe 1', version='1.0',
-                                                       description='Description of Recipe 1', definition='')
-        self.recipe_type_2 = RecipeType.objects.create(name='Recipe 2', version='1.0',
-                                                       description='Description of Recipe 2', definition='')
+        self.recipe_type_1 = recipe_test_utils.create_recipe_type()
+        self.recipe_type_2 = recipe_test_utils.create_recipe_type()
 
     def test_list_all(self):
-        '''Tests getting a list of recipe types.'''
+        """Tests getting a list of recipe types."""
         url = '/recipe-types/'
         response = self.client.generic('GET', url)
         results = json.loads(response.content)
@@ -36,7 +33,7 @@ class TestRecipeTypesView(TransactionTestCase):
         self.assertEqual(len(results['results']), 2)
 
     def test_create(self):
-        '''Tests creating a new recipe type.'''
+        """Tests creating a new recipe type."""
         url = '/recipe-types/'
         json_data = {
             'name': 'recipe-type-post-test',
@@ -64,7 +61,7 @@ class TestRecipeTypesView(TransactionTestCase):
         self.assertIsNone(results['trigger_rule'])
 
     def test_create_trigger(self):
-        '''Tests creating a new recipe type with a trigger rule.'''
+        """Tests creating a new recipe type with a trigger rule."""
         url = '/recipe-types/'
         json_data = {
             'name': 'recipe-type-post-test',
@@ -107,7 +104,7 @@ class TestRecipeTypesView(TransactionTestCase):
         self.assertEqual(results['trigger_rule']['type'], 'PARSE')
 
     def test_create_bad_param(self):
-        '''Tests creating a new recipe type with missing fields.'''
+        """Tests creating a new recipe type with missing fields."""
         url = '/recipe-types/'
         json_data = {
             'name': 'recipe-type-post-test',
@@ -117,7 +114,7 @@ class TestRecipeTypesView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_bad_job(self):
-        '''Tests creating a new recipe type with an invalid job relationship.'''
+        """Tests creating a new recipe type with an invalid job relationship."""
         url = '/recipe-types/'
         json_data = {
             'name': 'recipe-type-post-test',
@@ -140,7 +137,7 @@ class TestRecipeTypesView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_bad_trigger_type(self):
-        '''Tests creating a new recipe type with an invalid trigger type.'''
+        """Tests creating a new recipe type with an invalid trigger type."""
         url = '/recipe-types/'
         json_data = {
             'name': 'recipe-type-post-test',
@@ -165,7 +162,7 @@ class TestRecipeTypesView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_bad_trigger_config(self):
-        '''Tests creating a new recipe type with an invalid trigger rule configuration.'''
+        """Tests creating a new recipe type with an invalid trigger rule configuration."""
         url = '/recipe-types/'
         json_data = {
             'name': 'recipe-type-post-test',
@@ -194,7 +191,7 @@ class TestRecipeTypesView(TransactionTestCase):
 
 
 class TestRecipeTypeDetailsView(TransactionTestCase):
-    '''Tests related to the recipe-types details endpoint'''
+    """Tests related to the recipe-types details endpoint"""
 
     def setUp(self):
         django.setup()
@@ -237,7 +234,7 @@ class TestRecipeTypeDetailsView(TransactionTestCase):
                                                                 trigger_rule=self.trigger_rule)
 
     def test_not_found(self):
-        '''Tests calling the recipe type details view with an id that does not exist.'''
+        """Tests calling the recipe type details view with an id that does not exist."""
 
         url = '/recipe-types/100/'
         response = self.client.get(url)
@@ -245,7 +242,7 @@ class TestRecipeTypeDetailsView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_successful(self):
-        '''Tests successfully calling the recipe type details view.'''
+        """Tests successfully calling the recipe type details view."""
 
         url = '/recipe-types/%d/' % self.recipe_type.id
         response = self.client.get(url)
@@ -262,7 +259,7 @@ class TestRecipeTypeDetailsView(TransactionTestCase):
         self.assertEqual(result['trigger_rule']['id'], self.trigger_rule.id)
 
     def test_edit_simple(self):
-        '''Tests editing only the basic attributes of a recipe type'''
+        """Tests editing only the basic attributes of a recipe type"""
 
         url = '/recipe-types/%d/' % self.recipe_type.id
         json_data = {
@@ -285,7 +282,7 @@ class TestRecipeTypeDetailsView(TransactionTestCase):
         self.assertEqual(result['trigger_rule']['id'], self.trigger_rule.id)
 
     def test_edit_definition(self):
-        '''Tests editing the definition of a recipe type'''
+        """Tests editing the definition of a recipe type"""
         definition = self.definition.copy()
         definition['input_data'] = [{
             'name': 'input_file',
@@ -309,7 +306,7 @@ class TestRecipeTypeDetailsView(TransactionTestCase):
         self.assertEqual(result['trigger_rule']['id'], self.trigger_rule.id)
 
     def test_edit_trigger_rule(self):
-        '''Tests editing the trigger rule of a recipe type'''
+        """Tests editing the trigger rule of a recipe type"""
         trigger_config = self.trigger_config.copy()
         trigger_config['condition']['media_type'] = 'application/json'
 
@@ -332,7 +329,7 @@ class TestRecipeTypeDetailsView(TransactionTestCase):
         self.assertNotEqual(result['trigger_rule']['id'], self.trigger_rule.id)
 
     def test_edit_trigger_rule_pause(self):
-        '''Tests pausing the trigger rule of a recipe type'''
+        """Tests pausing the trigger rule of a recipe type"""
         trigger_config = self.trigger_config.copy()
         trigger_config['condition']['media_type'] = 'application/json'
 
@@ -353,7 +350,7 @@ class TestRecipeTypeDetailsView(TransactionTestCase):
         self.assertEqual(result['trigger_rule']['is_active'], False)
 
     def test_edit_trigger_rule_remove(self):
-        '''Tests removing the trigger rule from a recipe type'''
+        """Tests removing the trigger rule from a recipe type"""
         url = '/recipe-types/%d/' % self.recipe_type.id
         json_data = {
             'trigger_rule': None,
@@ -369,7 +366,7 @@ class TestRecipeTypeDetailsView(TransactionTestCase):
         self.assertIsNone(result['trigger_rule'])
 
     def test_edit_definition_and_trigger_rule(self):
-        '''Tests editing the recipe type definition and trigger rule together'''
+        """Tests editing the recipe type definition and trigger rule together"""
         definition = self.definition.copy()
         definition['input_data'] = [{
             'name': 'input_file',
@@ -400,7 +397,7 @@ class TestRecipeTypeDetailsView(TransactionTestCase):
         self.assertNotEqual(result['trigger_rule']['id'], self.trigger_rule.id)
 
     def test_edit_bad_definition(self):
-        '''Tests attempting to edit a recipe type using an invalid recipe definition'''
+        """Tests attempting to edit a recipe type using an invalid recipe definition"""
         definition = self.definition.copy()
         definition['version'] = 'BAD'
 
@@ -413,7 +410,7 @@ class TestRecipeTypeDetailsView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_edit_bad_trigger(self):
-        '''Tests attempting to edit a recipe type using an invalid trigger rule'''
+        """Tests attempting to edit a recipe type using an invalid trigger rule"""
         trigger_config = self.trigger_config.copy()
         trigger_config['version'] = 'BAD'
 
@@ -430,7 +427,7 @@ class TestRecipeTypeDetailsView(TransactionTestCase):
 
 
 class TestRecipeTypesValidationView(TransactionTestCase):
-    '''Tests related to the recipe-types validation endpoint'''
+    """Tests related to the recipe-types validation endpoint"""
 
     def setUp(self):
         django.setup()
@@ -439,7 +436,7 @@ class TestRecipeTypesValidationView(TransactionTestCase):
         self.job_type = job_test_utils.create_job_type()
 
     def test_successful(self):
-        '''Tests validating a new recipe type.'''
+        """Tests validating a new recipe type."""
         url = '/recipe-types/validation/'
         json_data = {
             'name': 'recipe-type-test',
@@ -464,7 +461,7 @@ class TestRecipeTypesValidationView(TransactionTestCase):
         self.assertDictEqual(results, {'warnings': []}, 'JSON result was incorrect')
 
     def test_successful_trigger(self):
-        '''Tests validating a new recipe type with a trigger.'''
+        """Tests validating a new recipe type with a trigger."""
         url = '/recipe-types/validation/'
         json_data = {
             'name': 'recipe-type-test',
@@ -503,7 +500,7 @@ class TestRecipeTypesValidationView(TransactionTestCase):
         self.assertDictEqual(results, {'warnings': []}, 'JSON result was incorrect')
 
     def test_bad_param(self):
-        '''Tests validating a new recipe type with missing fields.'''
+        """Tests validating a new recipe type with missing fields."""
         url = '/recipe-types/validation/'
         json_data = {
             'name': 'recipe-type-post-test',
@@ -513,7 +510,7 @@ class TestRecipeTypesValidationView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_bad_job(self):
-        '''Tests creating a new recipe type with an invalid job relationship.'''
+        """Tests creating a new recipe type with an invalid job relationship."""
         url = '/recipe-types/validation/'
         json_data = {
             'name': 'recipe-type-post-test',
@@ -536,7 +533,7 @@ class TestRecipeTypesValidationView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_warnings(self):
-        '''Tests creating a new recipe type with mismatched media type warnings.'''
+        """Tests creating a new recipe type with mismatched media type warnings."""
         interface = {
             'version': '1.0',
             'command': '/test.sh',
@@ -602,7 +599,7 @@ class TestRecipeTypesValidationView(TransactionTestCase):
         self.assertEqual(results['warnings'][1]['id'], 'media_type')
 
     def test_bad_trigger_type(self):
-        '''Tests validating a new recipe type with an invalid trigger type.'''
+        """Tests validating a new recipe type with an invalid trigger type."""
         url = '/recipe-types/validation/'
         json_data = {
             'name': 'recipe-type-post-test',
@@ -627,7 +624,7 @@ class TestRecipeTypesValidationView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_bad_trigger_config(self):
-        '''Tests validating a new recipe type with an invalid trigger rule configuration.'''
+        """Tests validating a new recipe type with an invalid trigger rule configuration."""
         url = '/recipe-types/validation/'
         json_data = {
             'name': 'recipe-type-post-test',
@@ -691,7 +688,7 @@ class TestRecipesView(TransactionTestCase):
         self.recipe2 = recipe_test_utils.create_recipe()
 
     def test_successful_all(self):
-        '''Tests getting recipes'''
+        """Tests getting recipes"""
 
         url = '/recipes/'
         response = self.client.generic('GET', url)
@@ -701,7 +698,7 @@ class TestRecipesView(TransactionTestCase):
         self.assertEqual(results['count'], 2)
 
     def test_successful_type_name(self):
-        '''Tests getting recipes by type name'''
+        """Tests getting recipes by type name"""
 
         url = '/recipes/?type_name=my-type'
         response = self.client.generic('GET', url)
@@ -712,7 +709,7 @@ class TestRecipesView(TransactionTestCase):
         self.assertEqual(results['results'][0]['recipe_type']['name'], 'my-type')
 
     def test_successful_type_id(self):
-        '''Tests getting recipes by type id'''
+        """Tests getting recipes by type id"""
 
         url = '/recipes/?type_id=%s' % self.recipe_type.id
         response = self.client.generic('GET', url)
@@ -723,7 +720,7 @@ class TestRecipesView(TransactionTestCase):
         self.assertEqual(results['results'][0]['recipe_type']['id'], self.recipe_type.id)
 
     def test_successful_details(self):
-        '''Tests getting recipe details'''
+        """Tests getting recipe details"""
 
         url = '/recipes/%s/' % self.recipe1.id
         response = self.client.generic('GET', url)

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -9,7 +9,9 @@ import job.test.utils as job_test_utils
 import recipe.test.utils as recipe_test_utils
 import storage.test.utils as storage_test_utils
 import trigger.test.utils as trigger_test_utils
-from recipe.models import RecipeType
+from recipe.handlers.graph import RecipeGraph
+from recipe.handlers.graph_delta import RecipeGraphDelta
+from recipe.models import RecipeJob, RecipeType
 from rest_framework import status
 
 
@@ -681,9 +683,22 @@ class TestRecipesView(TransactionTestCase):
             }],
         }
 
+        workspace1 = storage_test_utils.create_workspace()
+        file1 = storage_test_utils.create_file(workspace=workspace1)
+
+        data = {
+            'version': '1.0',
+            'input_data': [{
+                'name': 'input_file',
+                'file_id': file1.id,
+            }],
+            'workspace_id': workspace1.id,
+        }
+
         self.recipe_type = recipe_test_utils.create_recipe_type(name='my-type', definition=definition)
-        self.recipe1 = recipe_test_utils.create_recipe(self.recipe_type)
-        self.recipe_job1 = recipe_test_utils.create_recipe_job(recipe=self.recipe1)
+        recipe_handler = recipe_test_utils.create_recipe_handler(recipe_type=self.recipe_type, data=data)
+        self.recipe1 = recipe_handler.recipe
+        self.recipe1_jobs = recipe_handler.recipe_jobs
 
         self.recipe2 = recipe_test_utils.create_recipe()
 
@@ -731,3 +746,48 @@ class TestRecipesView(TransactionTestCase):
         self.assertEqual(results['recipe_type']['id'], self.recipe1.recipe_type.id)
         self.assertEqual(results['recipe_type_rev']['recipe_type']['id'], self.recipe1.recipe_type.id)
         self.assertDictEqual(results['jobs'][0]['job']['job_type_rev']['interface'], self.job_type1.interface)
+
+    def test_superseded(self):
+        """Tests successfully calling the recipe details view for superseded recipes."""
+
+        graph1 = RecipeGraph()
+        graph1.add_job('kml', self.job_type1.name, self.job_type1.version)
+        graph2 = RecipeGraph()
+        graph2.add_job('kml', self.job_type1.name, self.job_type1.version)
+        delta = RecipeGraphDelta(graph1, graph2)
+
+        superseded_jobs = {recipe_job.job_name: recipe_job.job for recipe_job in self.recipe1_jobs}
+        new_recipe = recipe_test_utils.create_recipe_handler(
+            recipe_type=self.recipe_type, superseded_recipe=self.recipe1, delta=delta, superseded_jobs=superseded_jobs
+        ).recipe
+
+        # Make sure the original recipe was updated
+        url = '/recipes/%i/' % self.recipe1.id
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(result['is_superseded'])
+        self.assertIsNone(result['root_superseded_recipe'])
+        self.assertIsNotNone(result['superseded_by_recipe'])
+        self.assertEqual(result['superseded_by_recipe']['id'], new_recipe.id)
+        self.assertIsNotNone(result['superseded'])
+        self.assertEqual(len(result['jobs']), 1)
+        for recipe_job in result['jobs']:
+            self.assertTrue(recipe_job['is_original'])
+
+        # Make sure the new recipe has the expected relations
+        url = '/recipes/%i/' % new_recipe.id
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(result['is_superseded'])
+        self.assertIsNotNone(result['root_superseded_recipe'])
+        self.assertEqual(result['root_superseded_recipe']['id'], self.recipe1.id)
+        self.assertIsNotNone(result['superseded_recipe'])
+        self.assertEqual(result['superseded_recipe']['id'], self.recipe1.id)
+        self.assertIsNone(result['superseded'])
+        self.assertEqual(len(result['jobs']), 1)
+        for recipe_job in result['jobs']:
+            self.assertFalse(recipe_job['is_original'])

--- a/scale/recipe/test/utils.py
+++ b/scale/recipe/test/utils.py
@@ -1,4 +1,4 @@
-'''Defines utility methods for testing jobs and job types'''
+"""Defines utility methods for testing jobs and job types"""
 from __future__ import unicode_literals
 
 import job.test.utils as job_test_utils
@@ -20,8 +20,8 @@ MOCK_ERROR_TYPE = 'MOCK_RECIPE_TRIGGER_RULE_ERROR_TYPE'
 
 
 class MockTriggerRuleConfiguration(RecipeTriggerRuleConfiguration):
-    '''Mock trigger rule configuration for testing
-    '''
+    """Mock trigger rule configuration for testing
+    """
 
     def __init__(self, trigger_rule_type, configuration):
         super(MockTriggerRuleConfiguration, self).__init__(trigger_rule_type, configuration)
@@ -37,8 +37,8 @@ class MockTriggerRuleConfiguration(RecipeTriggerRuleConfiguration):
 
 
 class MockErrorTriggerRuleConfiguration(RecipeTriggerRuleConfiguration):
-    '''Mock error trigger rule configuration for testing
-    '''
+    """Mock error trigger rule configuration for testing
+    """
 
     def __init__(self, trigger_rule_type, configuration):
         super(MockErrorTriggerRuleConfiguration, self).__init__(trigger_rule_type, configuration)
@@ -54,8 +54,8 @@ class MockErrorTriggerRuleConfiguration(RecipeTriggerRuleConfiguration):
 
 
 class MockTriggerRuleHandler(TriggerRuleHandler):
-    '''Mock trigger rule handler for testing
-    '''
+    """Mock trigger rule handler for testing
+    """
 
     def __init__(self):
         super(MockTriggerRuleHandler, self).__init__(MOCK_TYPE)
@@ -65,8 +65,8 @@ class MockTriggerRuleHandler(TriggerRuleHandler):
 
 
 class MockErrorTriggerRuleHandler(TriggerRuleHandler):
-    '''Mock error trigger rule handler for testing
-    '''
+    """Mock error trigger rule handler for testing
+    """
 
     def __init__(self):
         super(MockErrorTriggerRuleHandler, self).__init__(MOCK_ERROR_TYPE)
@@ -80,31 +80,31 @@ register_trigger_rule_handler(MockErrorTriggerRuleHandler())
 
 
 def create_recipe_type(name=None, version=None, title=None, description=None, definition=None, trigger_rule=None):
-    '''Creates a recipe type for unit testing
+    """Creates a recipe type for unit testing
 
     :returns: The RecipeType model
     :rtype: :class:`recipe.models.RecipeType`
-    '''
+    """
 
     if not name:
         global NAME_COUNTER
         name = 'test-recipe-type-%i' % NAME_COUNTER
-        NAME_COUNTER = NAME_COUNTER + 1
+        NAME_COUNTER += 1
 
     if not version:
         global VERSION_COUNTER
         version = '%i.0.0' % VERSION_COUNTER
-        VERSION_COUNTER = VERSION_COUNTER + 1
+        VERSION_COUNTER += 1
 
     if not title:
         global TITLE_COUNTER
         title = 'Test Recipe Type %i' % TITLE_COUNTER
-        TITLE_COUNTER = TITLE_COUNTER + 1
+        TITLE_COUNTER += 1
 
     if not description:
         global DESCRIPTION_COUNTER
         description = 'Test Description %i' % DESCRIPTION_COUNTER
-        DESCRIPTION_COUNTER = DESCRIPTION_COUNTER + 1
+        DESCRIPTION_COUNTER += 1
 
     if not definition:
         definition = {
@@ -131,7 +131,7 @@ def create_recipe_type(name=None, version=None, title=None, description=None, de
 
 
 def create_recipe(recipe_type=None, data=None, event=None):
-    '''Creates a job type model for unit testing
+    """Creates a job type model for unit testing
 
     :param recipe_type: The associated recipe type
     :type recipe_type: :class:'recipe.models.RecipeType'
@@ -141,7 +141,7 @@ def create_recipe(recipe_type=None, data=None, event=None):
     :type event: :class:'trigger.models.TriggerEvent'
     :returns: The recipe model
     :rtype: :class:`recipe.models.Recipe`
-    '''
+    """
 
     if not data:
         data = {}
@@ -163,17 +163,17 @@ def create_recipe(recipe_type=None, data=None, event=None):
 
 
 def create_recipe_job(recipe=None, job_name=None, job=None):
-    '''Creates a job type model for unit testing
+    """Creates a job type model for unit testing
 
     :param recipe: The associated recipe
     :type recipe: :class:'recipe.models.Recipe'
     :param job_name: The associated name for the recipe job
-    :type data: string
+    :type job_name: string
     :param job: The associated job
     :type job: :class:'job.models.Job'
     :returns: The recipe job model
     :rtype: :class:`recipe.models.RecipeJob`
-    '''
+    """
     if not recipe:
         recipe = create_recipe()
 

--- a/scale/trigger/handler.py
+++ b/scale/trigger/handler.py
@@ -1,4 +1,4 @@
-'''Defines the base class for handling trigger rules and provides apps a way to register handler sub-classes'''
+"""Defines the base class for handling trigger rules and provides apps a way to register handler sub-classes"""
 from __future__ import unicode_literals
 
 from abc import ABCMeta, abstractmethod
@@ -13,50 +13,50 @@ TRIGGER_RULE_HANDLERS = {}
 
 
 def get_trigger_rule_handler(trigger_rule_type):
-    '''Returns the trigger rule handler that is registered with the given type
+    """Returns the trigger rule handler that is registered with the given type
 
     :param trigger_rule_type: The trigger rule type
-    :type trigger_rule_type: str
+    :type trigger_rule_type: string
     :returns: The trigger rule handler, possibly None
     :rtype: :class:`trigger.handler.TriggerRuleHandler`
 
     :raises :class:`trigger.configuration.exceptions.InvalidTriggerType`: If the trigger type is invalid
-    '''
+    """
 
-    if not trigger_rule_type in TRIGGER_RULE_HANDLERS:
+    if trigger_rule_type not in TRIGGER_RULE_HANDLERS:
         raise InvalidTriggerType('%s is an invalid trigger rule type' % trigger_rule_type)
 
     return TRIGGER_RULE_HANDLERS[trigger_rule_type]
 
 
 def register_trigger_rule_handler(trigger_rule_handler):
-    '''Registers the given trigger rule handler with the given type
+    """Registers the given trigger rule handler with the given type
 
     :param trigger_rule_handler: The trigger rule handler
     :type trigger_rule_handler: :class:`trigger.handler.TriggerRuleHandler`
-    '''
+    """
 
     TRIGGER_RULE_HANDLERS[trigger_rule_handler.trigger_rule_type] = trigger_rule_handler
 
 
 class TriggerRuleHandler(object):
-    '''Base class for handling trigger rules
-    '''
+    """Base class for handling trigger rules
+    """
 
     __metaclass__ = ABCMeta
 
     def __init__(self, trigger_rule_type):
-        '''Constructor
+        """Constructor
 
         :param trigger_rule_type: The trigger rule type
-        :type trigger_rule_type: str
-        '''
+        :type trigger_rule_type: string
+        """
 
         self.trigger_rule_type = trigger_rule_type
 
     @abstractmethod
     def create_configuration(self, config_dict):
-        '''Creates and returns a trigger rule configuration from the given dict
+        """Creates and returns a trigger rule configuration from the given dict
 
         :param config_dict: The configuration as a dict
         :type config_dict: dict
@@ -64,25 +64,25 @@ class TriggerRuleHandler(object):
         :rtype: :class:`trigger.configuration.trigger_rule.TriggerRuleConfiguration`
 
         :raises :class:`trigger.configuration.exceptions.InvalidTriggerRule`: If the configuration is invalid
-        '''
+        """
 
         raise NotImplementedError()
 
     def create_trigger_rule(self, config_dict, name=None, is_active=True):
-        '''Creates and returns a trigger rule model with the given configuration. The returned trigger rule model will
+        """Creates and returns a trigger rule model with the given configuration. The returned trigger rule model will
         be saved in the database.
 
         :param config_dict: The configuration as a dict
         :type config_dict: dict
         :param name: An optional name for the trigger
-        :type name: str
+        :type name: string
         :param is_active: Whether or not the trigger should be active
         :type is_active: bool
         :returns: The new trigger rule
         :rtype: :class:`trigger.models.TriggerRule`
 
         :raises trigger.configuration.exceptions.InvalidTriggerRule: If the configuration is invalid
-        '''
+        """
 
         configuration = self.create_configuration(config_dict)
         return TriggerRule.objects.create_trigger_rule(self.trigger_rule_type, configuration, name, is_active)


### PR DESCRIPTION
Implemented according to the original issue, except root_superseded_recipe_id and superseded_recipe_id fields are replaced with nested objects per the standard REST conventions. Also used the RecipeBaseSerializer with a bit of added info to be consistent with the jobs API.

Made a couple small changes to the recipe handler API to make it more general for additional use cases and included some minor formatting/warning cleanup.