### PR TITLE
Issue 161 - Update job views to support filtering by multiple status values

### DIFF
--- a/scale/docs/rest/job.rst
+++ b/scale/docs/rest/job.rst
@@ -36,6 +36,7 @@ These services provide access to information about "all", "currently running" an
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | status             | String            | Optional | Return only jobs with a status matching this string.                |
 |                    |                   |          | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].            |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | job_id             | Integer           | Optional | Return only jobs with a given identifier.                           |
 |                    |                   |          | Duplicate it to filter by multiple values.                          |
@@ -623,6 +624,7 @@ These services provide access to information about "all", "currently running" an
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | status             | String            | Optional | Return only jobs with a status matching this string.                |
 |                    |                   |          | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].            |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | job_type_id        | Integer           | Optional | Return only jobs with a given job type identifier.                  |
 |                    |                   |          | Duplicate it to filter by multiple values.                          |
@@ -830,6 +832,7 @@ These services provide access to information about "all", "currently running" an
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | status             | String            | Optional | Return only jobs with a status matching this string.                |
 |                    |                   |          | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].            |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | job_type_id        | Integer           | Optional | Return only jobs with a given job type identifier.                  |
 |                    |                   |          | Duplicate it to filter by multiple values.                          |

--- a/scale/docs/rest/job_execution.rst
+++ b/scale/docs/rest/job_execution.rst
@@ -37,6 +37,7 @@ These services provide access to information about "all", "currently running" an
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | status             | String            | Optional | Return only executions with a status matching this string.          |
 |                    |                   |          | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].            |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | job_type_id        | Integer           | Optional | Return only jobs with a given job type identifier.                  |
 |                    |                   |          | Duplicate it to filter by multiple values.                          |

--- a/scale/docs/rest/node.rst
+++ b/scale/docs/rest/node.rst
@@ -69,7 +69,7 @@ These services provide access to information about the nodes.
 | .is_paused         | Boolean           | True if the node is paused and will not accept new jobs for execution.         |
 |                    |                   | Remaining tasks for a previously executing job will complete.                  |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| .is_paused_errors  |                   | True if the node was automatically paused due to a high error rate.            |
+| .is_paused_errors  | Boolean           | True if the node was automatically paused due to a high error rate.            |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .is_active         | Boolean           | True if the node is actively participating in the cluster.                     |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -139,7 +139,7 @@ These services provide access to information about the nodes.
 | is_paused          | Boolean           | True if the node is paused and will not accept new jobs for execution.         |
 |                    |                   | Remaining tasks for a previously executing job will complete.                  |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| .is_paused_errors  |                   | True if the node was automatically paused due to a high error rate.            |
+| is_paused_errors   | Boolean           | True if the node was automatically paused due to a high error rate.            |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | is_active          | Boolean           | True if the node is actively participating in the cluster.                     |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -167,7 +167,7 @@ These services provide access to information about the nodes.
 | ..cpus             | Float             | The scheduled number of CPUs at this node                                      |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | ..mem              | Float             | The scheduled amount of RAM in MiB at this node                                |
-+--------------------------+-------------+--------------------------------------------------------------------------------+
++--------------------+-------------------+--------------------------------------------------------------------------------+
 | ..disk             | Float             | The scheduled amount of disk space in MiB at this node                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .used              | JSON Object       | The used hardware resources for all nodes in the cluster                       |
@@ -335,7 +335,7 @@ These services provide access to information about the nodes.
 | is_paused          | Boolean           | True if the node is paused and will not accept new jobs for execution.         |
 |                    |                   | Remaining tasks for a previously executing job will complete.                  |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| .is_paused_errors  |                   | True if the node was automatically paused due to a high error rate.            |
+| is_paused_errors   | Boolean           | True if the node was automatically paused due to a high error rate.            |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | created            | ISO-8601 Datetime | When the associated database model was initially created.                      |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -401,7 +401,7 @@ These services provide access to information about the nodes.
 | is_paused          | Boolean           | True if the node is paused and will not accept new jobs for execution.         |
 |                    |                   | Remaining tasks for a previously executing job will complete.                  |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| .is_paused_errors  |                   | True if the node was automatically paused due to a high error rate.            |
+| is_paused_errors   | Boolean           | True if the node was automatically paused due to a high error rate.            |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | created            | ISO-8601 Datetime | When the associated database model was initially created.                      |
 +--------------------+-------------------+--------------------------------------------------------------------------------+

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -109,7 +109,7 @@ class JobManager(models.Manager):
 
         return job
 
-    def get_jobs(self, started=None, ended=None, status=None, job_ids=None, job_type_ids=None, job_type_names=None,
+    def get_jobs(self, started=None, ended=None, statuses=None, job_ids=None, job_type_ids=None, job_type_names=None,
                  job_type_categories=None, error_categories=None, order=None):
         """Returns a list of jobs within the given time range.
 
@@ -117,8 +117,8 @@ class JobManager(models.Manager):
         :type started: :class:`datetime.datetime`
         :param ended: Query jobs updated before this amount of time.
         :type ended: :class:`datetime.datetime`
-        :param status: Query jobs with the a specific execution status.
-        :type status: string
+        :param statuses: Query jobs with the a specific execution status.
+        :type statuses: [string]
         :param job_ids: Query jobs associated with the identifier.
         :type job_ids: [int]
         :param job_type_ids: Query jobs of the type associated with the identifier.
@@ -145,8 +145,8 @@ class JobManager(models.Manager):
         if ended:
             jobs = jobs.filter(last_modified__lte=ended)
 
-        if status:
-            jobs = jobs.filter(status=status)
+        if statuses:
+            jobs = jobs.filter(status__in=statuses)
         if job_ids:
             jobs = jobs.filter(id__in=job_ids)
         if job_type_ids:
@@ -223,7 +223,7 @@ class JobManager(models.Manager):
         job.products = output_files
         return job
 
-    def get_job_updates(self, started=None, ended=None, status=None, job_type_ids=None,
+    def get_job_updates(self, started=None, ended=None, statuses=None, job_type_ids=None,
                         job_type_names=None, job_type_categories=None, order=None):
         """Returns a list of jobs that changed status within the given time range.
 
@@ -231,8 +231,8 @@ class JobManager(models.Manager):
         :type started: :class:`datetime.datetime`
         :param ended: Query jobs updated before this amount of time.
         :type ended: :class:`datetime.datetime`
-        :param status: Query jobs with the a specific execution status.
-        :type status: string
+        :param statuses: Query jobs with the a specific execution status.
+        :type statuses: [string]
         :param job_type_ids: Query jobs of the type associated with the identifier.
         :type job_type_ids: [int]
         :param job_type_categories: Query jobs of the type associated with the category.
@@ -246,7 +246,7 @@ class JobManager(models.Manager):
         """
         if not order:
             order = ['last_status_change']
-        return self.get_jobs(started=started, ended=ended, status=status, job_type_ids=job_type_ids,
+        return self.get_jobs(started=started, ended=ended, statuses=statuses, job_type_ids=job_type_ids,
                              job_type_names=job_type_names, job_type_categories=job_type_categories, order=order)
 
     def get_locked_job(self, job_id):
@@ -781,7 +781,7 @@ class JobExecutionManager(models.Manager):
         # Update job model
         Job.objects.complete_job(job_exe.job, when, JobResults(job_exe.results))
 
-    def get_exes(self, started=None, ended=None, status=None, job_type_ids=None, job_type_names=None,
+    def get_exes(self, started=None, ended=None, statuses=None, job_type_ids=None, job_type_names=None,
                  job_type_categories=None, node_ids=None, order=None):
         """Returns a list of jobs within the given time range.
 
@@ -789,8 +789,8 @@ class JobExecutionManager(models.Manager):
         :type started: :class:`datetime.datetime`
         :param ended: Query job executions updated before this amount of time.
         :type ended: :class:`datetime.datetime`
-        :param status: Query job executions with the a specific status.
-        :type status: string
+        :param statuses: Query job executions with the a specific status.
+        :type statuses: [string]
         :param job_type_ids: Query job executions of the type associated with the identifier.
         :type job_type_ids: [int]
         :param job_type_names: Query job executions of the type associated with the name.
@@ -815,8 +815,8 @@ class JobExecutionManager(models.Manager):
         if ended:
             job_exes = job_exes.filter(last_modified__lte=ended)
 
-        if status:
-            job_exes = job_exes.filter(status=status)
+        if statuses:
+            job_exes = job_exes.filter(status__in=statuses)
         if job_type_ids:
             job_exes = job_exes.filter(job__job_type_id__in=job_type_ids)
         if job_type_names:

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -422,7 +422,7 @@ class JobsView(ListAPIView):
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
 
-        job_status = rest_util.parse_string(request, 'status', required=False)
+        job_statuses = rest_util.parse_string_list(request, 'status', required=False)
         job_ids = rest_util.parse_int_list(request, 'job_id', required=False)
         job_type_ids = rest_util.parse_int_list(request, 'job_type_id', required=False)
         job_type_names = rest_util.parse_string_list(request, 'job_type_name', required=False)
@@ -431,7 +431,7 @@ class JobsView(ListAPIView):
 
         order = rest_util.parse_string_list(request, 'order', required=False)
 
-        jobs = Job.objects.get_jobs(started, ended, job_status, job_ids, job_type_ids, job_type_names,
+        jobs = Job.objects.get_jobs(started, ended, job_statuses, job_ids, job_type_ids, job_type_names,
                                     job_type_categories, error_categories, order)
 
         page = self.paginate_queryset(jobs)
@@ -509,14 +509,14 @@ class JobUpdatesView(ListAPIView):
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
 
-        job_status = rest_util.parse_string(request, 'status', required=False)
+        job_statuses = rest_util.parse_string_list(request, 'status', required=False)
         job_type_ids = rest_util.parse_int_list(request, 'job_type_id', required=False)
         job_type_names = rest_util.parse_string_list(request, 'job_type_name', required=False)
         job_type_categories = rest_util.parse_string_list(request, 'job_type_category', required=False)
 
         order = rest_util.parse_string_list(request, 'order', required=False)
 
-        jobs = Job.objects.get_job_updates(started, ended, job_status, job_type_ids, job_type_names,
+        jobs = Job.objects.get_job_updates(started, ended, job_statuses, job_type_ids, job_type_names,
                                            job_type_categories, order)
 
         page = self.paginate_queryset(jobs)
@@ -542,7 +542,7 @@ class JobsWithExecutionView(ListAPIView):
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
 
-        job_status = rest_util.parse_string(request, 'status', required=False)
+        job_statuses = rest_util.parse_string_list(request, 'status', required=False)
         job_ids = rest_util.parse_int_list(request, 'job_id', required=False)
         job_type_ids = rest_util.parse_int_list(request, 'job_type_id', required=False)
         job_type_names = rest_util.parse_string_list(request, 'job_type_name', required=False)
@@ -551,7 +551,7 @@ class JobsWithExecutionView(ListAPIView):
 
         order = rest_util.parse_string_list(request, 'order', required=False)
 
-        jobs = Job.objects.get_jobs(started, ended, job_status, job_ids, job_type_ids, job_type_names,
+        jobs = Job.objects.get_jobs(started, ended, job_statuses, job_ids, job_type_ids, job_type_names,
                                     job_type_categories, error_categories, order)
 
         # Add the latest execution for each matching job
@@ -580,7 +580,7 @@ class JobExecutionsView(ListAPIView):
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
 
-        job_status = rest_util.parse_string(request, 'status', required=False)
+        job_statuses = rest_util.parse_string_list(request, 'status', required=False)
         job_type_ids = rest_util.parse_int_list(request, 'job_type_id', required=False)
         job_type_names = rest_util.parse_string_list(request, 'job_type_name', required=False)
         job_type_categories = rest_util.parse_string_list(request, 'job_type_category', required=False)
@@ -589,7 +589,7 @@ class JobExecutionsView(ListAPIView):
 
         order = rest_util.parse_string_list(request, 'order', required=False)
 
-        job_exes = JobExecution.objects.get_exes(started, ended, job_status, job_type_ids, job_type_names,
+        job_exes = JobExecution.objects.get_exes(started, ended, job_statuses, job_type_ids, job_type_names,
                                                  job_type_categories, node_ids, order)
 
         page = self.paginate_queryset(job_exes)

--- a/scale/queue/views.py
+++ b/scale/queue/views.py
@@ -172,7 +172,8 @@ class RequeueJobsView(GenericAPIView):
         priority = rest_util.parse_int(request, 'priority', required=False)
 
         # Fetch all the jobs matching the filters
-        jobs = Job.objects.get_jobs(started=started, ended=ended, status=job_status, job_ids=job_ids,
+        job_status = [job_status] if job_status else job_status
+        jobs = Job.objects.get_jobs(started=started, ended=ended, statuses=job_status, job_ids=job_ids,
                                     job_type_ids=job_type_ids, job_type_names=job_type_names,
                                     job_type_categories=job_type_categories, error_categories=error_categories)
         if not jobs:


### PR DESCRIPTION
Updated all REST views that have a status filter related to jobs. Only exception was the job re-queue API because it is a potentially breaking change due to it being packaged as a JSON POST rather than query string parameters.