### PR TITLE
Issue 321 - Filter Ingest REST API by Strike

### DIFF
--- a/scale/docs/rest/ingest.rst
+++ b/scale/docs/rest/ingest.rst
@@ -38,6 +38,10 @@ These services provide access to information about ingested files processed by t
 | status             | String            | Optional | Return only ingests with a status matching this string.             |
 |                    |                   |          | Choices: [TRANSFERRING, TRANSFERRED, DEFERRED, INGESTING, INGESTED, |
 |                    |                   |          | ERRORED, DUPLICATE].                                                |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| strike_id          | Integer           | Optional | Return only ingests created by a given strike process identifier.   |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | file_name          | String            | Optional | Return only ingests with a specific file name.                      |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -69,15 +69,17 @@ class IngestManager(models.Manager):
 
         return JobType.objects.get(name='scale-ingest', version='1.0')
 
-    def get_ingests(self, started=None, ended=None, status=None, file_name=None, order=None):
+    def get_ingests(self, started=None, ended=None, statuses=None, strike_ids=None, file_name=None, order=None):
         """Returns a list of ingests within the given time range.
 
         :param started: Query ingests updated after this amount of time.
         :type started: :class:`datetime.datetime`
         :param ended: Query ingests updated before this amount of time.
         :type ended: :class:`datetime.datetime`
-        :param status: Query ingests with the a specific process status.
-        :type status: string
+        :param statuses: Query ingests with the a specific process status.
+        :type statuses: [string]
+        :param strike_ids: Query ingests created by a specific strike processor.
+        :type strike_ids: list[string]
         :param file_name: Query ingests with the a specific file name.
         :type file_name: string
         :param order: A list of fields to control the sort order.
@@ -97,8 +99,10 @@ class IngestManager(models.Manager):
         if ended:
             ingests = ingests.filter(last_modified__lte=ended)
 
-        if status:
-            ingests = ingests.filter(status=status)
+        if statuses:
+            ingests = ingests.filter(status__in=statuses)
+        if strike_ids:
+            ingests = ingests.filter(strike_id__in=strike_ids)
         if file_name:
             ingests = ingests.filter(file_name=file_name)
 

--- a/scale/ingest/test/test_views.py
+++ b/scale/ingest/test/test_views.py
@@ -54,6 +54,17 @@ class TestIngestsView(TestCase):
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['status'], self.ingest1.status)
 
+    def test_strike_id(self):
+        """Tests successfully calling the ingests view filtered by strike processor."""
+
+        url = '/ingests/?strike_id=%i' % self.ingest1.strike.id
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['strike']['id'], self.ingest1.strike.id)
+
     def test_file_name(self):
         """Tests successfully calling the ingests view filtered by file name."""
 

--- a/scale/ingest/views.py
+++ b/scale/ingest/views.py
@@ -39,11 +39,12 @@ class IngestsView(ListAPIView):
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
 
-        ingest_status = rest_util.parse_string(request, 'status', required=False)
+        ingest_statuses = rest_util.parse_string_list(request, 'status', required=False)
+        strike_ids = rest_util.parse_int_list(request, 'strike_id', required=False)
         file_name = rest_util.parse_string(request, 'file_name', required=False)
         order = rest_util.parse_string_list(request, 'order', required=False)
 
-        ingests = Ingest.objects.get_ingests(started, ended, ingest_status, file_name, order)
+        ingests = Ingest.objects.get_ingests(started, ended, ingest_statuses, strike_ids, file_name, order)
 
         page = self.paginate_queryset(ingests)
         serializer = self.get_serializer(page, many=True)


### PR DESCRIPTION
Added strike_id filter parameter to ingests view that accepts multiple values.
Updated status filter to accept multiple values.