### PR TITLE
Issue 188 - General algorithm error should not be used on system jobs

### DIFF
--- a/scale/job/configuration/interface/error_interface.py
+++ b/scale/job/configuration/interface/error_interface.py
@@ -68,8 +68,8 @@ class ErrorInterface(object):
         return self.definition
 
     def get_error(self, exit_code=None, default_error_name='algorithm-unknown'):
-        """This method retrieves the error that maps to the given exit code. If the exit code is non-zero (success) None
-        is returned. For a failure exit code with no mapping, a general algorithm error is returned.
+        """This method retrieves the error that maps to the given exit code. If the exit code is zero (success) None is
+        returned. For a failure exit code with no mapping, the given default error is returned.
 
         :param exit_code: The exit code from a task
         :type exit_code: int

--- a/scale/job/configuration/interface/error_interface.py
+++ b/scale/job/configuration/interface/error_interface.py
@@ -1,4 +1,4 @@
-'''Defines the interface for translating a job's exit codes to error types'''
+"""Defines the interface for translating a job's exit codes to error types"""
 from __future__ import unicode_literals
 
 import logging
@@ -32,17 +32,17 @@ ERROR_INTERFACE_SCHEMA = {
 
 
 class ErrorInterface(object):
-    '''Represents the interface for translating a job's exit code to an error type'''
+    """Represents the interface for translating a job's exit code to an error type"""
 
     def __init__(self, definition):
-        '''Creates an error interface from the given definition.
+        """Creates an error interface from the given definition.
 
         If the definition is invalid, a :class:`job.configuration.interface.exceptions.InvalidInterfaceDefinition`
         exception will be thrown.
 
         :param definition: The interface definition
         :type definition: dict
-        '''
+        """
         if definition is None:
             definition = {}
 
@@ -59,23 +59,25 @@ class ErrorInterface(object):
             raise InvalidInterfaceDefinition('%s is an unsupported version number' % self.definition['version'])
 
     def get_dict(self):
-        '''Returns the internal dictionary that represents this error mapping
+        """Returns the internal dictionary that represents this error mapping
 
         :returns: The internal dictionary
         :rtype: dict
-        '''
+        """
 
         return self.definition
 
-    def get_error(self, exit_code=None):
-        '''This method retrieves the error that maps to the given exit code. If the exit code is non-zero (success) None
+    def get_error(self, exit_code=None, default_error_name='algorithm-unknown'):
+        """This method retrieves the error that maps to the given exit code. If the exit code is non-zero (success) None
         is returned. For a failure exit code with no mapping, a general algorithm error is returned.
 
         :param exit_code: The exit code from a task
         :type exit_code: int
+        :param default_error_name: The name of the error to use if no mapping exists for the exit code.
+        :type default_error_name: string
         :returns: The error model mapped to the given exit code, possibly None
         :rtype: :class:`error.models.Error`
-        '''
+        """
 
         error = None
         if exit_code is not None:
@@ -93,17 +95,17 @@ class ErrorInterface(object):
                     error = self._lookup_error(error_name)
 
             if not error:
-                # No exit code match, so return general algorithm error
-                error = Error.objects.get_builtin_error('algorithm-unknown')
+                # No exit code match, so return the given default error
+                error = Error.objects.get_builtin_error(default_error_name)
 
         return error
 
     def get_error_names(self):
-        '''Returns a set of all error names for this interface
+        """Returns a set of all error names for this interface
 
         :returns: Set of error names
-        :rtype: set[string]
-        '''
+        :rtype: {string}
+        """
         if 'exit_codes' not in self.definition:
             return set()
 
@@ -111,13 +113,13 @@ class ErrorInterface(object):
         return {error_name for error_name in codes.itervalues()}
 
     def validate(self):
-        '''Validates the error mappings to ensure that all referenced errors actually exist.
+        """Validates the error mappings to ensure that all referenced errors actually exist.
 
         :returns: A list of warnings discovered during validation.
-        :rtype: list[:class:`job.configuration.data.job_data.ValidationWarning`]
+        :rtype: [:class:`job.configuration.data.job_data.ValidationWarning`]
 
         :raises :class:`job.configuration.interface.exceptions.InvalidInterfaceDefinition`: If there is a missing error.
-        '''
+        """
         error_names = self.get_error_names()
         error_map = {error.name: error for error in Error.objects.filter(name__in=error_names)}
 
@@ -127,13 +129,13 @@ class ErrorInterface(object):
         return []
 
     def _lookup_error(self, name):
-        '''This method looks up error by name
+        """This method looks up error by name
 
         :param name: The name of the error to retrieve
         :type name: string
         :return: The error model with the given name.
         :rtype: :class:`error.models.Error`
-        '''
+        """
         try:
             return Error.objects.get_builtin_error(name)
         except Error.DoesNotExist:
@@ -141,7 +143,7 @@ class ErrorInterface(object):
             return None
 
     def _populate_default_values(self):
-        '''Goes through the definition and fills in any missing default values'''
+        """Goes through the definition and fills in any missing default values"""
         if 'version' not in self.definition:
             self.definition['version'] = '1.0'
         if 'exit_codes' not in self.definition:

--- a/scale/job/execution/running/tasks/job_task.py
+++ b/scale/job/execution/running/tasks/job_task.py
@@ -20,9 +20,10 @@ class JobTask(Task):
 
         super(JobTask, self).__init__('%i_job' % job_exe.id, job_exe)
 
+        self._is_system = job_exe.job.job_type.is_system
         self._uses_docker = job_exe.uses_docker()
         if self._uses_docker:
-            if job_exe.job.job_type.is_system:
+            if self._is_system:
                 self._docker_image = self.create_scale_image_name()
             else:
                 self._docker_image = job_exe.get_docker_image()
@@ -59,7 +60,8 @@ class JobTask(Task):
 
         if not error and self.is_running:
             # If the task successfully started, use job's error mapping here to determine error
-            error = self._error_mapping.get_error(task_results.exit_code)
+            default_error_name = 'unknown' if self._is_system else 'algorithm-unknown'
+            error = self._error_mapping.get_error(task_results.exit_code, default_error_name)
         if not error:
             error = self.consider_general_error(task_results)
 

--- a/scale/job/test/configuration/interface/test_error_interface.py
+++ b/scale/job/test/configuration/interface/test_error_interface.py
@@ -21,7 +21,7 @@ class TestErrorInterfaceValidate(TestCase):
         self.error_3 = error_test_utils.create_error(name='error_3', category='ALGORITHM')
 
     def test_get_error_zero(self):
-        ''' Tests that no error is returned when the exit_code is 0'''
+        """ Tests that no error is returned when the exit_code is 0"""
 
         error_interface_dict = {
             'version': '1.0',
@@ -38,7 +38,7 @@ class TestErrorInterfaceValidate(TestCase):
         self.assertIsNone(error)
 
     def test_get_error_found(self):
-        ''' Tests that an error model is returned given an exit_code other than 0'''
+        """ Tests that an error model is returned given an exit_code other than 0"""
 
         error_interface_dict = {
             'version': '1.0',
@@ -56,7 +56,7 @@ class TestErrorInterfaceValidate(TestCase):
         self.assertEqual(error.name, self.error_1.name)
 
     def test_get_error_missing(self):
-        '''Tests that general algorithm error is returned when a non-registered name is found in the mapping'''
+        """Tests that general algorithm error is returned when a non-registered name is found in the mapping"""
 
         # Clear error cache so test works correctly
         CACHED_BUILTIN_ERRORS.clear()
@@ -76,8 +76,30 @@ class TestErrorInterfaceValidate(TestCase):
         self.assertIsNotNone(error)
         self.assertEqual(error.name, 'algorithm-unknown')
 
+    def test_get_error_missing_default(self):
+        """Tests that custom error is returned when a non-registered name is found in the mapping"""
+
+        # Clear error cache so test works correctly
+        CACHED_BUILTIN_ERRORS.clear()
+
+        error_interface_dict = {
+            'version': '1.0',
+            'exit_codes': {
+                '1': self.error_1.name,
+                '2': self.error_2.name,
+                '3': self.error_3.name,
+            },
+        }
+
+        default_error = error_test_utils.create_error()
+        error_interface = ErrorInterface(error_interface_dict)
+        error = error_interface.get_error(4, default_error.name)
+
+        self.assertIsNotNone(error)
+        self.assertEqual(error.name, default_error.name)
+
     def test_get_error_names(self):
-        '''Tests getting error names from the mapping.'''
+        """Tests getting error names from the mapping."""
 
         error_interface_dict = {
             'version': '1.0',
@@ -93,7 +115,7 @@ class TestErrorInterfaceValidate(TestCase):
         self.assertSetEqual(error_names, {self.error_1.name, self.error_2.name})
 
     def test_get_error_names_none(self):
-        '''Tests getting error names when there is no error interface.'''
+        """Tests getting error names when there is no error interface."""
 
         error_interface_dict = {}
 
@@ -103,7 +125,7 @@ class TestErrorInterfaceValidate(TestCase):
         self.assertSetEqual(error_names, set())
 
     def test_get_error_names_empty(self):
-        '''Tests getting error names when there are no exit codes defined.'''
+        """Tests getting error names when there are no exit codes defined."""
 
         error_interface_dict = {
             'version': '1.0',
@@ -116,7 +138,7 @@ class TestErrorInterfaceValidate(TestCase):
         self.assertSetEqual(error_names, set())
 
     def test_get_error_names_unique(self):
-        '''Tests getting error names without duplicates.'''
+        """Tests getting error names without duplicates."""
 
         error_interface_dict = {
             'version': '1.0',
@@ -133,7 +155,7 @@ class TestErrorInterfaceValidate(TestCase):
         self.assertSetEqual(error_names, {self.error_1.name, self.error_2.name})
 
     def test_validate_empty(self):
-        '''Tests validating no error names.'''
+        """Tests validating no error names."""
 
         error_interface_dict = {
             'version': '1.0',
@@ -147,7 +169,7 @@ class TestErrorInterfaceValidate(TestCase):
         error_interface.validate()
 
     def test_validate_success(self):
-        '''Tests validating all error names.'''
+        """Tests validating all error names."""
 
         error_interface_dict = {
             'version': '1.0',
@@ -164,7 +186,7 @@ class TestErrorInterfaceValidate(TestCase):
         error_interface.validate()
 
     def test_validate_missing(self):
-        '''Tests validating when some error names are missing.'''
+        """Tests validating when some error names are missing."""
 
         error_interface_dict = {
             'version': '1.0',


### PR DESCRIPTION
Changed job task to provide a default 'unknown' error when a system job fails instead of defaulting to 'algorithm-unknown' error for everything.