### PR TITLE
Issue 218 - Job Configuration Documentation

### DIFF
--- a/scale/docs/architecture/jobs/index.rst
+++ b/scale/docs/architecture/jobs/index.rst
@@ -13,5 +13,6 @@ jobs that allow jobs to depend upon one another and for files produced by one jo
    error_interface
    job_interface
    job_data
+   job_configuration
    recipe_definition
    recipe_data

--- a/scale/docs/architecture/jobs/job_configuration.rst
+++ b/scale/docs/architecture/jobs/job_configuration.rst
@@ -1,0 +1,84 @@
+
+.. _architecture_jobs_job_configuration:
+
+Job Configuration
+========================================================================================================================
+
+The job configuration is a JSON document that defines the environment and configuration on which a specific job
+execution will run. This configuration includes information such as Docker parameters required by the job execution's
+container. This JSON schema is used internally by the Scale system and is not exposed through the REST API.
+
+.. _architecture_jobs_job_configuration_spec:
+
+Job Configuration Specification Version 1.0
+------------------------------------------------------------------------------------------------------------------------
+
+A valid job configuration is a JSON document with the following structure:
+ 
+.. code-block:: javascript
+
+   {
+      "version": STRING,
+      "pre_task": {
+         "docker_params": [{"flag": STRING, "value": STRING}],
+         "workspaces": [{"name": STRING, "mode": STRING}]
+      },
+      "job_task": {
+         "docker_params": [{"flag": STRING, "value": STRING}],
+         "workspaces": [{"name": STRING, "mode": STRING}]
+      },
+      "post_task": {
+         "docker_params": [{"flag": STRING, "value": STRING}],
+         "workspaces": [{"name": STRING, "mode": STRING}]
+      }
+   }
+
+**version**: JSON string
+
+    The *version* is an optional string value that defines the version of the configuration specification used. This
+    allows updates to be made to the specification while maintaining backwards compatibility by allowing Scale to
+    recognize an older version and convert it to the current version. The default value for *version* if it is not
+    included is the latest version, which is currently 1.0.
+
+**pre_task**: JSON object
+
+    The *pre_task* is a JSON object that defines the workspaces and Docker parameters to use for the pre task. It has
+    the following fields:
+
+    **docker_params**: JSON array
+
+        The *docker_params* field is a required list of JSON objects that define the parameters to pass to Docker. Each
+        JSON object has the following fields:
+
+        **flag**: JSON string
+
+            The *flag* is a required string describing the command line flag (long form) to use for passing the
+            parameter without the preceding dashes (e.g. use "volume" for passing "--volume=...").
+
+        **value**: JSON string
+
+            The *value* is a required string describing the value to pass to the parameter on the Docker command line.
+
+    **workspaces**: JSON array
+
+        The *workspaces* field is a required list of JSON objects that define the workspaces used by the task. Each JSON
+        object has the following fields:
+
+        **name**: JSON string
+
+            The *name* is a required string defining the unique name of the workspace.
+
+        **mode**: JSON string
+
+            The *mode* is a required string describing in what mode the workspace will be used. There are two valid
+            values: "ro" for read-only mode and "rw" for read-write mode.
+
+**job_task**: JSON object
+
+    The *job_task* is a JSON object that defines the workspaces and Docker parameters to use for the job task (which
+    performs the primary job/algorithm). It is identical in structure to *pre_task*.
+
+**post_task**: JSON object
+
+    The *post_task* is a JSON object that defines the workspaces and Docker parameters to use for the post task. It is
+    identical in structure to *pre_task*.

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1380,8 +1380,6 @@ class JobExecution(models.Model):
         # Configure any Docker parameters needed for workspaces
         configuration.configure_workspace_docker_params(framework_id, self.id, workspaces)
 
-
-
         self.configuration = configuration.get_dict()
 
     def get_docker_image(self):

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1282,6 +1282,7 @@ class JobExecution(models.Model):
     configuration = djorm_pgjson.fields.JSONField()
 
     node = models.ForeignKey('node.Node', blank=True, null=True, on_delete=models.PROTECT)
+    # TODO: Remove this unused field. This will force changes through the REST API though, so coordinate with UI
     environment = djorm_pgjson.fields.JSONField()
     cpus_scheduled = models.FloatField(blank=True, null=True)
     mem_scheduled = models.FloatField(blank=True, null=True)
@@ -1378,6 +1379,8 @@ class JobExecution(models.Model):
 
         # Configure any Docker parameters needed for workspaces
         configuration.configure_workspace_docker_params(framework_id, self.id, workspaces)
+
+
 
         self.configuration = configuration.get_dict()
 


### PR DESCRIPTION
I added documentation on the job configuration schema that was added as part of the Scale Dockerization.

I did not remove the job_environment field on the job_execution model since this would impact the REST API and UI. It can be removed in the future with other job_execution changes.