### PR TITLE
Issue 391 - Mesos.interface errored on import for new development environments

### DIFF
--- a/scale/mesos_api/tasks.py
+++ b/scale/mesos_api/tasks.py
@@ -2,17 +2,11 @@
 from __future__ import unicode_literals
 
 import logging
+from mesos.interface import mesos_pb2
 
 
 logger = logging.getLogger(__name__)
 
-
-try:
-    from mesos.interface import mesos_pb2
-    logger.info('Successfully imported native Mesos bindings')
-except ImportError:
-    logger.info('No native Mesos bindings, falling back to stubs')
-    import mesos_api.mesos_pb2 as mesos_pb2
 
 
 def create_mesos_task(task):

--- a/scale/mesos_api/utils.py
+++ b/scale/mesos_api/utils.py
@@ -3,12 +3,7 @@ import re
 from datetime import datetime, timedelta
 
 from django.utils.timezone import utc
-
-
-try:
-    from mesos.interface import mesos_pb2
-except ImportError:
-    import mesos_api.mesos_pb2 as mesos_pb2
+from mesos.interface import mesos_pb2
 
 
 EPOCH = datetime.utcfromtimestamp(0).replace(tzinfo=utc)

--- a/scale/pip/dev_win.txt
+++ b/scale/pip/dev_win.txt
@@ -8,6 +8,7 @@ django-filter>=0.7,<=0.8
 djangorestframework>=3.3.0,<3.4.0
 djorm-ext-pgjson>=0.2,<0.3
 jsonschema>=2.3,<2.4
+mesos.interface>=0.21.1,<=0.25
 pytz
 
 # These libraries contain native code and must be manually installed into your Python environment

--- a/scale/scheduler/management/commands/scale_scheduler.py
+++ b/scale/scheduler/management/commands/scale_scheduler.py
@@ -8,25 +8,14 @@ from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from mesos.interface import mesos_pb2
+from pesos.scheduler import PesosSchedulerDriver as MesosSchedulerDriver
 
 from scheduler.scale_scheduler import ScaleScheduler
 
 logger = logging.getLogger(__name__)
 
-# Try to import production Mesos bindings, fall back to stubs
-try:
-    from mesos.interface import mesos_pb2
-    from pesos.scheduler import PesosSchedulerDriver as MesosSchedulerDriver
-    logger.info('Successfully imported pesos bindings')
-except ImportError:
-    try:
-       from mesos.interface import mesos_pb2
-       from mesos.native import MesosSchedulerDriver
-       logger.info('Successfully imported native Mesos bindings')
-    except ImportError:
-       logger.info('No native Mesos bindings, falling back to stubs')
-       import mesos_api.mesos_pb2 as mesos_pb2
-       from mesos_api.mesos import MesosSchedulerDriver
+
 
 #TODO: make these command options
 MESOS_CHECKPOINT = False

--- a/scale/scheduler/management/commands/scale_scheduler.py
+++ b/scale/scheduler/management/commands/scale_scheduler.py
@@ -9,7 +9,7 @@ from optparse import make_option
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from mesos.interface import mesos_pb2
-from pesos.scheduler import PesosSchedulerDriver as MesosSchedulerDriver
+from mesos.native import MesosSchedulerDriver
 
 from scheduler.scale_scheduler import ScaleScheduler
 

--- a/scale/scheduler/scale_scheduler.py
+++ b/scale/scheduler/scale_scheduler.py
@@ -7,6 +7,8 @@ import threading
 
 from django.db import DatabaseError
 from django.utils.timezone import now
+from mesos.interface import Scheduler as MesosScheduler
+from mesos.interface import mesos_pb2
 
 from error.models import Error
 from job.execution.running.job_exe import RunningJobExecution
@@ -32,15 +34,6 @@ from scheduler.threads.schedule import SchedulingThread
 
 logger = logging.getLogger(__name__)
 
-
-try:
-    from mesos.interface import Scheduler as MesosScheduler
-    from mesos.interface import mesos_pb2
-    logger.info('Successfully imported native Mesos bindings')
-except ImportError:
-    logger.info('No native Mesos bindings, falling back to stubs')
-    from mesos_api.mesos import Scheduler as MesosScheduler
-    import mesos_api.mesos_pb2 as mesos_pb2
 
 
 class ScaleScheduler(MesosScheduler):

--- a/scale/scheduler/threads/db_sync.py
+++ b/scale/scheduler/threads/db_sync.py
@@ -7,19 +7,13 @@ import time
 
 from django.db import DatabaseError
 from django.utils.timezone import now
+from mesos.interface import mesos_pb2
 
 from job.models import JobExecution
 
 
 logger = logging.getLogger(__name__)
 
-
-try:
-    from mesos.interface import mesos_pb2
-    logger.info('Successfully imported native Mesos bindings')
-except ImportError:
-    logger.info('No native Mesos bindings, falling back to stubs')
-    import mesos_api.mesos_pb2 as mesos_pb2
 
 
 class DatabaseSyncThread(object):

--- a/scale/scheduler/threads/recon.py
+++ b/scale/scheduler/threads/recon.py
@@ -7,17 +7,11 @@ import threading
 import time
 
 from django.utils.timezone import now
+from mesos.interface import mesos_pb2
 
 
 logger = logging.getLogger(__name__)
 
-
-try:
-    from mesos.interface import mesos_pb2
-    logger.info('Successfully imported native Mesos bindings')
-except ImportError:
-    logger.info('No native Mesos bindings, falling back to stubs')
-    import mesos_api.mesos_pb2 as mesos_pb2
 
 
 class ReconciliationThread(object):

--- a/scale/scheduler/threads/schedule.py
+++ b/scale/scheduler/threads/schedule.py
@@ -7,6 +7,7 @@ import time
 
 from django.db import OperationalError
 from django.utils.timezone import now
+from mesos.interface import mesos_pb2
 
 from mesos_api.tasks import create_mesos_task
 from queue.job_exe import QueuedJobExecution
@@ -17,13 +18,6 @@ from util.retry import retry_database_query
 
 logger = logging.getLogger(__name__)
 
-
-try:
-    from mesos.interface import mesos_pb2
-    logger.info('Successfully imported native Mesos bindings')
-except ImportError:
-    logger.info('No native Mesos bindings, falling back to stubs')
-    import mesos_api.mesos_pb2 as mesos_pb2
 
 
 class SchedulingThread(object):


### PR DESCRIPTION
Added mesos.interface to the list of requirements in dev_win.txt

Moved the mesos.interface imports out of the try/catch block in all occurrences, no longer falling back on stubs