### PR TITLE
Issue 419 - Docker Image Version Tag

### DIFF
--- a/scale/job/execution/running/tasks/base_task.py
+++ b/scale/job/execution/running/tasks/base_task.py
@@ -195,8 +195,7 @@ class Task(object):
         :rtype: string
         """
 
-        # Docker tags do not support the + character, so we replace it with _
-        return '%s:%s' % (settings.SCALE_DOCKER_IMAGE, settings.VERSION.replace("+", "_"))
+        return '%s:%s' % (settings.SCALE_DOCKER_IMAGE, settings.DOCKER_VERSION)
 
     @abstractmethod
     def get_resources(self):

--- a/scale/scale/__init__.py
+++ b/scale/scale/__init__.py
@@ -13,6 +13,10 @@ VERSION = version_info_t(3, 1, 0, '-snapshot')
 
 __version__ = '{0.major}.{0.minor}.{0.patch}{0.qualifier}'.format(VERSION)
 
+# The Scale version is tagged on the Scale Docker image
+# Docker tags cannot support + chars, so replace it with an underscore
+__docker_version__ = __version__.replace('+', '_')
+
 __author__ = 'NGA'
 __contact__ = ''
 __homepage__ = 'https://ngageoint.github.io/scale'

--- a/scale/scale/__init__.py.template
+++ b/scale/scale/__init__.py.template
@@ -13,6 +13,10 @@ VERSION = version_info_t(3, 1, 0, '-snapshot___BUILDNUM___')
 
 __version__ = '{0.major}.{0.minor}.{0.patch}{0.qualifier}'.format(VERSION)
 
+# The Scale version is tagged on the Scale Docker image
+# Docker tags cannot support + chars, so replace it with an underscore
+__docker_version__ = __version__.replace('+', '_')
+
 __author__ = 'NGA'
 __contact__ = ''
 __homepage__ = 'https://ngageoint.github.io/scale'

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -17,6 +17,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 # Project version
 VERSION = scale.__version__
+DOCKER_VERSION = scale.__docker_version__
 
 # Mesos connection information. Default for -m
 # This can be something like "127.0.0.1:5050"


### PR DESCRIPTION
I created a new Django setting to contain the version tag used to tag the Scale Docker image. This centralizes the logic for replacing the '+' with an '_'.