### PR TITLE
Log Viewer Fix

### DIFF
--- a/scale-ui/app/modules/jobs/controllers/jobDetailController.js
+++ b/scale-ui/app/modules/jobs/controllers/jobDetailController.js
@@ -26,7 +26,7 @@
                 animation: true,
                 templateUrl: 'showLog.html',
                 scope: $scope,
-                windowClass: 'log-modal-window'
+                size: 'lg'
             });
         };
 

--- a/scale-ui/app/modules/jobs/controllers/jobsController.js
+++ b/scale-ui/app/modules/jobs/controllers/jobsController.js
@@ -138,8 +138,7 @@
                     animation: true,
                     templateUrl: 'showLog.html',
                     scope: $scope,
-                    size: 'lg',
-                    windowClass: 'log-modal-window'
+                    size: 'lg'
                 });
             });
         };

--- a/scale-ui/app/modules/jobs/directives/jobExecutionLogDirective.js
+++ b/scale-ui/app/modules/jobs/directives/jobExecutionLogDirective.js
@@ -10,6 +10,8 @@
 
             $scope.$watch('execution', function () {
                 if ($scope.execution) {
+                    vm.status = $scope.execution.status.toLowerCase();
+                    console.log($scope.execution);
                     jobExecutionService.getLog($scope.execution.id).then(null, null, function (result) {
                         // get difference of max scroll length and current scroll length.var  = result.data;
                         if (result) {

--- a/scale-ui/app/modules/jobs/directives/jobExecutionLogTemplate.html
+++ b/scale-ui/app/modules/jobs/directives/jobExecutionLogTemplate.html
@@ -1,15 +1,25 @@
 <div ng-show="vm.jobLogError" class="alert alert-danger text-center"><strong>{{ vm.jobLogError }}</strong> {{ vm.jobLogErrorStatus }}</div>
 <div ng-show="!vm.jobLogError">
     <div class="row">
-        <div class="col-xs-12 col-md-6 col-md-offset-3">
-            <div class="panel panel-error" ng-show="vm.execLog.status === 'FAILED'">
+        <div class="col-xs-12 col-md-6 ">
+            <div ng-show="execution.status !== 'FAILED'">
                 <div class="panel-heading">
                     <div class="panel-title">
-                        <strong>{{ vm.execLog.error.category }} Error: {{ vm.execLog.error.title }}</strong>
+                        <span class="label {{ execution.status.toLowerCase() }}">{{ execution.status }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-xs-12 col-md-6 col-md-offset-3">
+            <div class="panel panel-error" ng-show="execution.status === 'FAILED'">
+                <div class="panel-heading">
+                    <div class="panel-title">
+                        <strong>{{ execution.error.category }} Error: {{ execution.error.title }}</strong>
                     </div>
                 </div>
                 <div class="panel-body">
-                    {{ vm.execLog.error.description }}
+                    {{ execution.error.description }}
                 </div>
             </div>
         </div>

--- a/scale-ui/app/modules/jobs/directives/jobExecutionLogTemplate.html
+++ b/scale-ui/app/modules/jobs/directives/jobExecutionLogTemplate.html
@@ -1,17 +1,10 @@
 <div ng-show="vm.jobLogError" class="alert alert-danger text-center"><strong>{{ vm.jobLogError }}</strong> {{ vm.jobLogErrorStatus }}</div>
 <div ng-show="!vm.jobLogError">
     <div class="row">
-        <div class="col-xs-12 col-md-6 ">
-            <div ng-show="execution.status !== 'FAILED'">
-                <div class="panel-heading">
-                    <div class="panel-title">
-                        <span class="label {{ execution.status.toLowerCase() }}">{{ execution.status }}</span>
-                    </div>
-                </div>
-            </div>
+        <div class="col-xs-12 margin-bottom-md" ng-show="execution.status !== 'FAILED'">
+            <span class="label {{ execution.status.toLowerCase() }}">{{ execution.status }}</span>
         </div>
-
-        <div class="col-xs-12 col-md-6 col-md-offset-3">
+        <div class="col-xs-12">
             <div class="panel panel-error" ng-show="execution.status === 'FAILED'">
                 <div class="panel-heading">
                     <div class="panel-title">

--- a/scale-ui/app/test/data/job-details/jobDetails10.json
+++ b/scale-ui/app/test/data/job-details/jobDetails10.json
@@ -66,7 +66,7 @@
         "occurred": "2016-05-15T17:27:31.467Z"
     },
     "error": null,
-    "status": "COMPLETED",
+    "status": "FAILED",
     "priority": 210,
     "num_exes": 1,
     "timeout": 1800,
@@ -130,7 +130,7 @@
     "job_exes": [
         {
             "id": 14552,
-            "status": "COMPLETED",
+            "status": "FAILED",
             "command_arguments": "${input_file} ${job_output_dir}",
             "timeout": 1800,
             "pre_started": "2016-05-15T17:27:32.435Z",
@@ -153,7 +153,16 @@
             "node": {
                 "id": 1
             },
-            "error": null
+            "error": {
+                "id": 1,
+                "name": "unknown",
+                "title": "Unknown",
+                "description": "The error that caused the failure is unknown.",
+                "category": "SYSTEM",
+                "is_builtin": true,
+                "created": "2015-03-11T00:00:00Z",
+                "last_modified": "2015-03-11T00:00:00Z"
+            }
         }
     ],
     "inputs": [

--- a/scale-ui/app/test/data/jobs.json
+++ b/scale-ui/app/test/data/jobs.json
@@ -427,7 +427,7 @@
                 "occurred": "2016-05-06T21:16:09Z"
             },
             "error": null,
-            "status": "BLOCKED",
+            "status": "FAILED",
             "priority": 80,
             "num_exes": 43,
             "timeout": 2361,


### PR DESCRIPTION
This is a fix to display execution error details in the log viewer header.

Updated execution log viewer to use Execution details that have already been loaded. These details used to come from log service, but not since the changes were made to support elasticSearch logging. The data is already on $scope so no additional data loads were necessary.