### PR TITLE
Can now edit 'is_paused' field for a system job

### DIFF
--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1715,7 +1715,7 @@ class JobTypeManager(models.Manager):
         job_type = JobType.objects.select_for_update().get(pk=job_type_id)
         if job_type.is_system:
             if len(kwargs) > 1 or 'is_paused' not in kwargs:
-                raise Exception('You can only modify the is_paused field for a System Job')
+                raise InvalidJobField('You can only modify the is_paused field for a System Job')
 
         if interface:
             # New job interface, validate all existing recipes

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1714,7 +1714,8 @@ class JobTypeManager(models.Manager):
         # Acquire model lock for job type
         job_type = JobType.objects.select_for_update().get(pk=job_type_id)
         if job_type.is_system:
-            raise Exception('Cannot edit a system job type')
+            if len(kwargs) > 1 or 'is_paused' not in kwargs:
+                raise Exception('You can only modify the is_paused field for a System Job')
 
         if interface:
             # New job interface, validate all existing recipes

--- a/scale/job/test/test_models.py
+++ b/scale/job/test/test_models.py
@@ -996,21 +996,19 @@ class TestJobTypeManagerEditJobType(TransactionTestCase):
 
         name = 'my-job-type'
         version = '1.0'
-        is_paused = False
-        new_is_paused = True
         trigger_rule = trigger_test_utils.create_trigger_rule(trigger_type=job_test_utils.MOCK_TYPE,
                                                               configuration=self.trigger_config.get_dict())
-        job_type = JobType.objects.create_job_type(name, version, self.job_interface, trigger_rule, is_paused=is_paused)
+        job_type = JobType.objects.create_job_type(name, version, self.job_interface, trigger_rule, is_paused=False)
         job_type.is_system = True
         job_type.save()
 
         # Call test
-        JobType.objects.edit_job_type(job_type.id, is_paused=new_is_paused)
+        JobType.objects.edit_job_type(job_type.id, is_paused=True)
 
         # Check results
         job_type = JobType.objects.select_related('trigger_rule').get(pk=job_type.id)
         # No change
-        self.assertEqual(job_type.is_paused, new_is_paused)
+        self.assertEqual(job_type.is_paused, True)
 
     def test_uneditable_field(self):
         """Tests calling JobTypeManager.edit_job_type() to change an uneditable field"""

--- a/scale/job/test/test_models.py
+++ b/scale/job/test/test_models.py
@@ -991,6 +991,27 @@ class TestJobTypeManagerEditJobType(TransactionTestCase):
         # No change
         self.assertEqual(job_type.title, title)
 
+    def test_pause_system_job_type(self):
+        """Tests calling JobTypeManager.edit_job_type() and pausing a system job type"""
+
+        name = 'my-job-type'
+        version = '1.0'
+        is_paused = False
+        new_is_paused = True
+        trigger_rule = trigger_test_utils.create_trigger_rule(trigger_type=job_test_utils.MOCK_TYPE,
+                                                              configuration=self.trigger_config.get_dict())
+        job_type = JobType.objects.create_job_type(name, version, self.job_interface, trigger_rule, is_paused=is_paused)
+        job_type.is_system = True
+        job_type.save()
+
+        # Call test
+        JobType.objects.edit_job_type(job_type.id, is_paused=new_is_paused)
+
+        # Check results
+        job_type = JobType.objects.select_related('trigger_rule').get(pk=job_type.id)
+        # No change
+        self.assertEqual(job_type.is_paused, new_is_paused)
+
     def test_uneditable_field(self):
         """Tests calling JobTypeManager.edit_job_type() to change an uneditable field"""
 

--- a/scale/job/test/test_models.py
+++ b/scale/job/test/test_models.py
@@ -988,7 +988,7 @@ class TestJobTypeManagerEditJobType(TransactionTestCase):
 
         # Check results
         job_type = JobType.objects.select_related('trigger_rule').get(pk=job_type.id)
-        # No change
+        # No Change
         self.assertEqual(job_type.title, title)
 
     def test_pause_system_job_type(self):
@@ -1007,7 +1007,6 @@ class TestJobTypeManagerEditJobType(TransactionTestCase):
 
         # Check results
         job_type = JobType.objects.select_related('trigger_rule').get(pk=job_type.id)
-        # No change
         self.assertEqual(job_type.is_paused, True)
 
     def test_uneditable_field(self):

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -1063,6 +1063,43 @@ class TestJobTypeDetailsView(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_edit_system_job_pause(self):
+        """Tests pausing a system job"""
+        trigger_config = self.trigger_config.copy()
+        trigger_config['condition']['media_type'] = 'application/json'
+
+        url = '/job-types/%d/' % self.job_type.id
+        json_data = {
+            'is_paused': True
+        }
+        self.job_type.is_system = True
+        self.job_type.save()
+        response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(result['id'], self.job_type.id)
+        self.assertEqual(result['title'], self.job_type.title)
+        self.assertEqual(result['revision_num'], 1)
+        self.assertIsNotNone(result['interface'])
+        self.assertEqual(result['is_paused'], True)
+
+    def test_edit_system_job_invalid_field(self):
+        """Tests updating an invalid system job field"""
+        trigger_config = self.trigger_config.copy()
+        trigger_config['condition']['media_type'] = 'application/json'
+
+        url = '/job-types/%d/' % self.job_type.id
+        json_data = {
+            'title': 'Invalid title change'
+        }
+        self.job_type.is_system = True
+        self.job_type.save()
+        response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class TestJobTypesValidationView(TransactionTestCase):
     """Tests related to the job-types validation endpoint"""

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -1065,8 +1065,6 @@ class TestJobTypeDetailsView(TestCase):
 
     def test_edit_system_job_pause(self):
         """Tests pausing a system job"""
-        trigger_config = self.trigger_config.copy()
-        trigger_config['condition']['media_type'] = 'application/json'
 
         url = '/job-types/%d/' % self.job_type.id
         json_data = {
@@ -1086,9 +1084,6 @@ class TestJobTypeDetailsView(TestCase):
 
     def test_edit_system_job_invalid_field(self):
         """Tests updating an invalid system job field"""
-        trigger_config = self.trigger_config.copy()
-        trigger_config['condition']['media_type'] = 'application/json'
-
         url = '/job-types/%d/' % self.job_type.id
         json_data = {
             'title': 'Invalid title change'
@@ -1096,7 +1091,6 @@ class TestJobTypeDetailsView(TestCase):
         self.job_type.is_system = True
         self.job_type.save()
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
-        result = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
Modified the IF statement that was throwing an exception if a system job was attempted to be modified. Now instead of always throwing an exception for an attempted edit on a system job, an exception is only thrown if a field other than 'is_paused' is attempted to be edited.

Also added a unit test to verify this