### PR TITLE
Overview margin fix

### DIFF
--- a/scale-ui/app/modules/overview/partials/ovTemplate.html
+++ b/scale-ui/app/modules/overview/partials/ovTemplate.html
@@ -1,6 +1,6 @@
 <ais-header name="'System Overview'"></ais-header>
 
-<div class="row ov-margin-fix">
+<div class="row">
     <div id="ov-status" class="col-xs-12 col-md-6">
         <h2>Status</h2>
         <div ng-show="vm.loadingStatus" class="loading-component">

--- a/scale-ui/app/styles/pages/overview.less
+++ b/scale-ui/app/styles/pages/overview.less
@@ -36,10 +36,6 @@ h2 {
     }
 }
 
-.ov-margin-fix {
-    margin-bottom: 110px; /* this is necessary because of the health directives used inside this div */
-}
-
 .ov-jobs {
     .grid-chart-container {
         max-height: 320px;
@@ -50,18 +46,9 @@ h2 {
 }
 
 @media screen and (max-width:992px) {
-  .ov-margin-fix {
-    margin-bottom: 200px;
-  }
   .grid-chart {
     svg {
       width:100%;
     }
-  }
-}
-
-@media screen and (max-width:768px) {
-  .ov-margin-fix {
-    margin-bottom: 250px;
   }
 }


### PR DESCRIPTION
Removed a legacy css class that was causing a gap to appear on the overview page.