### PR TITLE
Issue 456 - Bug with CONFIG_URI set to None

### DIFF
--- a/scale/mesos_api/tasks.py
+++ b/scale/mesos_api/tasks.py
@@ -103,7 +103,9 @@ def _create_docker_task(task):
     arguments = task.command_arguments.split(" ")
     for argument in arguments:
         mesos_task.command.arguments.append(argument)
-    mesos_task.command.uris.add().value = settings.CONFIG_URI
+
+    if settings.CONFIG_URI:
+        mesos_task.command.uris.add().value = settings.CONFIG_URI
 
     mesos_task.container.docker.network = mesos_pb2.ContainerInfo.DockerInfo.Network.Value('BRIDGE')
     mesos_task.container.docker.force_pull_image = True


### PR DESCRIPTION
This is a bug fix that checks that the settings.CONFIG_URI is set from the environment variable before setting it to the Mesos task uris field.