### PR TITLE
Issue 457 - Add API to reprocess a recipe

### DIFF
--- a/scale/docs/rest/recipe.rst
+++ b/scale/docs/rest/recipe.rst
@@ -417,10 +417,26 @@ These services provide access to information about recipes.
 | **Reprocess Recipe**                                                                                                    |
 +=========================================================================================================================+
 | Creates a new recipe using its latest type revision by superseding an existing recipe and associated jobs.              |
+| Note that if the recipe type definition has not changed since the recipe was created, then one or more job names must be|
+| specified to force the recipe to be reprocessed.                                                                        |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **POST** /recipes/{id}/reprocess/                                                                                       |
 |          Where {id} is the unique identifier of an existing model.                                                      |
-+-------------------------------------------------------------------------------------------------------------------------+
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Content Type**   | *application/json*                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                         |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_name           | String            | Optional | The name of a job within the recipe definition that should be       |
+|                    |                   |          | included in the reprocessing request, even when the definition for  |
+|                    |                   |          | the job has not changed between recipe type revisions.              |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| all_jobs           | Boolean           | Optional | A flag that indicates all jobs in the recipe should be reprocessed, |
+|                    |                   |          | even when the recipe type definitions are identical. This option    |
+|                    |                   |          | overrides any job_name parameters and is typically used to re-run   |
+|                    |                   |          | jobs that failed due to temporary errors.                           |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **Status**         | 201 CREATED                                                                                        |

--- a/scale/docs/rest/recipe.rst
+++ b/scale/docs/rest/recipe.rst
@@ -427,16 +427,21 @@ These services provide access to information about recipes.
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **JSON Fields**                                                                                                         |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
-| job_name           | String            | Optional | The name of a job within the recipe definition that should be       |
+| job_names          | Array[String]     | Optional | The name of jobs within the recipe definition that should be        |
 |                    |                   |          | included in the reprocessing request, even when the definition for  |
-|                    |                   |          | the job has not changed between recipe type revisions.              |
-|                    |                   |          | Duplicate it to filter by multiple values.                          |
+|                    |                   |          | those jobs has not changed between recipe type revisions.           |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | all_jobs           | Boolean           | Optional | A flag that indicates all jobs in the recipe should be reprocessed, |
 |                    |                   |          | even when the recipe type definitions are identical. This option    |
 |                    |                   |          | overrides any job_name parameters and is typically used to re-run   |
 |                    |                   |          | jobs that failed due to temporary errors.                           |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
+| .. code-block:: javascript                                                                                              |
+|                                                                                                                         |
+|    {                                                                                                                    |
+|        "all_jobs": true                                                                                                 |
+|    }                                                                                                                    |
++-------------------------------------------------------------------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **Status**         | 201 CREATED                                                                                        |

--- a/scale/docs/rest/recipe.rst
+++ b/scale/docs/rest/recipe.rst
@@ -409,3 +409,238 @@ These services provide access to information about recipes.
 |        ]                                                                                                                |
 |    }                                                                                                                    |
 +-------------------------------------------------------------------------------------------------------------------------+
+
+
+.. _rest_recipe_reprocess:
+
++-------------------------------------------------------------------------------------------------------------------------+
+| **Reprocess Recipe**                                                                                                    |
++=========================================================================================================================+
+| Creates a new recipe using its latest type revision by superseding an existing recipe and associated jobs.              |
++-------------------------------------------------------------------------------------------------------------------------+
+| **POST** /recipes/{id}/reprocess/                                                                                       |
+|          Where {id} is the unique identifier of an existing model.                                                      |
++-------------------------------------------------------------------------------------------------------------------------+
+| **Successful Response**                                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Status**         | 201 CREATED                                                                                        |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Content Type**   | *application/json*                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+|                    | JSON Object       | All fields are the same as the recipe details model.                           |
+|                    |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                              |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .. code-block:: javascript                                                                                              |
+|                                                                                                                         |
+|    {                                                                                                                    |
+|        "id": 72,                                                                                                        |
+|        "recipe_type": {                                                                                                 |
+|            "id": 1,                                                                                                     |
+|            "name": "MyRecipe",                                                                                          |
+|            "version": "1.0.0",                                                                                          |
+|            "description": "This is a description of the recipe",                                                        |
+|            "is_active": true,                                                                                           |
+|            "definition": {                                                                                              |
+|                "input_data": [                                                                                          |
+|                    {                                                                                                    |
+|                        "media_types": [                                                                                 |
+|                            "image/png"                                                                                  |
+|                        ],                                                                                               |
+|                        "type": "file",                                                                                  |
+|                        "name": "input_file"                                                                             |
+|                    }                                                                                                    |
+|                ],                                                                                                       |
+|                "version": "1.0",                                                                                        |
+|                "jobs": [                                                                                                |
+|                    {                                                                                                    |
+|                        "recipe_inputs": [                                                                               |
+|                            {                                                                                            |
+|                                "job_input": "input_file",                                                               |
+|                                "recipe_input": "input_file"                                                             |
+|                            }                                                                                            |
+|                        ],                                                                                               |
+|                        "name": "kml",                                                                                   |
+|                        "job_type": {                                                                                    |
+|                            "name": "kml-footprint",                                                                     |
+|                            "version": "1.2.3"                                                                           |
+|                        }                                                                                                |
+|                    }                                                                                                    |
+|                ]                                                                                                        |
+|            },                                                                                                           |
+|            "created": "2015-06-15T19:03:26.346Z",                                                                       |
+|            "last_modified": "2015-06-15T19:03:26.346Z",                                                                 |
+|            "archived": null                                                                                             |
+|        },                                                                                                               |
+|        "recipe_type_rev": {                                                                                             |
+|            "id": 5,                                                                                                     |
+|            "recipe_type": {                                                                                             |
+|                "id": 1                                                                                                  |
+|            },                                                                                                           |
+|            "revision_num": 3,                                                                                           |
+|            "definition": {                                                                                              |
+|                "input_data": [                                                                                          |
+|                    {                                                                                                    |
+|                        "media_types": [                                                                                 |
+|                            "image/png"                                                                                  |
+|                        ],                                                                                               |
+|                        "type": "file",                                                                                  |
+|                        "name": "input_file"                                                                             |
+|                    }                                                                                                    |
+|                ],                                                                                                       |
+|                "version": "1.0",                                                                                        |
+|                "jobs": [                                                                                                |
+|                    {                                                                                                    |
+|                        "recipe_inputs": [                                                                               |
+|                            {                                                                                            |
+|                                "job_input": "input_file",                                                               |
+|                                "recipe_input": "input_file"                                                             |
+|                            }                                                                                            |
+|                        ],                                                                                               |
+|                        "name": "kml",                                                                                   |
+|                        "job_type": {                                                                                    |
+|                            "name": "kml-footprint",                                                                     |
+|                            "version": "1.2.3"                                                                           |
+|                        }                                                                                                |
+|                    }                                                                                                    |
+|                ]                                                                                                        |
+|            },                                                                                                           |
+|            "created": "2015-11-06T19:44:09.989Z"                                                                        |
+|        },                                                                                                               |
+|        "event": {                                                                                                       |
+|            "id": 7,                                                                                                     |
+|            "type": "PARSE",                                                                                             |
+|            "rule": {                                                                                                    |
+|                "id": 8,                                                                                                 |
+|                "type": "PARSE",                                                                                         |
+|                "name": "parse-png",                                                                                     |
+|                "is_active": true,                                                                                       |
+|                "configuration": {                                                                                       |
+|                    "version": "1.0",                                                                                    |
+|                    "data": {                                                                                            |
+|                        "workspace_name": "products",                                                                    |
+|                        "input_data_name": "input_file"                                                                  |
+|                    },                                                                                                   |
+|                    "condition": {                                                                                       |
+|                        "media_type": "image/png",                                                                       |
+|                        "data_types": []                                                                                 |
+|                    }                                                                                                    |
+|                }                                                                                                        |
+|            },                                                                                                           |
+|            "occurred": "2015-08-28T19:03:59.054Z",                                                                      |
+|            "description": {                                                                                             |
+|                "file_name": "data-file.png",                                                                            |
+|                "version": "1.0",                                                                                        |
+|                "parse_id": 1                                                                                            |
+|            }                                                                                                            |
+|        },                                                                                                               |
+|        "is_superseded": false,                                                                                          |
+|        "root_superseded_recipe": {...},                                                                                 |
+|        "superseded_recipe": {...},                                                                                      |
+|        "superseded_by_recipe": null,                                                                                    |
+|        "created": "2015-06-15T19:03:26.346Z",                                                                           |
+|        "completed": "2015-06-15T19:05:26.346Z",                                                                         |
+|        "superseded": null,                                                                                              |
+|        "last_modified": "2015-06-15T19:05:26.346Z"                                                                      |
+|        "data": {                                                                                                        |
+|            "input_data": [                                                                                              |
+|                {                                                                                                        |
+|                    "name": "input_file",                                                                                |
+|                    "file_id": 4,                                                                                        |
+|                }                                                                                                        |
+|            ],                                                                                                           |
+|            "version": "1.0"                                                                                             |
+|            "workspace_id": 2                                                                                            |
+|        }                                                                                                                |
+|        "input_files": [                                                                                                 |
+|            {                                                                                                            |
+|                "id": 4,                                                                                                 |
+|                "workspace": {                                                                                           |
+|                    "id": 1,                                                                                             |
+|                    "name": "Raw Source"                                                                                 |
+|                },                                                                                                       |
+|                "file_name": "input_file.txt",                                                                           |
+|                "media_type": "text/plain",                                                                              |
+|                "file_size": 1234,                                                                                       |
+|                "data_type": [],                                                                                         |
+|                "is_deleted": false,                                                                                     |
+|                "uuid": "c8928d9183fc99122948e7840ec9a0fd",                                                              |
+|                "url": "http://host.com/input_file.txt",                                                                 |
+|                "created": "2015-09-10T15:24:53.962Z",                                                                   |
+|                "deleted": null,                                                                                         |
+|                "data_started": "2015-09-10T14:50:49Z",                                                                  |
+|                "data_ended": "2015-09-10T14:51:05Z",                                                                    |
+|                "geometry": null,                                                                                        |
+|                "center_point": null,                                                                                    |
+|                "meta_data": {...}                                                                                       |
+|                "last_modified": "2015-09-10T15:25:02.808Z"                                                              |
+|            }                                                                                                            |
+|        ],                                                                                                               |
+|        "jobs": [                                                                                                        |
+|            {                                                                                                            |
+|                "job_name": "kml",                                                                                       |
+|                "is_original": true,                                                                                     |
+|                "job": {                                                                                                 |
+|                    "id": 7,                                                                                             |
+|                    "job_type": {                                                                                        |
+|                        "id": 8,                                                                                         |
+|                        "name": "kml-footprint",                                                                         |
+|                        "version": "1.2.3",                                                                              |
+|                        "title": "KML Footprint",                                                                        |
+|                        "description": "Creates a KML footprint",                                                        |
+|                        "category": "footprint",                                                                         |
+|                        "author_name": null,                                                                             |
+|                        "author_url": null,                                                                              |
+|                        "is_system": false,                                                                              |
+|                        "is_long_running": false,                                                                        |
+|                        "is_active": true,                                                                               |
+|                        "is_operational": true,                                                                          |
+|                        "is_paused": false,                                                                              |
+|                        "icon_code": "f0ac"                                                                              |
+|                    },                                                                                                   |
+|                    "job_type_rev": {                                                                                    |
+|                        "id": 5,                                                                                         |
+|                        "job_type": {                                                                                    |
+|                            "id": 8                                                                                      |
+|                        },                                                                                               |
+|                        "revision_num": 1,                                                                               |
+|                        "interface": {...},                                                                              |
+|                        "created": "2015-11-06T21:30:34.622Z"                                                            |
+|                    },                                                                                                   |
+|                    "event": {                                                                                           |
+|                        "id": 7,                                                                                         |
+|                        "type": "PARSE",                                                                                 |
+|                        "rule": {                                                                                        |
+|                            "id": 8                                                                                      |
+|                        },                                                                                               |
+|                        "occurred": "2015-08-28T19:03:59.054Z"                                                           |
+|                    },                                                                                                   |
+|                    "error": null,                                                                                       |
+|                    "status": "COMPLETED",                                                                               |
+|                    "priority": 210,                                                                                     |
+|                    "num_exes": 1,                                                                                       |
+|                    "timeout": 1800,                                                                                     |
+|                    "max_tries": 3,                                                                                      |
+|                    "cpus_required": 1.0,                                                                                |
+|                    "mem_required": 15360.0,                                                                             |
+|                    "disk_in_required": 2.0,                                                                             |
+|                    "disk_out_required": 16.0,                                                                           |
+|                    "is_superseded": false,                                                                              |
+|                    "root_superseded_job": null,                                                                         |
+|                    "superseded_job": null,                                                                              |
+|                    "superseded_by_job": null,                                                                           |
+|                    "delete_superseded": true,                                                                           |
+|                    "created": "2015-08-28T17:55:41.005Z",                                                               |
+|                    "queued": "2015-08-28T17:56:41.005Z",                                                                |
+|                    "started": "2015-08-28T17:57:41.005Z",                                                               |
+|                    "ended": "2015-08-28T17:58:41.005Z",                                                                 |
+|                    "last_status_change": "2015-08-28T17:58:45.906Z",                                                    |
+|                    "superseded": null,                                                                                  |
+|                    "last_modified": "2015-08-28T17:58:46.001Z"                                                          |
+|                }                                                                                                        |
+|            },                                                                                                           |
+|            ...                                                                                                          |
+|        ]                                                                                                                |
+|    }                                                                                                                    |
++-------------------------------------------------------------------------------------------------------------------------+

--- a/scale/recipe/exceptions.py
+++ b/scale/recipe/exceptions.py
@@ -1,0 +1,16 @@
+"""Defines exceptions that can occur when interacting with recipes and recipe types"""
+
+
+class CreateRecipeError(Exception):
+    """Exception indicating that a recipe cannot be created"""
+    pass
+
+
+class ReprocessError(Exception):
+    """Exception indicating that a reprocessing request cannot be completed"""
+    pass
+
+
+class SupersedeError(Exception):
+    """Exception indicating that a recipe cannot be superseded"""
+    pass

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -811,7 +811,7 @@ class TestRecipesView(TransactionTestCase):
 
         url = '/recipes/%i/reprocess/' % self.recipe1.id
         json_data = {
-            'job_name': 'kml',
+            'job_names': ['kml'],
         }
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         results = json.loads(response.content)

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -11,7 +11,7 @@ import storage.test.utils as storage_test_utils
 import trigger.test.utils as trigger_test_utils
 from recipe.handlers.graph import RecipeGraph
 from recipe.handlers.graph_delta import RecipeGraphDelta
-from recipe.models import RecipeJob, RecipeType
+from recipe.models import RecipeType
 from rest_framework import status
 
 
@@ -791,3 +791,40 @@ class TestRecipesView(TransactionTestCase):
         self.assertEqual(len(result['jobs']), 1)
         for recipe_job in result['jobs']:
             self.assertFalse(recipe_job['is_original'])
+
+    def test_reprocess_all_jobs(self):
+        """Tests reprocessing all jobs in an existing recipe"""
+
+        url = '/recipes/%i/reprocess/' % self.recipe1.id
+        json_data = {
+            'all_jobs': True,
+        }
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        results = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNotEqual(results['id'], self.recipe1.id)
+        self.assertEqual(results['recipe_type']['id'], self.recipe1.recipe_type.id)
+
+    def test_reprocess_job(self):
+        """Tests reprocessing one job in an existing recipe"""
+
+        url = '/recipes/%i/reprocess/' % self.recipe1.id
+        json_data = {
+            'job_name': 'kml',
+        }
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        results = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertNotEqual(results['id'], self.recipe1.id)
+        self.assertEqual(results['recipe_type']['id'], self.recipe1.recipe_type.id)
+
+    def test_no_changes(self):
+        """Tests reprocessing a recipe that has not changed without specifying any jobs throws an error."""
+
+        url = '/recipes/%i/reprocess/' % self.recipe1.id
+        json_data = {}
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/scale/recipe/test/utils.py
+++ b/scale/recipe/test/utils.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import job.test.utils as job_test_utils
 import trigger.test.utils as trigger_test_utils
+from recipe.configuration.definition.recipe_definition import RecipeDefinition
 from recipe.configuration.data.recipe_data import RecipeData
 from recipe.configuration.data.exceptions import InvalidRecipeConnection
 from recipe.handlers.graph import RecipeGraph
@@ -131,6 +132,12 @@ def create_recipe_type(name=None, version=None, title=None, description=None, de
     RecipeTypeRevision.objects.create_recipe_type_revision(recipe_type)
 
     return recipe_type
+
+
+def edit_recipe_type(recipe_type, definition):
+    """Updates the definition of a recipe type, including creating a new revision for unit testing
+    """
+    RecipeType.objects.edit_recipe_type(recipe_type.id, None, None, RecipeDefinition(definition), None, False)
 
 
 def create_recipe(recipe_type=None, data=None, event=None):

--- a/scale/recipe/urls.py
+++ b/scale/recipe/urls.py
@@ -1,4 +1,4 @@
-'''Defines the URLs for the RESTful recipe services'''
+"""Defines the URLs for the RESTful recipe services"""
 from django.conf.urls import patterns, url
 
 import recipe.views
@@ -15,4 +15,5 @@ urlpatterns = patterns(
     # Recipe views
     url(r'^recipes/$', recipe.views.RecipesView.as_view(), name='recipes_view'),
     url(r'^recipes/(\d+)/$', recipe.views.RecipeDetailsView.as_view(), name='recipe_details_view'),
+    url(r'^recipes/(\d+)/reprocess/$', recipe.views.RecipeReprocessView.as_view(), name='recipe_reprocess_view'),
 )

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -327,7 +327,7 @@ class RecipeReprocessView(GenericAPIView):
         :returns: the HTTP response to send back to the user
         """
 
-        job_names = rest_util.parse_string_list(request, 'job_name', required=False)
+        job_names = rest_util.parse_string_list(request, 'job_names', required=False)
         all_jobs = rest_util.parse_bool(request, 'all_jobs', required=False)
 
         try:


### PR DESCRIPTION
- Added a new view that supports reprocessing an existing recipe.
- Added job_names and all_jobs filter parameters per original issue.
- Added model method to support reprocessing a single recipe.
- Added tests and docs.
- Changed some generic exceptions to more specific types.