### PR TITLE
Issue 457 - Fixed reprocessed recipes to also queue up jobs.

### DIFF
--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -506,13 +506,13 @@ class QueueManager(models.Manager):
         :param superseded_jobs: If not None, represents the job models (stored by job name) of the old recipe to
             supersede
         :type superseded_jobs: {string: :class:`job.models.Job`}
-        :returns: The ID of the new recipe
-        :rtype: int
+        :returns: A handler for the new recipe
+        :rtype: :class:`recipe.handlers.handler.RecipeHandler`
 
         :raises :class:`recipe.configuration.data.exceptions.InvalidRecipeData`: If the recipe data is invalid
         """
 
-        handler = Recipe.objects.create_recipe(recipe_type, event, data, superseded_recipe, delta, superseded_jobs)
+        handler = Recipe.objects.create_recipe(recipe_type, data, event, superseded_recipe, delta, superseded_jobs)
         jobs_to_queue = []
         for job_tuple in handler.get_existing_jobs_to_queue():
             job = job_tuple[0]
@@ -525,7 +525,7 @@ class QueueManager(models.Manager):
         if jobs_to_queue:
             self._queue_jobs(jobs_to_queue)
 
-        return handler.recipe.id
+        return handler
 
     # TODO: once Django user auth is used, have the user information passed into here
     @transaction.atomic
@@ -540,8 +540,8 @@ class QueueManager(models.Manager):
         :type recipe_type: :class:`recipe.models.RecipeType`
         :param data: The recipe data to run on, should be None if superseded_recipe is provided
         :type data: :class:`recipe.data.recipe_data.RecipeData`
-        :returns: The ID of the new recipe
-        :rtype: int
+        :returns: A handler for the new recipe
+        :rtype: :class:`recipe.handlers.handler.RecipeHandler`
 
         :raises :class:`recipe.configuration.data.exceptions.InvalidRecipeData`: If the recipe data is invalid
         """

--- a/scale/queue/views.py
+++ b/scale/queue/views.py
@@ -114,14 +114,17 @@ class QueueNewRecipeView(GenericAPIView):
             raise Http404
 
         try:
-            recipe_id = Queue.objects.queue_new_recipe_for_user(recipe_type, RecipeData(recipe_data))
+            handler = Queue.objects.queue_new_recipe_for_user(recipe_type, RecipeData(recipe_data))
         except InvalidRecipeData:
             return Response('Invalid recipe information.', status=status.HTTP_400_BAD_REQUEST)
 
-        recipe_details = Recipe.objects.get_details(recipe_id)
+        try:
+            recipe = Recipe.objects.get_details(handler.recipe.id)
+        except RecipeType.DoesNotExist:
+            raise Http404
 
-        serializer = self.get_serializer(recipe_details)
-        recipe_url = urlresolvers.reverse('recipe_details_view', args=[recipe_id])
+        serializer = self.get_serializer(recipe)
+        recipe_url = urlresolvers.reverse('recipe_details_view', args=[recipe.id])
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=dict(location=recipe_url))
 
 

--- a/scale/recipe/test/utils.py
+++ b/scale/recipe/test/utils.py
@@ -212,5 +212,5 @@ def create_recipe_handler(recipe_type=None, data=None, event=None, superseded_re
     if superseded_recipe and not delta:
         delta = RecipeGraphDelta(RecipeGraph(), RecipeGraph())
 
-    return Recipe.objects.create_recipe(recipe_type, event, data, superseded_recipe=superseded_recipe,
+    return Recipe.objects.create_recipe(recipe_type, data, event, superseded_recipe=superseded_recipe,
                                         delta=delta, superseded_jobs=superseded_jobs)


### PR DESCRIPTION
- Changed create_recipe call to queue_recipe so that jobs are scheduled.
- Fixed create_recipe parameter order to be consistent with other APIs.
- Fixed queue_recipe to return a recipe handler to be consistent with other APIs.
- Added unit test asserts to cover the bug.