### PR TITLE
Issue 483 - Add product superseded fields to sources REST API

### DIFF
--- a/scale/docs/rest/source_file.rst
+++ b/scale/docs/rest/source_file.rst
@@ -138,7 +138,8 @@ These services provide access to information about source files that Scale has i
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Source File Details**                                                                                                 |
 +=========================================================================================================================+
-| Returns a specific source file and all its related model information including ingests and derived products.            |
+| Returns a specific source file and all its related model information including ingests and derived products. Associated |
+| products that are superseded are excluded by default.                                                                   |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /sources/{id}/                                                                                                  |
 |         Where {id} is the unique identifier of an existing model.                                                       |
@@ -146,6 +147,10 @@ These services provide access to information about source files that Scale has i
 | **GET** /sources/{file_name}/                                                                                           |
 |         Where {file_name} is the unique name of a source file associated with an existing model.                        |
 +-------------------------------------------------------------------------------------------------------------------------+
+| **Query Parameters**                                                                                                    |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| include_superseded | Boolean           | Optional | Whether to include superseded products. Defaults to false.          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **Status**         | 200 OK                                                                                             |
@@ -279,6 +284,8 @@ These services provide access to information about source files that Scale has i
 |                "is_published": true,                                                                                    |
 |                "published": "1970-01-01T00:00:00Z",                                                                     |
 |                "unpublished": null,                                                                                     |
+|                "is_superseded": false,                                                                                  |
+|                "superseded": null,                                                                                      |
 |                "job_type": {                                                                                            |
 |                    "id": 6,                                                                                             |
 |                    "name": "kml-parse",                                                                                 |

--- a/scale/source/serializers_extra.py
+++ b/scale/source/serializers_extra.py
@@ -19,6 +19,11 @@ class SourceFileDetailsSerializer(SourceFileSerializer):
 
     try:
         from product.serializers import ProductFileSerializer
-        products = ProductFileSerializer(many=True)
+
+        class SourceFileDetailsProductFileSerializer(ProductFileSerializer):
+            is_superseded = serializers.BooleanField()
+            superseded = serializers.DateTimeField()
+
+        products = SourceFileDetailsProductFileSerializer(many=True)
     except:
         products = []

--- a/scale/source/views.py
+++ b/scale/source/views.py
@@ -69,8 +69,10 @@ class SourceDetailsView(RetrieveAPIView):
                 raise Http404
             source_id = sources[0]['id']
 
+        include_superseded = rest_util.parse_bool(request, 'include_superseded', required=False)
+
         try:
-            source = SourceFile.objects.get_details(source_id)
+            source = SourceFile.objects.get_details(source_id, include_superseded=include_superseded)
         except SourceFile.DoesNotExist:
             raise Http404
 


### PR DESCRIPTION
- Added superseded field to products in the sources details view.
- Excluded superseded products by default.
- Added parameter to include superseded products.
- Updated tests and docs.