### PR TITLE
Issue 497 - Add superseded filter to jobs API

### DIFF
--- a/scale/docs/rest/job.rst
+++ b/scale/docs/rest/job.rst
@@ -11,7 +11,7 @@ These services provide access to information about "all", "currently running" an
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Job List**                                                                                                            |
 +=========================================================================================================================+
-| Returns a list of all jobs.                                                                                             |
+| Returns a list of all jobs. Jobs marked as superseded are excluded by default.                                          |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /jobs/                                                                                                          |
 +-------------------------------------------------------------------------------------------------------------------------+
@@ -53,6 +53,8 @@ These services provide access to information about "all", "currently running" an
 | error_category     | String            | Optional | Return only jobs that failed due to an error with a given category. |
 |                    |                   |          | Choices: [SYSTEM, DATA, ALGORITHM].                                 |
 |                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| include_superseded | Boolean           | Optional | Whether to include superseded job instances. Defaults to false.     |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
@@ -599,7 +601,8 @@ These services provide access to information about "all", "currently running" an
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Job Updates**                                                                                                         |
 +=========================================================================================================================+
-| Returns a list of jobs with associated input files that changed status in the given time range.                         |
+| Returns a list of jobs with associated input files that changed status in the given time range. Jobs marked as          |
+| superseded are excluded by default.                                                                                     |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /jobs/updates/                                                                                                  |
 +-------------------------------------------------------------------------------------------------------------------------+
@@ -634,6 +637,8 @@ These services provide access to information about "all", "currently running" an
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | job_type_category  | String            | Optional | Return only jobs with a given job type category.                    |
 |                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| include_superseded | Boolean           | Optional | Whether to include superseded job instances. Defaults to false.     |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
@@ -807,7 +812,7 @@ These services provide access to information about "all", "currently running" an
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Job with Execution List**                                                                                             |
 +=========================================================================================================================+
-| Returns a list of all jobs with their latest execution.                                                                 |
+| Returns a list of all jobs with their latest execution. Jobs marked as superseded are excluded by default.              |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /jobs/executions/                                                                                               |
 +-------------------------------------------------------------------------------------------------------------------------+
@@ -846,6 +851,8 @@ These services provide access to information about "all", "currently running" an
 | error_category     | String            | Optional | Return only jobs that failed due to an error with a given category. |
 |                    |                   |          | Choices: [SYSTEM, DATA, ALGORITHM].                                 |
 |                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| include_superseded | Boolean           | Optional | Whether to include superseded job instances. Defaults to false.     |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -30,6 +30,8 @@ class TestJobsView(TestCase):
         self.job_type2 = job_test_utils.create_job_type(name='test2', version='1.0', category='test-2')
         self.job2 = job_test_utils.create_job(job_type=self.job_type2, status='PENDING')
 
+        self.job3 = job_test_utils.create_job(is_superseded=True)
+
     def test_successful(self):
         """Tests successfully calling the jobs view."""
 
@@ -119,6 +121,16 @@ class TestJobsView(TestCase):
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['id'], job.id)
         self.assertEqual(result['results'][0]['error']['category'], error.category)
+
+    def test_superseded(self):
+        """Tests getting superseded jobs."""
+
+        url = '/jobs/?include_superseded=true'
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(result['results']), 3)
 
     def test_order_by(self):
         """Tests successfully calling the jobs view with sorting."""
@@ -431,6 +443,8 @@ class TestJobsUpdateView(TestCase):
             data={'input_data': [{'name': 'input_file', 'file_id': self.file.id}]},
         )
 
+        self.job3 = job_test_utils.create_job(is_superseded=True)
+
     def test_successful(self):
         """Tests successfully calling the jobs view."""
 
@@ -495,6 +509,16 @@ class TestJobsUpdateView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['job_type']['category'], self.job1.job_type.category)
+
+    def test_superseded(self):
+        """Tests getting superseded jobs."""
+
+        url = '/jobs/updates/?include_superseded=true'
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(result['results']), 3)
 
 
 class TestJobTypesView(TestCase):
@@ -1453,6 +1477,8 @@ class TestJobsWithExecutionView(TransactionTestCase):
         time.sleep(.01)
         self.last_run_2b = job_test_utils.create_job_exe(job=self.job_2b, status='COMPLETED')
 
+        self.job_3 = job_test_utils.create_job(is_superseded=True)
+
     def test_get_latest_job_exes(self):
         """Tests calling the jobs information service without a filter"""
 
@@ -1548,6 +1574,16 @@ class TestJobsWithExecutionView(TransactionTestCase):
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['id'], job.id)
         self.assertEqual(result['results'][0]['error']['category'], error.category)
+
+    def test_superseded(self):
+        """Tests getting superseded jobs."""
+
+        url = '/jobs/executions/?include_superseded=true'
+        response = self.client.generic('GET', url)
+        result = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(result['results']), 5)
 
 
 class TestJobExecutionsView(TransactionTestCase):

--- a/scale/job/test/utils.py
+++ b/scale/job/test/utils.py
@@ -78,7 +78,7 @@ register_trigger_rule_handler(MockErrorTriggerRuleHandler())
 
 def create_job(job_type=None, event=None, status='PENDING', error=None, data=None, num_exes=0, queued=None,
                started=None, ended=None, last_status_change=None, priority=100, results=None, superseded_job=None,
-               delete_superseded=True):
+               delete_superseded=True, is_superseded=False, superseded=None):
     """Creates a job model for unit testing
 
     :returns: The job model
@@ -99,6 +99,8 @@ def create_job(job_type=None, event=None, status='PENDING', error=None, data=Non
         }
     if superseded_job and not superseded_job.is_superseded:
         Job.objects.supersede_jobs([superseded_job], timezone.now())
+    if is_superseded and not superseded:
+        superseded = timezone.now()
 
     job = Job.objects.create_job(job_type, event, superseded_job=superseded_job, delete_superseded=delete_superseded)
     job.priority = priority
@@ -111,6 +113,8 @@ def create_job(job_type=None, event=None, status='PENDING', error=None, data=Non
     job.last_status_change = last_status_change
     job.error = error
     job.results = results
+    job.is_superseded = is_superseded
+    job.superseded = superseded
     job.save()
     return job
 

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -446,17 +446,20 @@ class JobsView(ListAPIView):
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
 
-        job_statuses = rest_util.parse_string_list(request, 'status', required=False)
+        statuses = rest_util.parse_string_list(request, 'status', required=False)
         job_ids = rest_util.parse_int_list(request, 'job_id', required=False)
         job_type_ids = rest_util.parse_int_list(request, 'job_type_id', required=False)
         job_type_names = rest_util.parse_string_list(request, 'job_type_name', required=False)
         job_type_categories = rest_util.parse_string_list(request, 'job_type_category', required=False)
         error_categories = rest_util.parse_string_list(request, 'error_category', required=False)
+        include_superseded = rest_util.parse_bool(request, 'include_superseded', required=False)
 
         order = rest_util.parse_string_list(request, 'order', required=False)
 
-        jobs = Job.objects.get_jobs(started, ended, job_statuses, job_ids, job_type_ids, job_type_names,
-                                    job_type_categories, error_categories, order)
+        jobs = Job.objects.get_jobs(started=started, ended=ended, statuses=statuses, job_ids=job_ids,
+                                    job_type_ids=job_type_ids, job_type_names=job_type_names,
+                                    job_type_categories=job_type_categories, error_categories=error_categories,
+                                    include_superseded=include_superseded, order=order)
 
         page = self.paginate_queryset(jobs)
         serializer = self.get_serializer(page, many=True)
@@ -533,15 +536,17 @@ class JobUpdatesView(ListAPIView):
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
 
-        job_statuses = rest_util.parse_string_list(request, 'status', required=False)
+        statuses = rest_util.parse_string_list(request, 'status', required=False)
         job_type_ids = rest_util.parse_int_list(request, 'job_type_id', required=False)
         job_type_names = rest_util.parse_string_list(request, 'job_type_name', required=False)
         job_type_categories = rest_util.parse_string_list(request, 'job_type_category', required=False)
+        include_superseded = rest_util.parse_bool(request, 'include_superseded', required=False)
 
         order = rest_util.parse_string_list(request, 'order', required=False)
 
-        jobs = Job.objects.get_job_updates(started, ended, job_statuses, job_type_ids, job_type_names,
-                                           job_type_categories, order)
+        jobs = Job.objects.get_job_updates(started=started, ended=ended, statuses=statuses, job_type_ids=job_type_ids,
+                                           job_type_names=job_type_names, job_type_categories=job_type_categories,
+                                           include_superseded=include_superseded, order=order)
 
         page = self.paginate_queryset(jobs)
         Job.objects.populate_input_files(page)
@@ -566,17 +571,20 @@ class JobsWithExecutionView(ListAPIView):
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
 
-        job_statuses = rest_util.parse_string_list(request, 'status', required=False)
+        statuses = rest_util.parse_string_list(request, 'status', required=False)
         job_ids = rest_util.parse_int_list(request, 'job_id', required=False)
         job_type_ids = rest_util.parse_int_list(request, 'job_type_id', required=False)
         job_type_names = rest_util.parse_string_list(request, 'job_type_name', required=False)
         job_type_categories = rest_util.parse_string_list(request, 'job_type_category', required=False)
         error_categories = rest_util.parse_string_list(request, 'error_category', required=False)
+        include_superseded = rest_util.parse_bool(request, 'include_superseded', required=False)
 
         order = rest_util.parse_string_list(request, 'order', required=False)
 
-        jobs = Job.objects.get_jobs(started, ended, job_statuses, job_ids, job_type_ids, job_type_names,
-                                    job_type_categories, error_categories, order)
+        jobs = Job.objects.get_jobs(started=started, ended=ended, statuses=statuses, job_ids=job_ids,
+                                    job_type_ids=job_type_ids, job_type_names=job_type_names,
+                                    job_type_categories=job_type_categories, error_categories=error_categories,
+                                    include_superseded=include_superseded, order=order)
 
         # Add the latest execution for each matching job
         page = self.paginate_queryset(jobs)


### PR DESCRIPTION
- Updated get_jobs to exclude superseded jobs by default.
- Added supersedes parameters to jobs, job updates, and jobs with executions views.
- Updated tests and docs.