### PR TITLE
Issue 532 - Requeue Job API Broken

### DIFF
--- a/scale/docs/rest/queue.rst
+++ b/scale/docs/rest/queue.rst
@@ -679,6 +679,16 @@ place jobs and recipes on the queue for processing.
 | priority           | Integer           | Optional | Change the priority of matching jobs when adding them to the queue. |
 |                    |                   |          | Defaults to jobs current priority, lower number is higher priority. |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
+| .. code-block:: javascript                                                                                              |
+|                                                                                                                         |
+|     {                                                                                                                   |
+|         "started": "2016-01-01T00:00:00Z",                                                                              |
+|         "ended": "2016-01-01-10T00:00:00Z",                                                                             |
+|         "status": "FAILED",                                                                                             |
+|         "job_type_ids": [1, 2, 3],                                                                                      |
+|         "error_categories": ["SYSTEM"]                                                                                  |
+|    }                                                                                                                    |
++-------------------------------------------------------------------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **Status**         | 200 OK                                                                                             |

--- a/scale/queue/serializers.py
+++ b/scale/queue/serializers.py
@@ -19,3 +19,16 @@ class QueueStatusSerializer(serializers.Serializer):
     count = serializers.IntegerField()
     longest_queued = serializers.DateTimeField()
     highest_priority = serializers.IntegerField()
+
+
+class RequeueJobSerializer(serializers.Serializer):
+    """Converts re-queue job JSON input to dictionary attributes"""
+    started = serializers.DateTimeField(required=False)
+    ended = serializers.DateTimeField(required=False)
+    status = serializers.CharField(allow_blank=True, allow_null=True, required=False)
+    job_ids = serializers.ListField(child=serializers.IntegerField(required=False))
+    job_type_ids = serializers.ListField(child=serializers.IntegerField(required=False))
+    job_type_names = serializers.ListField(child=serializers.CharField(required=False))
+    job_type_categories = serializers.ListField(child=serializers.CharField(required=False))
+    error_categories = serializers.ListField(child=serializers.CharField(required=False))
+    priority = serializers.IntegerField(required=False)

--- a/scale/queue/test/test_views.py
+++ b/scale/queue/test/test_views.py
@@ -340,16 +340,18 @@ class TestRequeueJobsView(TestCase):
         self.recipe_job = recipe_test_utils.create_recipe_job(recipe=self.recipe, job_name='Job 1', job=self.job_1)
         self.recipe_job = recipe_test_utils.create_recipe_job(recipe=self.recipe, job_name='Job 2', job=self.job_2)
 
-    def test_bad_job_id(self):
-        """Tests calling the requeue view with an invalid job type ID."""
+    def test_no_match(self):
+        """Tests calling the requeue view where there are no matching jobs to schedule."""
         json_data = {
             'job_ids': [1000],
         }
 
         url = '/queue/requeue-jobs/'
         response = self.client.post(url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 0)
 
     def test_requeue_canceled(self,):
         """Tests calling the requeue view successfully for a job that was never queued."""

--- a/scale/queue/views.py
+++ b/scale/queue/views.py
@@ -182,15 +182,14 @@ class RequeueJobsView(GenericAPIView):
         jobs = Job.objects.get_jobs(started=started, ended=ended, statuses=job_status, job_ids=job_ids,
                                     job_type_ids=job_type_ids, job_type_names=job_type_names,
                                     job_type_categories=job_type_categories, error_categories=error_categories)
-        if not jobs:
-            raise Http404
 
         # Attempt to queue all jobs matching the filters
         requested_job_ids = {job.id for job in jobs}
-        Queue.objects.requeue_jobs(requested_job_ids, priority)
+        if requested_job_ids:
+            Queue.objects.requeue_jobs(requested_job_ids, priority)
 
-        # Refresh models to get the new status information for all originally requested jobs
-        jobs = Job.objects.get_jobs(job_ids=requested_job_ids)
+            # Refresh models to get the new status information for all originally requested jobs
+            jobs = Job.objects.get_jobs(job_ids=requested_job_ids)
 
         page = self.paginate_queryset(jobs)
         serializer = JobSerializer(page, many=True)

--- a/scale/queue/views.py
+++ b/scale/queue/views.py
@@ -16,7 +16,7 @@ from job.configuration.data.exceptions import InvalidData
 from job.models import Job, JobType
 from job.serializers import JobDetailsSerializer, JobSerializer
 from queue.models import JobLoad, Queue
-from queue.serializers import JobLoadGroupSerializer, QueueStatusSerializer
+from queue.serializers import JobLoadGroupSerializer, QueueStatusSerializer, RequeueJobSerializer
 from recipe.configuration.data.exceptions import InvalidRecipeData
 from recipe.configuration.data.recipe_data import RecipeData
 from recipe.models import Recipe, RecipeType
@@ -154,7 +154,7 @@ class RequeueJobsView(GenericAPIView):
     """This view is the endpoint for requeuing jobs which have already been executed."""
     parser_classes = (JSONParser,)
     queryset = Job.objects.all()
-    serializer_class = JobSerializer
+    serializer_class = RequeueJobSerializer
 
     def post(self, request):
         """Increase max_tries, place it on the queue, and returns the new job information in JSON form
@@ -193,5 +193,5 @@ class RequeueJobsView(GenericAPIView):
         jobs = Job.objects.get_jobs(job_ids=requested_job_ids)
 
         page = self.paginate_queryset(jobs)
-        serializer = self.get_serializer(page, many=True)
+        serializer = JobSerializer(page, many=True)
         return self.get_paginated_response(serializer.data)


### PR DESCRIPTION
- Fixed the DRF HTML form to show example JSON with the correct fields.
- Updated the docs for the POST endpoint to show a valid example.
- Changed view to return a 200 response when no jobs match the query.

Not fixed as part of this PR:
- View hangs for large queries (we already have a separate issue covering that).
- Requeue All button grabs more than what is selected. Not sure exactly what this means, but it sounds like a UI bug.