### PR TITLE
Issue 511 - Recipe editor validation warnings no longer prevent save

### DIFF
--- a/scale-ui/app/modules/recipes/directives/recipeGraphViewerDirective.js
+++ b/scale-ui/app/modules/recipes/directives/recipeGraphViewerDirective.js
@@ -4,7 +4,7 @@
 (function () {
     angular.module('scaleApp').controller('aisScaleRecipeGraphViewerController', function ($rootScope, $scope, $location, $uibModal, scaleConfig, scaleService, jobTypeService, recipeService, workspacesService, RecipeType, RecipeTypeDetail, JobType, localStorage) {
         var vm = this;
-        
+
         vm.vertices = [];
         vm.edges = [];
         vm.selectedJob = null;
@@ -669,7 +669,7 @@
                 _.forEach($scope.recipeType.definition.jobs, function (job) {
                     // populate the current jobType
                     /*var thisJobType = _.find($scope.recipeType.job_types,{id: job.job_type_id});
-                    job.job_type = thisJobType;*/
+                     job.job_type = thisJobType;*/
 
                     // find dependents
                     if (job.job_type && job.job_type.job_type_interface) {
@@ -787,7 +787,7 @@
             zoom = d3.behavior.zoom().on("zoom", function () {
                 zoomScale = d3.event.scale;
                 inner.attr("transform", "translate(" + d3.event.translate + ")" +
-                    "scale(" + zoomScale + ")");
+                  "scale(" + zoomScale + ")");
             });
             svg.call(zoom);
 

--- a/scale-ui/app/modules/recipes/directives/recipeGraphViewerDirective.js
+++ b/scale-ui/app/modules/recipes/directives/recipeGraphViewerDirective.js
@@ -417,7 +417,7 @@
                 if (validationResult.warnings && validationResult.warnings.length > 0) {
                     // display the warnings
                     var warningsHtml = getWarningsHtml(validationResult.warnings);
-                    toastr["error"](warningsHtml);
+                    toastr["warning"](warningsHtml);
                 } else {
                     toastr["success"]('Recipe is valid.');
                 }
@@ -438,20 +438,19 @@
                 if (validationResult.warnings && validationResult.warnings.length > 0) {
                     // display the warnings
                     var warningsHtml = getWarningsHtml(validationResult.warnings);
-                    toastr["error"](warningsHtml);
+                    toastr["warning"](warningsHtml);
                     vm.savingRecipe = false;
-                } else {
-                    recipeService.saveRecipeType($scope.recipeType).then(function (saveResult) {
-                        vm.savingRecipe = false;
-                        $scope.recipeType = RecipeTypeDetail.transformer(saveResult);
-                        if (scaleConfig.static) {
-                            console.log(JSON.stringify($scope.recipeType));
-                            localStorage.setItem('recipeType' + $scope.recipeType.id, JSON.stringify($scope.recipeType));
-                        }
-                        vm.redraw();
-                        $location.path('/recipes/types/' + $scope.recipeType.id);
-                    });
                 }
+                recipeService.saveRecipeType($scope.recipeType).then(function (saveResult) {
+                    vm.savingRecipe = false;
+                    $scope.recipeType = RecipeTypeDetail.transformer(saveResult);
+                    if (scaleConfig.static) {
+                        console.log(JSON.stringify($scope.recipeType));
+                        localStorage.setItem('recipeType' + $scope.recipeType.id, JSON.stringify($scope.recipeType));
+                    }
+                    vm.redraw();
+                    $location.path('/recipes/types/' + $scope.recipeType.id);
+                });
             }).catch(function (error) {
                 if (error && error.detail) {
                     toastr['error'](error.detail);

--- a/scale-ui/gulpfile.js
+++ b/scale-ui/gulpfile.js
@@ -16,6 +16,7 @@ var gulp = require('gulp'),
     gzip = require('gulp-gzip'),
     fs = require('fs'),
     p = require('./package.json'),
+    modRewrite = require('connect-modrewrite'),
     util = require('gulp-util');
 
 var paths = {
@@ -255,7 +256,14 @@ gulp.task('connect', ['build'], function () {
     connect.server({
         port: 9000,
         root: 'build',
-        livereload: true
+        livereload: true,
+        middleware: function() {
+            return [
+                modRewrite([
+                    '^/api/(.*)$ http://localhost:8000/$1 [P]'
+                ])
+            ];
+        }
     });
 });
 

--- a/scale-ui/package.json
+++ b/scale-ui/package.json
@@ -5,6 +5,7 @@
     "gulp-util": "^3.0.7"
   },
   "devDependencies": {
+    "connect-modrewrite": "^0.9.0",
     "del": "^2.2.0",
     "gulp": "^3.9.0",
     "gulp-bump": "^1.0.0",


### PR DESCRIPTION
Fixes #511. Updated Recipe Editor to allow saving when there are validation warnings. API returns HTTP errors when there are validation errors and save is not allowed.