### PR TITLE
Issue 567 - Add ability to sort Failure Rates list by failure type

### DIFF
--- a/scale-ui/app/modules/common/services/stateService.js
+++ b/scale-ui/app/modules/common/services/stateService.js
@@ -78,7 +78,9 @@
                 ended: null,
                 name: data.name ? data.name : null,
                 category: null,
-                order: null
+                order: data.order ? data.order : 'desc',
+                orderField: data.orderField ? data.orderField : 'twentyfour_hours',
+                orderErrorType: data.orderErrorType ? data.orderErrorType : 'errorTotal'
             };
         };
 

--- a/scale-ui/app/modules/jobs/controllers/jobTypesFailureRatesController.js
+++ b/scale-ui/app/modules/jobs/controllers/jobTypesFailureRatesController.js
@@ -19,6 +19,76 @@
         vm.performanceData = [];
         vm.jobTypeValues = [jobTypeViewAll];
         vm.selectedJobType = vm.jobTypesParams.name ? vm.jobTypesParams.name : jobTypeViewAll;
+        vm.sortOrders = {
+            twentyfour_hours: {
+                system: {
+                    direction: 'desc',
+                    icon: 'asdf'
+                },
+                algorithm: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                },
+                data: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                },
+                total: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                },
+                errorTotal: {
+                    direction: 'asc',
+                    icon: 'fa-caret-down'
+                }
+            },
+            fortyeight_hours: {
+                system: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                },
+                algorithm: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                },
+                data: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                },
+                total: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                },
+                errorTotal: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                }
+            },
+            thirty_days: {
+                system: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                },
+                algorithm: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                },
+                data: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                },
+                total: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                },
+                errorTotal: {
+                    direction: 'desc',
+                    icon: 'hidden'
+                }
+            }
+        };
+        vm.currSortField = 'twentyfour_hours';
+        vm.currSortErrorType = 'errorTotal';
         vm.subnavLinks = scaleConfig.subnavLinks.jobs;
         subnavService.setCurrentPath('jobs/failure-rates');
 
@@ -28,6 +98,7 @@
                 displayName: 'Job Type',
                 cellTemplate: '<div class="ui-grid-cell-contents"><span ng-bind-html="row.entity.job_type.getIcon()"></span> {{ row.entity.job_type.title }} {{ row.entity.job_type.version }}</div>',
                 filterHeaderTemplate: '<div class="ui-grid-filter-container"><select class="form-control input-sm" ng-model="grid.appScope.vm.selectedJobType" ng-options="jobType as (jobType.title + \' \' + jobType.version) for jobType in grid.appScope.vm.jobTypeValues"></select></div>',
+                width: '16%',
                 enableSorting: false
             },
             {
@@ -35,6 +106,7 @@
                 displayName: '24 Hours',
                 enableSorting: false,
                 enableFiltering: false,
+                width: '28%',
                 headerCellTemplate: 'gridHeader.html',
                 cellTemplate: 'gridRow.html'
             },
@@ -43,6 +115,7 @@
                 displayName: '48 Hours',
                 enableSorting: false,
                 enableFiltering: false,
+                width: '28%',
                 headerCellTemplate: 'gridHeader.html',
                 cellTemplate: 'gridRow.html'
             },
@@ -51,6 +124,7 @@
                 displayName: '30 Days',
                 enableSorting: false,
                 enableFiltering: false,
+                width: '28%',
                 headerCellTemplate: 'gridHeader.html',
                 cellTemplate: 'gridRow.html'
             }
@@ -107,6 +181,24 @@
             if (!vm.loading) {
                 vm.filterResults();
             }
+        };
+
+        vm.sortBy = function (errorType, field) {
+            vm.sortOrders[vm.currSortField][vm.currSortErrorType].icon = 'hidden';
+            vm.gridOptions.data = _.sortByOrder(vm.performanceData, function (d) {
+                if (errorType === 'errorTotal') {
+                    if (d[field].total > 0) {
+                        return d[field].errorTotal / d[field].total;
+                    }
+                    return 0;
+                }
+                return d[field][errorType];
+            }, [vm.sortOrders[field][errorType].direction]);
+            vm.currSortErrorType = errorType;
+            vm.currSortField = field;
+            vm.sortOrders[field][errorType].icon = vm.sortOrders[field][errorType].direction === 'desc' ? 'fa-caret-down' : 'fa-caret-up';
+            vm.sortOrders[field][errorType].direction = vm.sortOrders[field][errorType].direction === 'desc' ? 'asc' : 'desc';
+            $scope.gridApi.core.refresh();
         };
 
         var formatData = function (data, numDays) {

--- a/scale-ui/app/modules/jobs/partials/jobTypesFailureRatesTemplate.html
+++ b/scale-ui/app/modules/jobs/partials/jobTypesFailureRatesTemplate.html
@@ -33,12 +33,12 @@
     <div class="ui-grid-cell-contents">
         {{ col.displayName }}
         <div class="row margin-top-md">
-            <div class="col-xs-4 col-md-6"><span class="header-label">Failure %</span></div>
+            <div class="col-xs-4 col-md-6"><a class="header-label" ng-click="grid.appScope.vm.sortBy('errorTotal', col.field)">Failure %</a> <i class="fa" ng-class="grid.appScope.vm.sortOrders[col.field].errorTotal.icon"></i></div>
             <div class="col-xs-8 col-md-6 text-right">
-                <span class="label label-system" uib-tooltip="System Errors" tooltip-append-to-body="true">Sys</span>
-                <span class="label label-algorithm" uib-tooltip="Algorithm Errors" tooltip-append-to-body="true">Alg</span>
-                <span class="label label-data" uib-tooltip="Data Errors" tooltip-append-to-body="true">Data</span>
-                <span class="label label-running" uib-tooltip="Total Jobs" tooltip-append-to-body="true">Total</span>
+                <span class="label label-system" uib-tooltip="System Errors" tooltip-append-to-body="true" ng-click="grid.appScope.vm.sortBy('system', col.field)">Sys <i class="fa" ng-class="grid.appScope.vm.sortOrders[col.field].system.icon"></i></span>
+                <span class="label label-algorithm" uib-tooltip="Algorithm Errors" tooltip-append-to-body="true" ng-click="grid.appScope.vm.sortBy('algorithm', col.field)">Alg  <i class="fa" ng-class="grid.appScope.vm.sortOrders[col.field].algorithm.icon"></i></span>
+                <span class="label label-data" uib-tooltip="Data Errors" tooltip-append-to-body="true" ng-click="grid.appScope.vm.sortBy('data', col.field)">Data  <i class="fa" ng-class="grid.appScope.vm.sortOrders[col.field].data.icon"></i></span>
+                <span class="label label-running" uib-tooltip="Total Jobs" tooltip-append-to-body="true" ng-click="grid.appScope.vm.sortBy('total', col.field)">Total  <i class="fa" ng-class="grid.appScope.vm.sortOrders[col.field].total.icon"></i></span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Closes #567 
Clicking on each of the error type headers in any of the columns will sort the data by that error type over the associated time period.  Clicking on "Failure %" will sort the data by failure percentage.  Default sort is desc, but clicking on each header multiple times will toggle between asc and desc. A directional caret icon is displayed next to the label currently being used for sorting.

Right now this sorting is not persisted through the URL. Please comment if that is necessary.

![image](https://cloud.githubusercontent.com/assets/15909071/20223815/4816b6ce-a809-11e6-9d0e-d10e2b595673.png)
