### PR TITLE
Issue 603 - Fixed executing batch creator command

### DIFF
--- a/scale/batch/management/commands/scale_batch_creator.py
+++ b/scale/batch/management/commands/scale_batch_creator.py
@@ -33,10 +33,9 @@ class Command(BaseCommand):
 
         # Schedule all the batch recipes
         try:
-            batch = Batch.objects.get(pk=batch_id)
+            Batch.objects.schedule_recipes(batch_id)
         except Batch.DoesNotExist:
             logger.exception('Unable to find batch: %i', batch_id)
             sys.exit(1)
 
-        Batch.objects.schedule_recipes(batch)
         logger.info('Command completed: scale_batch_creator')

--- a/scale/batch/test/management/commands/test_scale_batch_creator.py
+++ b/scale/batch/test/management/commands/test_scale_batch_creator.py
@@ -32,4 +32,4 @@ class TestBatchCreator(TestCase):
         cmd = BatchCommand()
         cmd.run_from_argv(['manage.py', 'scale_batch_creator', '-i', str(self.batch.id)])
 
-        self.assertTrue(mock_batch_manager.schedule_recipes.called)
+        mock_batch_manager.schedule_recipes.assert_called_with(self.batch.id)


### PR DESCRIPTION
The unit test did not verify the arguments were correct, only that a method was called so the new command never actually worked in practice.