### PR TITLE
Issue 603 - Fixed batch to accept full time stamps

### DIFF
--- a/scale/batch/configuration/definition/batch_definition.py
+++ b/scale/batch/configuration/definition/batch_definition.py
@@ -1,11 +1,10 @@
 """Defines the class for managing a batch definition"""
 from __future__ import unicode_literals
 
-import datetime
-
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 
+import util.parse as parse
 from batch.configuration.definition.exceptions import InvalidDefinition
 
 
@@ -57,12 +56,10 @@ BATCH_DEFINITION_SCHEMA = {
                 'started': {
                     'description': 'The start of the range to use when matching recipes to re-process',
                     'type': 'string',
-                    'pattern': '^\d{4}-\d{2}-\d{2}$',
                 },
                 'ended': {
                     'description': 'The end of the range to use when matching recipes to re-process',
                     'type': 'string',
-                    'pattern': '^\d{4}-\d{2}-\d{2}$',
                 },
             },
         },
@@ -102,13 +99,13 @@ class BatchDefinition(object):
         self.started = None
         if date_range and 'started' in date_range:
             try:
-                self.started = datetime.datetime.strptime(date_range['started'], '%Y-%m-%d')
+                self.started = parse.parse_datetime(date_range['started'])
             except ValueError:
                 raise InvalidDefinition('Invalid start date format: %s' % date_range['started'])
         self.ended = None
         if date_range and 'ended' in date_range:
             try:
-                self.ended = datetime.datetime.strptime(date_range['ended'], '%Y-%m-%d')
+                self.ended = parse.parse_datetime(date_range['ended'])
             except ValueError:
                 raise InvalidDefinition('Invalid end date format: %s' % date_range['ended'])
 

--- a/scale/batch/test/configuration/definition/test_batch_definition.py
+++ b/scale/batch/test/configuration/definition/test_batch_definition.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import datetime
 
 import django
+import django.utils.timezone as timezone
 from django.test import TestCase
 
 from batch.configuration.definition.exceptions import InvalidDefinition
@@ -30,15 +31,15 @@ class TestBatchDefinition(TestCase):
         definition = {
             'version': '1.0',
             'date_range': {
-                'started': '2016-01-01',
-                'ended': '2016-12-31',
+                'started': '2016-01-01T00:00:00.000Z',
+                'ended': '2016-12-31T00:00:00.000Z',
             },
         }
 
         # No exception means success
         batch_def = BatchDefinition(definition)
-        self.assertEqual(batch_def.started, datetime.datetime(2016, 1, 1))
-        self.assertEqual(batch_def.ended, datetime.datetime(2016, 12, 31))
+        self.assertEqual(batch_def.started, datetime.datetime(2016, 1, 1, tzinfo=timezone.utc))
+        self.assertEqual(batch_def.ended, datetime.datetime(2016, 12, 31, tzinfo=timezone.utc))
 
     def test_date_range_started(self):
         """Tests defining a date range with only a start date"""
@@ -46,13 +47,13 @@ class TestBatchDefinition(TestCase):
         definition = {
             'version': '1.0',
             'date_range': {
-                'started': '2016-01-01',
+                'started': '2016-01-01T00:00:00.000Z',
             },
         }
 
         # No exception means success
         batch_def = BatchDefinition(definition)
-        self.assertEqual(batch_def.started, datetime.datetime(2016, 1, 1))
+        self.assertEqual(batch_def.started, datetime.datetime(2016, 1, 1, tzinfo=timezone.utc))
 
     def test_date_range_ended(self):
         """Tests defining a date range with only an end date"""
@@ -60,13 +61,13 @@ class TestBatchDefinition(TestCase):
         definition = {
             'version': '1.0',
             'date_range': {
-                'ended': '2016-12-31',
+                'ended': '2016-12-31T00:00:00.000Z',
             },
         }
 
         # No exception means success
         batch_def = BatchDefinition(definition)
-        self.assertEqual(batch_def.ended, datetime.datetime(2016, 12, 31))
+        self.assertEqual(batch_def.ended, datetime.datetime(2016, 12, 31, tzinfo=timezone.utc))
 
     def test_date_range_type_invalid(self):
         """Tests defining a date range with an invalid enumerated type"""

--- a/scale/batch/test/test_models.py
+++ b/scale/batch/test/test_models.py
@@ -249,8 +249,8 @@ class TestBatchManager(TransactionTestCase):
 
         definition = {
             'date_range': {
-                'started': '2016-01-10',
-                'ended': '2016-02-10',
+                'started': '2016-01-10T00:00:00.000Z',
+                'ended': '2016-02-10T00:00:00.000Z',
             },
         }
         batch = batch_test_utils.create_batch(recipe_type=self.recipe_type, definition=definition)
@@ -275,8 +275,8 @@ class TestBatchManager(TransactionTestCase):
         definition = {
             'date_range': {
                 'type': 'data',
-                'started': '2016-01-01',
-                'ended': '2016-01-10',
+                'started': '2016-01-01T00:00:00.000Z',
+                'ended': '2016-01-10T00:00:00.000Z',
             },
         }
         batch = batch_test_utils.create_batch(recipe_type=self.recipe_type, definition=definition)
@@ -322,7 +322,7 @@ class TestBatchManager(TransactionTestCase):
         definition = {
             'date_range': {
                 'type': 'data',
-                'started': '2016-01-10',
+                'started': '2016-01-10T00:00:00.000Z',
             },
         }
         batch = batch_test_utils.create_batch(recipe_type=self.recipe_type, definition=definition)
@@ -374,7 +374,7 @@ class TestBatchManager(TransactionTestCase):
         definition = {
             'date_range': {
                 'type': 'data',
-                'ended': '2016-01-15',
+                'ended': '2016-01-15T00:00:00.000Z',
             },
         }
         batch = batch_test_utils.create_batch(recipe_type=self.recipe_type, definition=definition)
@@ -438,8 +438,8 @@ class TestBatchManager(TransactionTestCase):
         definition = {
             'date_range': {
                 'type': 'data',
-                'started': '2016-02-01',
-                'ended': '2016-02-10',
+                'started': '2016-02-01T00:00:00.000Z',
+                'ended': '2016-02-10T00:00:00.000Z',
             },
         }
         batch = batch_test_utils.create_batch(recipe_type=self.recipe_type, definition=definition)

--- a/scale/util/parse.py
+++ b/scale/util/parse.py
@@ -1,4 +1,5 @@
-'''Defines utility functions for parsing data.'''
+"""Defines utility functions for parsing data."""
+from __future__ import unicode_literals
 
 import datetime
 import re
@@ -18,11 +19,6 @@ iso8601_duration_re = re.compile(
     r')?'
     r'$'
 )
-
-
-class ParseError(Exception):
-    '''Exception indicating a value cannot be parsed.'''
-    pass
 
 
 # TODO The following is from the Django 1.8 django.utils.dateparse, we can remove this when upgrading.
@@ -45,18 +41,18 @@ def parse_duration(value):
 # Solution modified from http://akinfold.blogspot.com/2012/12/datetimefield-doesnt-accept-iso-8601.html
 def parse_datetime(value):
     if 'Z' not in value and '+' not in value:
-        raise ParseError('Datetime value must include a timezone: %s' % value)
+        raise ValueError('Datetime value must include a timezone: %s' % value)
     return dateparse.parse_datetime(value)
 
 
 def parse_timestamp(value):
-    '''Parses any valid ISO date/time, duration, or timestamp.
+    """Parses any valid ISO date/time, duration, or timestamp.
 
     :param value: The raw string value to parse.
     :type value: str
     :returns: The result of parsing the given string value.
     :rtype: datetime.datetime
-    '''
+    """
     if value and value.startswith('P'):
         return timezone.now() - parse_duration(value)
     return parse_datetime(value)

--- a/scale/util/rest.py
+++ b/scale/util/rest.py
@@ -14,7 +14,6 @@ from rest_framework.exceptions import APIException
 from rest_framework.settings import api_settings
 
 import util.parse as parse_util
-from util.parse import ParseError
 
 
 class DefaultPagination(pagination.PageNumberPagination):
@@ -454,10 +453,8 @@ def parse_datetime(request, name, default_value=None, required=True):
         if result:
             return result
         raise
-    except ParseError:
-        raise BadParameter('Datetime value must include a timezone: %s' % name)
     except:
-        raise BadParameter('Invalid datetime format for parameter: %s' % name)
+        raise BadParameter('Datetime values must follow ISO-8601 and include a timezone: %s' % name)
 
 
 def parse_dict(request, name, default_value=None, required=True):

--- a/scale/util/test/test_parse.py
+++ b/scale/util/test/test_parse.py
@@ -1,4 +1,5 @@
-#@PydevCodeAnalysisIgnore
+from __future__ import unicode_literals
+
 import datetime
 
 import django
@@ -7,7 +8,6 @@ import mock
 from django.test import TestCase
 
 import util.parse as parse_util
-from util.parse import ParseError
 
 
 class TestParse(TestCase):
@@ -16,33 +16,33 @@ class TestParse(TestCase):
         django.setup()
 
     def test_parse_duration(self):
-        '''Tests parsing a valid ISO duration.'''
+        """Tests parsing a valid ISO duration."""
         self.assertEqual(parse_util.parse_duration('PT3H0M0S'), datetime.timedelta(0, 10800))
 
     def test_parse_duration_invalid(self):
-        '''Tests parsing an invalid ISO duration.'''
+        """Tests parsing an invalid ISO duration."""
         self.assertIsNone(parse_util.parse_duration('BAD'))
 
     def test_parse_datetime(self):
-        '''Tests parsing a valid ISO datetime.'''
+        """Tests parsing a valid ISO datetime."""
         self.assertEqual(parse_util.parse_datetime('2015-01-01T00:00:00Z'),
                          datetime.datetime(2015, 1, 1, tzinfo=timezone.utc))
 
     def test_parse_datetime_invalid(self):
-        '''Tests parsing an invalid ISO datetime.'''
+        """Tests parsing an invalid ISO datetime."""
         self.assertIsNone(parse_util.parse_datetime('20150101T00:00:00Z'))
 
     def test_parse_datetime_missing_timezone(self):
-        '''Tests parsing an ISO datetime missing a timezone.'''
-        self.assertRaises(ParseError, parse_util.parse_datetime, '2015-01-01T00:00:00')
+        """Tests parsing an ISO datetime missing a timezone."""
+        self.assertRaises(ValueError, parse_util.parse_datetime, '2015-01-01T00:00:00')
 
     @mock.patch('django.utils.timezone.now')
     def test_parse_timestamp_duration(self, mock_now):
-        '''Tests parsing a valid ISO duration.'''
+        """Tests parsing a valid ISO duration."""
         mock_now.return_value = datetime.datetime(2015, 1, 1, 10, tzinfo=timezone.utc)
         self.assertEqual(parse_util.parse_timestamp('PT3H0M0S'), datetime.datetime(2015, 1, 1, 7, tzinfo=timezone.utc))
 
     def test_parse_timestamp_datetime(self):
-        '''Tests parsing a valid ISO datetime.'''
+        """Tests parsing a valid ISO datetime."""
         self.assertEqual(parse_util.parse_timestamp('2015-01-01T00:00:00Z'),
                          datetime.datetime(2015, 1, 1, tzinfo=timezone.utc))


### PR DESCRIPTION
- Removed regex pattern for validating date formats with json schema and instead use our built-in parsing so the validation is more robust.
- Updated unit tests to use full time stamps.
- Changed parse util to use a more standard ValueError instead of a custom ParseError to make caller code simpler.