### PR TITLE
Issue 604 - Need the ability to filter out inactive jobs

### DIFF
--- a/scale/docs/rest/job_type.rst
+++ b/scale/docs/rest/job_type.rst
@@ -36,8 +36,11 @@ These services provide access to information about job types.
 | category           | String            | Optional | Return only job types with a given category.                        |
 |                    |                   |          | Duplicate it to filter by multiple values.                          |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
-| is_operational     | String            | Optional | Return only job types that are operational (True) or still in a     |
-|                    |                   |          | research & development (R&D) phase (False).                         |
+| is_active          | Boolean           | Optional | Return only job types that are active (True) or inactive (False).   |
+|                    |                   |          | Defaults to only active job types (True).                           |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| is_operational     | Boolean           | Optional | Return only job types that are operational (True) or still in a     |
+|                    |                   |          | research & development (R&D) phase (False). Defaults to all.        |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | order              | String            | Optional | One or more fields to use when ordering the results.                |
 |                    |                   |          | Duplicate it to multi-sort, (ex: order=name&order=version).         |

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1763,7 +1763,8 @@ class JobTypeManager(models.Manager):
 
         return JobType.objects.get(name='scale-clock', version='1.0')
 
-    def get_job_types(self, started=None, ended=None, names=None, categories=None, is_operational=None, order=None):
+    def get_job_types(self, started=None, ended=None, names=None, categories=None, is_active=True, is_operational=None,
+                      order=None):
         """Returns a list of job types within the given time range.
 
         :param started: Query job types updated after this amount of time.
@@ -1774,6 +1775,8 @@ class JobTypeManager(models.Manager):
         :type names: [string]
         :param categories: Query jobs of the type associated with the category.
         :type categories: [string]
+        :param is_active: Query job types that are actively available for use.
+        :type is_active: bool
         :param is_operational: Query job types that are operational or research phase.
         :type is_operational: bool
         :param order: A list of fields to control the sort order.
@@ -1796,6 +1799,8 @@ class JobTypeManager(models.Manager):
             job_types = job_types.filter(name__in=names)
         if categories:
             job_types = job_types.filter(category__in=categories)
+        if is_active is not None:
+            job_types = job_types.filter(is_active=is_active)
         if is_operational is not None:
             job_types = job_types.filter(is_operational=is_operational)
 

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -544,6 +544,7 @@ class TestJobTypesView(TestCase):
         self.error = error_test_utils.create_error()
         self.job_type1 = job_test_utils.create_job_type(priority=2, mem=1.0, max_scheduled=1)
         self.job_type2 = job_test_utils.create_job_type(priority=1, mem=2.0, is_operational=False)
+        self.job_type3 = job_test_utils.create_job_type(priority=1, mem=2.0, is_active=False)
 
     def test_successful(self):
         """Tests successfully calling the get all job types view."""
@@ -575,6 +576,7 @@ class TestJobTypesView(TestCase):
 
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['id'], self.job_type1.id)
         self.assertEqual(result['results'][0]['name'], self.job_type1.name)
 
     def test_category(self):
@@ -586,7 +588,20 @@ class TestJobTypesView(TestCase):
 
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['id'], self.job_type1.id)
         self.assertEqual(result['results'][0]['category'], self.job_type1.category)
+
+    def test_is_active(self):
+        """Tests successfully calling the job types view filtered by inactive state."""
+
+        url = rest_util.get_url('/job-types/?is_active=false')
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['id'], self.job_type3.id)
+        self.assertEqual(result['results'][0]['is_active'], self.job_type3.is_active)
 
     def test_is_operational(self):
         """Tests successfully calling the job types view filtered by operational state."""
@@ -597,6 +612,7 @@ class TestJobTypesView(TestCase):
 
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['id'], self.job_type2.id)
         self.assertEqual(result['results'][0]['is_operational'], self.job_type2.is_operational)
 
     def test_sorting(self):
@@ -608,6 +624,7 @@ class TestJobTypesView(TestCase):
 
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 2)
+        self.assertEqual(result['results'][0]['id'], self.job_type2.id)
         self.assertEqual(result['results'][0]['name'], self.job_type2.name)
         self.assertEqual(result['results'][0]['version'], self.job_type2.version)
 
@@ -620,6 +637,7 @@ class TestJobTypesView(TestCase):
 
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 2)
+        self.assertEqual(result['results'][0]['id'], self.job_type2.id)
         self.assertEqual(result['results'][0]['name'], self.job_type2.name)
         self.assertEqual(result['results'][0]['version'], self.job_type2.version)
 

--- a/scale/job/test/utils.py
+++ b/scale/job/test/utils.py
@@ -156,8 +156,8 @@ def create_job_exe(job_type=None, job=None, status='RUNNING', configuration=None
 
 
 def create_job_type(name=None, version=None, category=None, interface=None, priority=50, timeout=3600, max_tries=3,
-                    max_scheduled=None, cpus=1.0, mem=1.0, disk=1.0, error_mapping=None, is_operational=True,
-                    trigger_rule=None):
+                    max_scheduled=None, cpus=1.0, mem=1.0, disk=1.0, error_mapping=None, is_active=True,
+                    is_operational=True, trigger_rule=None):
     """Creates a job type model for unit testing
 
     :returns: The job type model
@@ -199,7 +199,7 @@ def create_job_type(name=None, version=None, category=None, interface=None, prio
     job_type = JobType.objects.create(name=name, version=version, category=category, interface=interface,
                                       priority=priority, timeout=timeout, max_tries=max_tries,
                                       max_scheduled=max_scheduled, cpus_required=cpus, mem_required=mem,
-                                      disk_out_const_required=disk, error_mapping=error_mapping,
+                                      disk_out_const_required=disk, error_mapping=error_mapping, is_active=is_active,
                                       is_operational=is_operational, trigger_rule=trigger_rule)
     JobTypeRevision.objects.create_job_type_revision(job_type)
     return job_type

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -52,11 +52,12 @@ class JobTypesView(ListCreateAPIView):
 
         names = rest_util.parse_string_list(request, 'name', required=False)
         categories = rest_util.parse_string_list(request, 'category', required=False)
+        is_active = rest_util.parse_bool(request, 'is_active', default_value=True)
         is_operational = rest_util.parse_bool(request, 'is_operational', required=False)
         order = rest_util.parse_string_list(request, 'order', ['name', 'version'])
 
         job_types = JobType.objects.get_job_types(started=started, ended=ended, names=names, categories=categories,
-                                                  is_operational=is_operational, order=order)
+                                                  is_active=is_active, is_operational=is_operational, order=order)
 
         page = self.paginate_queryset(job_types)
         serializer = self.get_serializer(page, many=True)


### PR DESCRIPTION
- Updated /job-types/ API to only include active job types by default.
- Added a new is_active filter parameter.
- Updated tests and docs.