### PR TITLE
#569: Correct Django SCRIPT_NAME behind DCOS and Marathon LB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM centos:centos7
 MAINTAINER Scale Developers <https://github.com/ngageoint/scale>
 
 EXPOSE 80
-EXPOSE 8000
-EXPOSE 5051
 
 # recognized environment variables
 # CONFIG_URI
@@ -58,6 +56,7 @@ RUN yum install -y epel-release \
          gdal-python \
          geos \
          httpd \
+         mod_wsgi \
          nfs-utils \
          postgresql \
          protobuf \
@@ -76,6 +75,11 @@ RUN yum install -y epel-release \
  && curl -o /usr/bin/gosu -fsSL ${GOSU_URL} \
  && chmod +sx /usr/bin/gosu \
  && rm -f /etc/httpd/conf.d/welcome.conf \
+ && sed -i 's^User apache^User scale^g' /etc/httpd/conf/httpd.conf \
+ && sed -ri \
+		-e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
+		-e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \
+		/etc/httpd/conf/httpd.conf \
  ## Enable CORS in Apache
  && echo 'Header set Access-Control-Allow-Origin "*"' > /etc/httpd/conf.d/cors.conf \
  && yum clean all

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,8 @@ RUN yum install -y epel-release \
  && chmod +sx /usr/bin/gosu \
  && rm -f /etc/httpd/conf.d/welcome.conf \
  && sed -i 's^User apache^User scale^g' /etc/httpd/conf/httpd.conf \
+ # Patch access logs to show originating IP instead of reverse proxy.
+ && sed -i 's!LogFormat "%h!LogFormat "%{X-Forwarded-For}i %h!g' /etc/httpd/conf/httpd.conf \
  && sed -ri \
 		-e 's!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g' \
 		-e 's!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,9 +130,4 @@ RUN mkdir -p /var/log/scale /var/lib/scale-metrics /scale/input_data /scale/outp
 # finish the build
 RUN python manage.py collectstatic --noinput --settings=
 
-# Copy in webserver configuration file
-COPY dockerfiles/framework/scale/gunicorn.conf.py /opt/scale/
-
-CMD [ "/usr/bin/gunicorn", "-c", "gunicorn.conf.py", "scale.wsgi:application" ]
-
 ENTRYPOINT ["./entryPoint.sh"]

--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -160,7 +160,8 @@ def deploy_webserver(client, app_name, es_urls, db_host, db_port):
             "DCOS_SERVICE_SCHEME": "http",
             "DCOS_SERVICE_NAME": FRAMEWORK_NAME,
             "DCOS_SERVICE_PORT_INDEX": "0",
-            "HAPROXY_0_VHOST": vhost
+            "HAPROXY_0_VHOST": vhost,
+            "HAPROXY_0_BACKEND_HTTP_OPTIONS": "http-request set-header X-HAPROXY 1\n"
         },
         'healthChecks': [
             {

--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -61,7 +61,7 @@ def run(client):
     if DEPLOY_WEBSERVER.lower() == 'true':
         app_name = '%s-webserver' % FRAMEWORK_NAME
         webserver_port = deploy_webserver(client, app_name, es_urls, db_host, db_port)
-        print("WEBSERVER_ADDRESS=http://%s.marathon.mesos:%s/service/%s/" % (app_name, webserver_port, FRAMEWORK_NAME))
+        print("WEBSERVER_ADDRESS=http://%s.marathon.mesos:%s" % (app_name, webserver_port))
 
 
 def delete_marathon_app(client, app_name, fail_on_error=False):

--- a/dockerfiles/framework/scale/entryPoint.sh
+++ b/dockerfiles/framework/scale/entryPoint.sh
@@ -69,12 +69,6 @@ then
     python manage.py loaddata country_data.json
 fi
 
-if [[ "${DCOS_PACKAGE_FRAMEWORK_NAME}x" != "x"  && "${ENABLE_WEBSERVER}" != "true" ]]
-then
-    sed -i "s/framework.name\ =\ 'Scale'/framework.name\ =\ '"${DCOS_PACKAGE_FRAMEWORK_NAME}"'/" /opt/scale/scheduler/management/commands/scale_scheduler.py
-    sed -i "/framework.name/ a\ \ \ \ \ \ \ \ framework.webui_url = 'http://"${DCOS_PACKAGE_FRAMEWORK_NAME}".marathon.slave.mesos:"${PORT0}"/'" scheduler/management/commands/scale_scheduler.py
-fi
-
 # If ENABLE_WEBSERVER is set, we are running the container in web server mode.
 if [[ "${ENABLE_WEBSERVER}" == "true" ]]
 then

--- a/dockerfiles/framework/scale/entryPoint.sh
+++ b/dockerfiles/framework/scale/entryPoint.sh
@@ -83,7 +83,6 @@ then
     check_elastic
 
     gosu root sed -i 's^User apache^User scale^g' /etc/httpd/conf/httpd.conf
-    gosu root sed -i 's/\/SCALE/\/'${DCOS_PACKAGE_FRAMEWORK_NAME}'/' /etc/httpd/conf.d/scale.conf
     sed -i 's^/api^./api^' /opt/scale/ui/config/scaleConfig.json
     sed -i 's^/docs^./docs^' /opt/scale/ui/config/scaleConfig.json
     gosu root /usr/sbin/httpd

--- a/dockerfiles/framework/scale/entryPoint.sh
+++ b/dockerfiles/framework/scale/entryPoint.sh
@@ -82,12 +82,7 @@ then
     check_db
     check_elastic
 
-    gosu root sed -i 's^User apache^User scale^g' /etc/httpd/conf/httpd.conf
-    sed -i 's^/api^./api^' /opt/scale/ui/config/scaleConfig.json
-    sed -i 's^/docs^./docs^' /opt/scale/ui/config/scaleConfig.json
-    gosu root /usr/sbin/httpd
-
-    exec /usr/bin/gunicorn -c gunicorn.conf.py scale.wsgi:application
+    exec gosu root /usr/sbin/httpd -D FOREGROUND
 fi
 
 # Default fallback entrypoint that is used by scheduler and pre/post task.

--- a/dockerfiles/framework/scale/gunicorn.conf.py
+++ b/dockerfiles/framework/scale/gunicorn.conf.py
@@ -1,6 +1,0 @@
-import os
-
-bind = '0.0.0.0:8000'
-
-# Using GUnicorn recommended worker computation based on resources allocated
-workers = int(os.getenv('SCALE_WEBSERVER_CPU', 1)) * 2 + 1

--- a/dockerfiles/framework/scale/scale.conf
+++ b/dockerfiles/framework/scale/scale.conf
@@ -22,12 +22,18 @@ DocumentRoot "/opt/scale/ui/"
 
 WSGIDaemonProcess scale python-path=/opt/scale:/usr/lib/python2.7/site-packages processes=${SCALE_WEBSERVER_CPU} threads=4
 WSGIProcessGroup scale
+
 WSGIScriptAlias /service/${DCOS_PACKAGE_FRAMEWORK_NAME}/api /opt/scale/scale/wsgi.py
+WSGIScriptAlias /service/${DCOS_PACKAGE_FRAMEWORK_NAME}/admin /opt/scale/scale/wsgi.py/admin
+Alias /service/${DCOS_PACKAGE_FRAMEWORK_NAME}/static /opt/scale/static/
+Alias /service/${DCOS_PACKAGE_FRAMEWORK_NAME}/docs /opt/scale/docs/_build/html/
+Alias /service/${DCOS_PACKAGE_FRAMEWORK_NAME} /opt/scale/ui/
+
+
 WSGIScriptAlias /api /opt/scale/scale/wsgi.py
 WSGIScriptAlias /admin /opt/scale/scale/wsgi.py/admin
-
 Alias /docs /opt/scale/docs/_build/html/
 Alias /static /opt/scale/static/
-Alias /service/${DCOS_PACKAGE_FRAMEWORK_NAME}/static /opt/scale/static/
+
 
 

--- a/dockerfiles/framework/scale/scale.conf
+++ b/dockerfiles/framework/scale/scale.conf
@@ -3,12 +3,22 @@
 #######
 Alias /docs /opt/scale/docs/_build/html/
 Alias /static /opt/scale/static/
-Alias /service/SCALE/static /opt/scale/static/
+Alias /service/${DCOS_PACKAGE_FRAMEWORK_NAME}/static /opt/scale/static/
+
+<Location /service/${DCOS_PACKAGE_FRAMEWORK_NAME}/api>
+  ProxyPass http://localhost:8000/
+  ProxyPassReverse http://localhost:8000/
+  Require all granted
+
+  RequestHeader set X-SCRIPT-NAME "/service/${DCOS_PACKAGE_FRAMEWORK_NAME}/api"
+</Location>
 
 <Location /api>
   ProxyPass http://localhost:8000/
   ProxyPassReverse http://localhost:8000/
   Require all granted
+
+  RequestHeader set SCRIPT_NAME "/api"
 </Location>
 
 <Location /admin>

--- a/dockerfiles/framework/scale/scale.conf
+++ b/dockerfiles/framework/scale/scale.conf
@@ -1,34 +1,5 @@
-#######
-# scale config specifics
-#######
-Alias /docs /opt/scale/docs/_build/html/
-Alias /static /opt/scale/static/
-Alias /service/${DCOS_PACKAGE_FRAMEWORK_NAME}/static /opt/scale/static/
+DocumentRoot "/opt/scale/ui/"
 
-<Location /service/${DCOS_PACKAGE_FRAMEWORK_NAME}/api>
-  ProxyPass http://localhost:8000/
-  ProxyPassReverse http://localhost:8000/
-  Require all granted
-
-  RequestHeader set X-SCRIPT-NAME "/service/${DCOS_PACKAGE_FRAMEWORK_NAME}/api"
-</Location>
-
-<Location /api>
-  ProxyPass http://localhost:8000/
-  ProxyPassReverse http://localhost:8000/
-  Require all granted
-
-  RequestHeader set SCRIPT_NAME "/api"
-</Location>
-
-<Location /admin>
-  ProxyPass http://localhost:8000/admin
-  ProxyPassReverse http://localhost:8000/admin
-  Require all granted
-</Location>
-
-#DocumentRoot "/opt/scale/ui/"
-Alias / /opt/scale/ui/
 <Directory "/opt/scale/ui">
   Options Indexes FollowSymLinks
   Require all granted
@@ -42,3 +13,21 @@ Alias / /opt/scale/ui/
   Options Indexes FollowSymLinks
   Require all granted
 </Directory>
+
+<Directory "/opt/scale/scale">
+  <Files wsgi.py>
+    Require all granted
+  </Files>
+</Directory>
+
+WSGIDaemonProcess scale python-path=/opt/scale:/usr/lib/python2.7/site-packages processes=${SCALE_WEBSERVER_CPU} threads=4
+WSGIProcessGroup scale
+WSGIScriptAlias /service/${DCOS_PACKAGE_FRAMEWORK_NAME}/api /opt/scale/scale/wsgi.py
+WSGIScriptAlias /api /opt/scale/scale/wsgi.py
+WSGIScriptAlias /admin /opt/scale/scale/wsgi.py/admin
+
+Alias /docs /opt/scale/docs/_build/html/
+Alias /static /opt/scale/static/
+Alias /service/${DCOS_PACKAGE_FRAMEWORK_NAME}/static /opt/scale/static/
+
+

--- a/scale-ui/config/scaleConfig.json
+++ b/scale-ui/config/scaleConfig.json
@@ -199,9 +199,9 @@
         "activityIconCode": "f110",
 
         "urls": {
-            "apiPrefix": "/api/v4/",
+            "apiPrefix": "./api/v4/",
             "overrides": {},
-            "documentation": "/docs"
+            "documentation": "./docs"
         },
 
         "defaultGaugeWidth": 160,

--- a/scale/pip/prod_linux.txt
+++ b/scale/pip/prod_linux.txt
@@ -8,7 +8,6 @@ django-filter>=0.7,<=0.8
 djangorestframework>=3.3.0,<3.4.0
 djorm-ext-pgjson>=0.2,<0.3
 elasticsearch>=2.4.0,<2.5
-gunicorn>=18.0.0,<19.0.0
 jsonschema>=2.3,<2.4
 kazoo>=2.2.1
 mesos.interface>=0.21.1,<=0.25

--- a/scale/scale/local_settings_docker.py
+++ b/scale/scale/local_settings_docker.py
@@ -87,3 +87,7 @@ if MARATHON_PASSED_IMAGE:
 
 # The location of the config file containing Docker credentials
 CONFIG_URI = os.environ.get('CONFIG_URI', CONFIG_URI)
+
+# Logging configuration
+LOGGING = LOG_CONSOLE_INFO
+

--- a/scale/scale/local_settings_docker.py
+++ b/scale/scale/local_settings_docker.py
@@ -11,8 +11,8 @@ SECRET_KEY = os.environ.get('SCALE_SECRET_KEY', INSECURE_DEFAULT_KEY)
 DEBUG = bool(os.environ.get('SCALE_DEBUG', False))
 TEMPLATE_DEBUG = DEBUG
 
-# Set the external URL context here
-FORCE_SCRIPT_NAME = os.environ.get('SCALE_API_URL', '/api')
+# Set the external URL context here, default to using SCRIPT_NAME passed by reverse proxy.
+FORCE_SCRIPT_NAME = os.environ.get('SCALE_API_URL', None)
 USE_X_FORWARDED_HOST = True
 
 ALLOWED_HOSTS = ['*']
@@ -20,8 +20,9 @@ override_hosts = os.environ.get('SCALE_ALLOWED_HOSTS')
 if override_hosts:
     ALLOWED_HOSTS = override_hosts.split(',')
 
+FRAMEWORK_NAME = os.environ.get('DCOS_PACKAGE_FRAMEWORK_NAME', 'scale')
 STATIC_ROOT = os.environ.get('SCALE_STATIC_ROOT', 'static/')
-STATIC_URL = os.environ.get('SCALE_STATIC_URL', '/static/')
+STATIC_URL = os.environ.get('SCALE_STATIC_URL', '/service/%s/static/' % FRAMEWORK_NAME)
 
 LOGGING_ADDRESS = os.environ.get('SCALE_LOGGING_ADDRESS', LOGGING_ADDRESS)
 ELASTICSEARCH_URLS = os.environ.get('SCALE_ELASTICSEARCH_URLS', ELASTICSEARCH_URLS)

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -101,6 +101,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'util.middleware.ExceptionLoggingMiddleware',
 )
 
 REST_FRAMEWORK = {

--- a/scale/scale/wsgi.py
+++ b/scale/scale/wsgi.py
@@ -11,4 +11,15 @@ import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "scale.local_settings")
 
 from django.core.wsgi import get_wsgi_application
-application = get_wsgi_application()
+
+_application = get_wsgi_application()
+
+def application(environ, start_response):
+    script_name = environ.get('HTTP_X_SCRIPT_NAME', '')
+    if script_name:
+        environ['SCRIPT_NAME'] = script_name
+        path_info = environ['PATH_INFO']
+        if path_info.startswith(script_name):
+            environ['PATH_INFO'] = path_info[len(script_name):]
+
+    return _application(environ, start_response)

--- a/scale/scale/wsgi.py
+++ b/scale/scale/wsgi.py
@@ -12,14 +12,5 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "scale.local_settings")
 
 from django.core.wsgi import get_wsgi_application
 
-_application = get_wsgi_application()
+application = get_wsgi_application()
 
-def application(environ, start_response):
-    script_name = environ.get('HTTP_X_SCRIPT_NAME', '')
-    if script_name:
-        environ['SCRIPT_NAME'] = script_name
-        path_info = environ['PATH_INFO']
-        if path_info.startswith(script_name):
-            environ['PATH_INFO'] = path_info[len(script_name):]
-
-    return _application(environ, start_response)

--- a/scale/scale/wsgi.py
+++ b/scale/scale/wsgi.py
@@ -12,5 +12,18 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "scale.local_settings")
 
 from django.core.wsgi import get_wsgi_application
 
-application = get_wsgi_application()
+_application = get_wsgi_application()
 
+def application(environ, start_response):
+    framework_name = os.environ.get('DCOS_PACKAGE_FRAMEWORK_NAME', 'scale')
+
+    # If we are running behind Marathon LB we must set the HTTP_X_HAPROXY header to
+    # configure the API to use the direct access context. Otherwise it assumes reverse proxy
+    # behind DCOS Admin Router (Nginx)
+    behind_haproxy = environ.get('HTTP_X_HAPROXY')
+    if behind_haproxy:
+        environ['SCRIPT_NAME'] = '/api'
+    else:
+        environ['SCRIPT_NAME'] = '/service/%s/api' % framework_name
+
+    return _application(environ, start_response)

--- a/scale/scheduler/management/commands/scale_scheduler.py
+++ b/scale/scheduler/management/commands/scale_scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import logging
+import os
 import signal
 import sys
 
@@ -74,7 +75,17 @@ class Command(BaseCommand):
         framework = mesos_pb2.FrameworkInfo()
         framework.user = ''  # Have Mesos fill in the current user.
         framework.name = 'Scale'
+        framework_name = os.getenv('DCOS_PACKAGE_FRAMEWORK_NAME')
 
+        if framework_name:
+            framework.name = framework_name
+            framework.webui_url = 'http://%s.marathon.slave.mesos:%s/services/%s/' % (
+                framework_name,
+                os.getenv('PORT0'),
+                framework_name,
+            )
+        "/service/${DCOS_PACKAGE_FRAMEWORK_NAME}/'"
+        scheduler / management / commands / scale_scheduler.py
         logger.info('Connecting to Mesos master at %s', mesos_master)
 
         # TODO(vinod): Make checkpointing the default when it is default on the slave.

--- a/scale/util/middleware.py
+++ b/scale/util/middleware.py
@@ -1,8 +1,17 @@
-'''Common middleware classes used in the web server configuration.'''
+"""Common middleware classes used in the web server configuration."""
+
+import logging
+
+
+class ExceptionLoggingMiddleware(object):
+
+    def process_exception(self, request, exception):
+        """Logs exceptions during service calls."""
+        logging.exception('Exception handling request for %s.' % request.path)
 
 
 class MultipleProxyMiddleware(object):
-    '''Rewrites the proxy headers so that only the first the proxy forwarded host is used.
+    """Rewrites the proxy headers so that only the first the proxy forwarded host is used.
 
     By default Django, does not support forwarding the server host name when sitting behind multiple proxy servers.
     Without this middleware the host name returned to the client will contain both proxy names delimited by a comma,
@@ -11,7 +20,7 @@ class MultipleProxyMiddleware(object):
     users however, we want to always take that name instead.
 
     Code derived from the Django documentation for "Request and response objects", HttpRequest.get_host() method.
-    '''
+    """
     FORWARDED_FOR_FIELDS = [
         'HTTP_X_FORWARDED_FOR',
         'HTTP_X_FORWARDED_HOST',
@@ -19,7 +28,7 @@ class MultipleProxyMiddleware(object):
     ]
 
     def process_request(self, request):
-        '''Rewrite forwarded host headers to support multiple proxy servers.'''
+        """Rewrite forwarded host headers to support multiple proxy servers."""
         for field in self.FORWARDED_FOR_FIELDS:
             if field in request.META:
                 if ',' in request.META[field]:


### PR DESCRIPTION
Django uses WSGI SCRIPT_NAME environment values to identify what the context it is running within. Optimally, we would have 2 contexts configured (/service/scale/api and /api). The first would support DCOS Admin UI and the 2nd Marathon LB. Unfortunately, there is no way to get DCOS Admin to reverse proxy to the /service/scale endpoint as it is explicltly set to only proxy to the root context.

The workaround is to set the default behavior of Scale webserver to operate at `/scale/service/api` and use a header injected by Marathon LB (haProxy) to tell the Scale WSGI connector to operate at `/api`. This logic can be found in `scale/wsgi.py`

This pull request also removes gunicorn, as configuration of WSGI environments is significantly complicated when there is a second reverse proxy in front of the WSGI server. Apache is now directly launching Django with mod_wsgi running in daemonized mode.

The biggest improvement of using Apache is that we have a single unified source of logs, including access and error logs. Exception middleware has also been added that will log any exceptions to stderr. This was completely lacking previously.