### PR TITLE
#617: Reload configuration of S3 monitor during live strike execution.

### DIFF
--- a/scale/ingest/strike/monitors/s3_monitor.py
+++ b/scale/ingest/strike/monitors/s3_monitor.py
@@ -68,11 +68,15 @@ class S3Monitor(Monitor):
 
         logger.info('Running experimental S3 Strike processor')
 
-        with SQSClient(self._credentials, self._region_name) as client:
-            queue = client.get_queue_by_name(self._sqs_name)
+        # Loop endlessly polling SQS queue
+        while self._running:
+            # Between each pass over the SQS, refresh configuration from database in case of credential changes.
+            # This eliminates the need to stop and restart a Strike job to pick up configuration updates.
+            self.reload_configuration()
 
-            # Loop endlessly polling SQS queue
-            while self._running:
+            with SQSClient(self._credentials, self._region_name) as client:
+                queue = client.get_queue_by_name(self._sqs_name)
+
                 # For each new file we receive a notification about:
                 logger.info('Beginning long-poll against queue with wait time of %s seconds.' % self.wait_time)
                 messages = queue.receive_messages(MaxNumberOfMessages=self.messages_per_request,


### PR DESCRIPTION
Update to support reloading Strike configuration following each pass over the SQS. If there is a message backlog, all messages will be processed before the configuration is reloaded.