### PR TITLE
#630 and #576: Docker labels and release updates.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-# scale dockerfile
 FROM centos:centos7
 MAINTAINER Scale Developers <https://github.com/ngageoint/scale>
+
+LABEL \
+    VERSION="4.0.0-snapshot" \
+    RUN="docker run -d geoint/scale scale_scheduler" \
+    SOURCE="https://github.com/ngageoint/scale" \
+    DESCRIPTION="Containerized processing framework for algorithms focused on remote sensing" \
+    CLASSIFICATION="UNCLASSIFIED"
 
 EXPOSE 80
 

--- a/dockerfiles/logstash-elastic-ha/Dockerfile
+++ b/dockerfiles/logstash-elastic-ha/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Scale Developers <https://github.com/ngageoint/scale>
 
 LABEL \
     VERSION="4.0.0-snapshot" \
-    RUN="docker run -d geoint/scale scale_scheduler" \
+    RUN="docker run -e ELASTICSEARCH_URLS=http://elastic:9200 -p 8000:8000 -p 80:80 geoint/logstash-elastic-ha" \
     SOURCE="https://github.com/ngageoint/scale/tree/master/dockerfiles/logstash-elastic-ha" \
     DESCRIPTION="Log aggregator, formatter and Elasticsearch forwarder for Scale jobs" \
     CLASSIFICATION="UNCLASSIFIED"

--- a/dockerfiles/logstash-elastic-ha/Dockerfile
+++ b/dockerfiles/logstash-elastic-ha/Dockerfile
@@ -1,5 +1,12 @@
 FROM logstash:2.4
-MAINTAINER Jonathan Meyer <jon@gisjedi.com>
+MAINTAINER Scale Developers <https://github.com/ngageoint/scale>
+
+LABEL \
+    VERSION="4.0.0-snapshot" \
+    RUN="docker run -d geoint/scale scale_scheduler" \
+    SOURCE="https://github.com/ngageoint/scale/tree/master/dockerfiles/logstash-elastic-ha" \
+    DESCRIPTION="Log aggregator, formatter and Elasticsearch forwarder for Scale jobs" \
+    CLASSIFICATION="UNCLASSIFIED"
 
 RUN apt-get update && apt-get install -y supervisor python-requests
 

--- a/generate-release.sh
+++ b/generate-release.sh
@@ -35,12 +35,15 @@ echo -e "\nChange the revision on master"
 tput sgr0
 sed -i "" -e "s/^VERSION = version_info_t.*$/VERSION = version_info_t($1, $2, $3, '-snapshot')/" scale/scale/__init__.py
 sed -i "" -e "s/^VERSION = version_info_t.*$/VERSION = version_info_t($1, $2, $3, '-snapshot___BUILDNUM___')/" scale/scale/__init__.py.template
+sed -i "" -e 's/VERSION="[^"]*"/VERSION="'$1'.'$2'.'$3'-snapshot"/g' Dockerfile
+sed -i "" -e 's/VERSION="[^"]*"/VERSION="'$1'.'$2'.'$3'-snapshot"/g' dockerfiles/logstash-elastic-ha/Dockerfile
 grep "VERSION = " scale/scale/__init__.py scale/scale/__init__.py.template
 
 tput setaf 2
-echo -e "\nCommit the change"
+echo -e "\nCommit and push the change"
 tput sgr0
-git commit -a -m "Update snapshot revision to $vestring"
+git commit -a -m "Update snapshot revision to $verstring"
+git push origin HEAD
 
 tput setaf 2
 echo -e "\nDetach the head"
@@ -52,12 +55,14 @@ echo -e "\nChange the revision on the release"
 tput sgr0
 sed -i "" -e "s/^VERSION = version_info_t.*$/VERSION = version_info_t($1, $2, $3, '')/" scale/scale/__init__.py
 sed -i "" -e "s/^VERSION = version_info_t.*$/VERSION = version_info_t($1, $2, $3, '___BUILDNUM___')/" scale/scale/__init__.py.template
+sed -i "" -e 's/VERSION="[^"]*"/VERSION="'$1'.'$2'.'$3'"/g' Dockerfile
+sed -i "" -e 's/VERSION="[^"]*"/VERSION="'$1'.'$2'.'$3'"/g' dockerfiles/logstash-elastic-ha/Dockerfile
 grep "VERSION = " scale/scale/__init__.py scale/scale/__init__.py.template
 
 tput setaf 2
 echo -e "\nCommit the change"
 tput sgr0
-git commit -a -m "Update snapshot revision to $vestring"
+git commit -a -m "Update version values for release $verstring"
 
 tput setaf 2
 echo -e "\nTag the release"

--- a/generate-release.sh
+++ b/generate-release.sh
@@ -38,6 +38,7 @@ sed -i "" -e "s/^VERSION = version_info_t.*$/VERSION = version_info_t($1, $2, $3
 sed -i "" -e 's/VERSION="[^"]*"/VERSION="'$1'.'$2'.'$3'-snapshot"/g' Dockerfile
 sed -i "" -e 's/VERSION="[^"]*"/VERSION="'$1'.'$2'.'$3'-snapshot"/g' dockerfiles/logstash-elastic-ha/Dockerfile
 grep "VERSION = " scale/scale/__init__.py scale/scale/__init__.py.template
+grep "VERSION=" Dockerfile dockerfiles/logstash-elastic-ha/Dockerfile
 
 tput setaf 2
 echo -e "\nCommit and push the change"
@@ -58,6 +59,7 @@ sed -i "" -e "s/^VERSION = version_info_t.*$/VERSION = version_info_t($1, $2, $3
 sed -i "" -e 's/VERSION="[^"]*"/VERSION="'$1'.'$2'.'$3'"/g' Dockerfile
 sed -i "" -e 's/VERSION="[^"]*"/VERSION="'$1'.'$2'.'$3'"/g' dockerfiles/logstash-elastic-ha/Dockerfile
 grep "VERSION = " scale/scale/__init__.py scale/scale/__init__.py.template
+grep "VERSION=" Dockerfile dockerfiles/logstash-elastic-ha/Dockerfile
 
 tput setaf 2
 echo -e "\nCommit the change"


### PR DESCRIPTION
Added labels to both main Scale and Logstash HA images to satisfy the requirements outlined in #630. As updates were also needed to `generate-release.sh` to accomodate, fixes were applied there to address #576. There were typos referencing the version environment variable and a missing push to apply the snapshot version to the Python environment.