### PR TITLE
#615 - S3 strike and broker configuration hardening

### DIFF
--- a/scale/storage/brokers/s3_broker.py
+++ b/scale/storage/brokers/s3_broker.py
@@ -72,7 +72,8 @@ class S3Broker(Broker):
         # TODO Change credentials to use an encrypted store key reference
         self._credentials = AWSClient.instantiate_credentials_from_config(config)
 
-        if 'host_path' in config:
+        # Ensure empty or white-space filled host_paths do not cause mounts to be applied
+        if 'host_path' in config and len(config['host_path'].strip()):
             volume = BrokerVolume(None, config['host_path'])
             volume.host = True
             self._volume = volume

--- a/scale/storage/test/brokers/test_s3_broker.py
+++ b/scale/storage/test/brokers/test_s3_broker.py
@@ -137,6 +137,26 @@ class TestS3Broker(TestCase):
         self.assertEqual(broker._credentials.access_key_id, 'ABC')
         self.assertEqual(broker._credentials.secret_access_key, '123')
 
+    def test_load_configuration_whitespace_filled_host_path(self):
+        """Tests loading a valid configuration successfully while purging empty host_path value"""
+
+        json_config = {
+            'type': S3Broker().broker_type,
+            'bucket_name': 'my_bucket.domain.com',
+            'host_path': '  ',
+            'credentials': {
+                'access_key_id': 'ABC',
+                'secret_access_key': '123',
+            },
+        }
+        broker = S3Broker()
+        broker.load_configuration(json_config)
+
+        self.assertEqual(broker._bucket_name, 'my_bucket.domain.com')
+        self.assertIsNone(broker._volume)
+        self.assertEqual(broker._credentials.access_key_id, 'ABC')
+        self.assertEqual(broker._credentials.secret_access_key, '123')
+
     @patch('storage.brokers.s3_broker.S3Client')
     def test_move_files(self, mock_client_class):
         """Tests moving files successfully"""

--- a/scale/util/aws.py
+++ b/scale/util/aws.py
@@ -62,9 +62,12 @@ class AWSClient(object):
     def instantiate_credentials_from_config(config):
         """Extract credential keys from configuration and return instantiated credential object
 
+        If values provided in the `access_key_id` or `secret_access_key` keys of `credentials` configuration object are
+        empty, None will be returned. In this case, role-based authentication should be attempted.
+
         :param config: Resource specific configuration
         :type config: :class:`botocore.client.Config`
-        :return: instantiated credential object
+        :return: instantiated credential object or None if keys provided were empty
         :rtype: :class:`util.aws.AWSCredentials`
 
         :raises :class:`util.exceptions.InvalidAWSCredentials`: If the credentials provided are incomplete.
@@ -80,7 +83,7 @@ class AWSClient(object):
             secret_key = credentials_dict['secret_access_key'].strip()
 
             # If either Access Key or Secret Access Key are empty, fail-over to role-based auth.
-            # TODO: This should be removed once the UI has been improved to prune unset values from requests.
+            # TODO: This should be changed to also raise as above, once the UI has been improved to prune unset values.
             if not len(access_key) or not len(secret_key):
                 return None
 

--- a/scale/util/aws.py
+++ b/scale/util/aws.py
@@ -60,13 +60,31 @@ class AWSClient(object):
 
     @staticmethod
     def instantiate_credentials_from_config(config):
+        """Extract credential keys from configuration and return instantiated credential object
+
+        :param config: Resource specific configuration
+        :type config: :class:`botocore.client.Config`
+        :return: instantiated credential object
+        :rtype: :class:`util.aws.AWSCredentials`
+
+        :raises :class:`util.exceptions.InvalidAWSCredentials`: If the credentials provided are incomplete.
+        """
         if 'credentials' in config and config['credentials']:
             credentials_dict = config['credentials']
-            if 'access_key_id' not in credentials_dict or not credentials_dict['access_key_id']:
+            if 'access_key_id' not in credentials_dict:
                 raise InvalidAWSCredentials('"credentials" requires "access_key_id" to be populated')
-            if 'secret_access_key' not in credentials_dict or not credentials_dict['secret_access_key']:
+            if 'secret_access_key' not in credentials_dict:
                 raise InvalidAWSCredentials('"credentials" requires "secret_access_key" to be populated')
-            return AWSCredentials(credentials_dict['access_key_id'], credentials_dict['secret_access_key'])
+
+            access_key = credentials_dict['access_key_id'].strip()
+            secret_key = credentials_dict['secret_access_key'].strip()
+
+            # If either Access Key or Secret Access Key are empty, fail-over to role-based auth.
+            # TODO: This should be removed once the UI has been improved to prune unset values from requests.
+            if not len(access_key) or not len(secret_key):
+                return None
+
+            return AWSCredentials(access_key, secret_key)
 
 
 class SQSClient(AWSClient):

--- a/scale/util/test/test_aws.py
+++ b/scale/util/test/test_aws.py
@@ -1,0 +1,46 @@
+from __future__ import unicode_literals
+
+import datetime
+
+import django
+import django.utils.timezone as timezone
+import mock
+from django.test import TestCase
+
+from util.aws import AWSClient
+from util.exceptions import InvalidAWSCredentials
+
+
+class TestAws(TestCase):
+
+    def setUp(self):
+        django.setup()
+
+    def test_instantiate_credentials_from_config(self):
+        """Tests instantiating AWS Credentials from a valid configuration."""
+        config = { 'credentials': { 'access_key_id': 'ACCESSKEY', 'secret_access_key': 'SECRETKEY'}}
+        credential = AWSClient.instantiate_credentials_from_config(config)
+        self.assertEqual(credential.access_key_id, 'ACCESSKEY')
+        self.assertEqual(credential.secret_access_key, 'SECRETKEY')
+
+    def test_instantiate_credentials_from_config_missing_access_key(self):
+        """Tests instantiating AWS Credentials from a configuration missing access key."""
+        config = { 'credentials': { 'secret_access_key': 'SECRETKEY' }}
+        with self.assertRaises(InvalidAWSCredentials):
+            AWSClient.instantiate_credentials_from_config(config)
+
+    def test_instantiate_credentials_from_config_missing_secret_key(self):
+        """Tests instantiating AWS Credentials from a configuration missing secret key."""
+        config = { 'credentials': { 'access_key_id': 'ACCESSKEY' }}
+        with self.assertRaises(InvalidAWSCredentials):
+            AWSClient.instantiate_credentials_from_config(config)
+
+    def test_instantiate_credentials_from_config_empty_access_key(self):
+        """Tests instantiating AWS Credentials from a configuration with an empty access key."""
+        config = { 'credentials': { 'access_key_id': '', 'secret_access_key': 'SECRETKEY' }}
+        self.assertIsNone(AWSClient.instantiate_credentials_from_config(config))
+
+    def test_instantiate_credentials_from_config_empty_secret_key(self):
+        """Tests instantiating AWS Credentials from a configuration with an empty secret key."""
+        config = { 'credentials': { 'access_key_id': 'ACCESSKEY', 'secret_access_key': ' ' }}
+        self.assertIsNone(AWSClient.instantiate_credentials_from_config(config))

--- a/scale/util/test/test_aws.py
+++ b/scale/util/test/test_aws.py
@@ -1,10 +1,6 @@
 from __future__ import unicode_literals
 
-import datetime
-
 import django
-import django.utils.timezone as timezone
-import mock
 from django.test import TestCase
 
 from util.aws import AWSClient


### PR DESCRIPTION
Handling for a number of whitespace filled values provided via UI. host_path, credentials.access_key_id and credentials.secret_access_key now all will probably be handled when only containing whitespace.