### PR TITLE
Issue 637 - Fix Ingest Status REST API Slowness

### DIFF
--- a/scale/ingest/migrations/0006_auto_20161202_1621.py
+++ b/scale/ingest/migrations/0006_auto_20161202_1621.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ingest', '0005_auto_20160728_1243'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ingest',
+            name='data_ended',
+            field=models.DateTimeField(db_index=True, null=True, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='ingest',
+            name='data_started',
+            field=models.DateTimeField(db_index=True, null=True, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='ingest',
+            name='ingest_ended',
+            field=models.DateTimeField(db_index=True, null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/scale/ingest/migrations/0007_auto_20161206_1329.py
+++ b/scale/ingest/migrations/0007_auto_20161206_1329.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ingest', '0006_auto_20161202_1621'),
+        ('source', '0001_initial'),
+    ]
+
+    def populate_ingest_data_time(apps, schema_editor):
+        # Go through all of the parsed source file models and populate data time for ingest models
+        SourceFile = apps.get_model('source', 'SourceFile')
+        Ingest = apps.get_model('ingest', 'Ingest')
+
+        total_count = SourceFile.objects.filter(is_parsed=True).count()
+        if not total_count:
+            return
+
+        print('\nUpdating ingests for source files: %i' % total_count)
+        done_count = 0
+        batch_size = 500
+        while done_count < total_count:
+            batch_end = done_count + batch_size
+
+            for src_file in SourceFile.objects.filter(is_parsed=True).order_by('id')[done_count:batch_end]:
+                Ingest.objects.filter(source_file_id=src_file.id).update(data_started=src_file.data_started,
+                                                                         data_ended=src_file.data_ended)
+                done_count += 1
+
+            percent = (float(done_count) / float(total_count)) * 100.00
+            print('Progress: %i/%i (%.2f%%)' % (done_count, total_count, percent))
+        print ('Migration finished.')
+
+    operations = [
+        migrations.RunPython(populate_ingest_data_time),
+    ]

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -310,6 +310,10 @@ class Ingest(models.Model):
     :type ingest_ended: :class:`django.db.models.DateTimeField`
     :keyword source_file: A reference to the source file that was stored by this ingest
     :type source_file: :class:`django.db.models.ForeignKey`
+    :keyword data_started: The start time of the data in this source file
+    :type data_started: :class:`django.db.models.DateTimeField`
+    :keyword data_ended: The end time of the data in this source file
+    :type data_ended: :class:`django.db.models.DateTimeField`
 
     :keyword created: When the ingest model was created
     :type created: :class:`django.db.models.DateTimeField`
@@ -346,8 +350,11 @@ class Ingest(models.Model):
 
     job = models.ForeignKey('job.Job', blank=True, null=True)
     ingest_started = models.DateTimeField(blank=True, null=True)
-    ingest_ended = models.DateTimeField(blank=True, null=True)
+    ingest_ended = models.DateTimeField(blank=True, null=True, db_index=True)
+
     source_file = models.ForeignKey('source.SourceFile', blank=True, null=True)
+    data_started = models.DateTimeField(blank=True, null=True, db_index=True)
+    data_ended = models.DateTimeField(blank=True, null=True, db_index=True)
 
     created = models.DateTimeField(auto_now_add=True)
     last_modified = models.DateTimeField(auto_now=True)

--- a/scale/ingest/test/utils.py
+++ b/scale/ingest/test/utils.py
@@ -36,7 +36,8 @@ def create_ingest(file_name='test.txt', status='TRANSFERRING', transfer_started=
     return Ingest.objects.create(file_name=file_name, file_size=source_file.file_size, status=status, job=job,
                                  bytes_transferred=source_file.file_size, transfer_started=transfer_started,
                                  transfer_ended=transfer_ended, media_type='text/plain', ingest_started=ingest_started,
-                                 ingest_ended=ingest_ended, workspace=workspace, strike=strike, source_file=source_file)
+                                 ingest_ended=ingest_ended, data_started=data_started, data_ended=data_ended,
+                                 workspace=workspace, strike=strike, source_file=source_file)
 
 
 def create_strike(name=None, title=None, description=None, configuration=None, job=None):

--- a/scale/ingest/test/utils.py
+++ b/scale/ingest/test/utils.py
@@ -36,8 +36,9 @@ def create_ingest(file_name='test.txt', status='TRANSFERRING', transfer_started=
     return Ingest.objects.create(file_name=file_name, file_size=source_file.file_size, status=status, job=job,
                                  bytes_transferred=source_file.file_size, transfer_started=transfer_started,
                                  transfer_ended=transfer_ended, media_type='text/plain', ingest_started=ingest_started,
-                                 ingest_ended=ingest_ended, data_started=data_started, data_ended=data_ended,
-                                 workspace=workspace, strike=strike, source_file=source_file)
+                                 ingest_ended=ingest_ended, data_started=source_file.data_started,
+                                 data_ended=source_file.data_ended, workspace=workspace, strike=strike,
+                                 source_file=source_file)
 
 
 def create_strike(name=None, title=None, description=None, configuration=None, job=None):

--- a/scale/source/models.py
+++ b/scale/source/models.py
@@ -148,6 +148,13 @@ class SourceFileManager(models.GeoManager):
         src_file.set_countries()
         src_file.save()
 
+        try:
+            # Try to update corresponding ingest models with this file's data time
+            from ingest.models import Ingest
+            Ingest.objects.filter(source_file_id=src_file_id).update(data_started=data_started, data_ended=data_ended)
+        except ImportError:
+            pass
+
         # Move the source file if a new workspace path is provided and the workspace allows it
         old_workspace_path = src_file.file_path
         if new_workspace_path and src_file.workspace.is_move_enabled:

--- a/scale/storage/migrations/0003_auto_20161202_1621.py
+++ b/scale/storage/migrations/0003_auto_20161202_1621.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storage', '0002_workspace_is_move_enabled'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='scalefile',
+            name='data_ended',
+            field=models.DateTimeField(db_index=True, null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/scale/storage/models.py
+++ b/scale/storage/models.py
@@ -364,7 +364,7 @@ class ScaleFile(models.Model):
 
     # Optional geospatial fields
     data_started = models.DateTimeField(blank=True, null=True, db_index=True)
-    data_ended = models.DateTimeField(blank=True, null=True)
+    data_ended = models.DateTimeField(blank=True, null=True, db_index=True)
     geometry = models.GeometryField('Geometry', blank=True, null=True, srid=4326)
     center_point = models.PointField(blank=True, null=True, srid=4326)
     meta_data = djorm_pgjson.fields.JSONField()


### PR DESCRIPTION
Created data_started and data_ended fields for the ingest model that are copied from the corresponding source file when it is parsed.
Added appropriate indexes for the way the ingest models are accessed (ingest_ended, data_started, data_ended).
Re-worked the API query to cut out joining the source_file, scale_file, and workspace models.
Added migration to populate existing ingest models with their source_file's data time.