### PR TITLE
S3 bucket validation should catch credential errors

### DIFF
--- a/scale/storage/brokers/s3_broker.py
+++ b/scale/storage/brokers/s3_broker.py
@@ -118,12 +118,9 @@ class S3Broker(Broker):
         with S3Client(credentials, region_name) as client:
             try:
                 client.get_bucket(config['bucket_name'])
-            except ClientError:
+            except (ClientError, NoCredentialsError):
                 warnings.append(ValidationWarning('bucket_access',
                                                   'Unable to access bucket. Check the bucket name and credentials.'))
-            except NoCredentialsError:
-                warnings.append(ValidationWarning('bucket_access',
-                                                  'Unable to access bucket. Check the bucket credentials.'))
 
         return warnings
 

--- a/scale/storage/brokers/s3_broker.py
+++ b/scale/storage/brokers/s3_broker.py
@@ -6,7 +6,7 @@ import os
 import ssl
 import time
 
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, NoCredentialsError
 
 import storage.settings as settings
 from storage.brokers.broker import Broker, BrokerVolume
@@ -121,6 +121,9 @@ class S3Broker(Broker):
             except ClientError:
                 warnings.append(ValidationWarning('bucket_access',
                                                   'Unable to access bucket. Check the bucket name and credentials.'))
+            except NoCredentialsError:
+                warnings.append(ValidationWarning('bucket_access',
+                                                  'Unable to access bucket. Check the bucket credentials.'))
 
         return warnings
 


### PR DESCRIPTION
Added additional except case to catch S3 credentials that are missing from the workspace. 