### PR TITLE
Issue 632 - System Timeout Errors

### DIFF
--- a/scale/ingest/apps.py
+++ b/scale/ingest/apps.py
@@ -16,6 +16,10 @@ class IngestConfig(AppConfig):
         Override this method in subclasses to run code when Django starts.
         """
 
+        # Register ingest job type timeout error
+        from job.execution.tasks.job_task import JOB_TYPE_TIMEOUT_ERRORS
+        JOB_TYPE_TIMEOUT_ERRORS['scale-ingest'] = 'ingest-timeout'
+
         from ingest.triggers.ingest_trigger_handler import IngestTriggerHandler
         from trigger.handler import register_trigger_rule_handler
 

--- a/scale/ingest/fixtures/ingest_errors.json
+++ b/scale/ingest/fixtures/ingest_errors.json
@@ -1,0 +1,15 @@
+[
+    {
+        "model": "error.Error",
+        "pk": null,
+        "fields": {
+            "name": "ingest-timeout",
+            "title": "Ingest Timeout",
+            "description": "The ingest job exceeded its timeout threshold. This is likely due to excessive time uploading the source data to its workspace.",
+            "category": "SYSTEM",
+            "is_builtin": true,
+            "created": "2017-01-06T00:00:00.0Z",
+            "last_modified": "2017-01-06T00:00:00.0Z"
+        }
+    }
+]

--- a/scale/ingest/test/test_app.py
+++ b/scale/ingest/test/test_app.py
@@ -1,0 +1,55 @@
+from __future__ import unicode_literals
+
+from datetime import timedelta
+
+import django
+from django.test import TestCase
+from django.utils.timezone import now
+
+import job.test.utils as job_test_utils
+from ingest.models import Ingest
+from job.execution.job_exe import RunningJobExecution
+from job.models import JobExecution
+from job.tasks.manager import TaskManager
+from job.tasks.update import TaskStatusUpdate
+
+
+class TestIngestJobType(TestCase):
+    """Tests things related to the ingest job type"""
+
+    fixtures = ['basic_errors.json', 'basic_job_errors.json', 'ingest_job_types.json', 'ingest_errors.json']
+
+    def setUp(self):
+        django.setup()
+
+        self.task_mgr = TaskManager()
+
+    def test_timed_out_system_job_task(self):
+        """Tests running through a job execution where a system job task times out"""
+
+        ingest_job_type = Ingest.objects.get_ingest_job_type()
+        ingest_job_type.max_tries = 1
+        ingest_job_type.save()
+        job = job_test_utils.create_job(job_type=ingest_job_type, num_exes=1)
+        job_exe = job_test_utils.create_job_exe(job=job)
+        running_job_exe = RunningJobExecution(job_exe)
+
+        # Start job-task and then task times out
+        when_launched = now() + timedelta(seconds=1)
+        job_task_started = when_launched + timedelta(seconds=1)
+        when_timed_out = job_task_started + timedelta(seconds=1)
+        job_task = running_job_exe.start_next_task()
+        self.task_mgr.launch_tasks([job_task], when_launched)
+        update = job_test_utils.create_task_status_update(job_task.id, 'agent', TaskStatusUpdate.RUNNING,
+                                                          job_task_started)
+        self.task_mgr.handle_task_update(update)
+        running_job_exe.task_update(update)
+        timed_out_task = running_job_exe.execution_timed_out(job_task, when_timed_out)
+        self.assertEqual(job_task.id, timed_out_task.id)
+        self.assertTrue(running_job_exe.is_finished())
+        self.assertFalse(running_job_exe.is_next_task_ready())
+
+        job_exe = JobExecution.objects.get(id=job_exe.id)
+        self.assertEqual('FAILED', job_exe.status)
+        self.assertEqual('ingest-timeout', job_exe.error.name)
+        self.assertEqual(when_timed_out, job_exe.ended)

--- a/scale/job/fixtures/basic_job_errors.json
+++ b/scale/job/fixtures/basic_job_errors.json
@@ -57,7 +57,7 @@
         "fields": {
             "name": "launch-timeout",
             "title": "Launch Timeout",
-            "description": "A task for this job failed to start within a reasonable amount of time after being launched. Please contact a Scale administrator to diagnose the problem.",
+            "description": "A task for this job failed to start within a reasonable amount of time after being launched.",
             "category": "SYSTEM",
             "is_builtin": true,
             "created": "2017-01-06T00:00:00.0Z",
@@ -84,6 +84,19 @@
             "name": "post-timeout",
             "title": "Post-task Timeout",
             "description": "The post-task did not finish within a reasonable amount of time. This is likely due to excessive time uploading the algorithm's output data to their workspace(s).",
+            "category": "SYSTEM",
+            "is_builtin": true,
+            "created": "2017-01-06T00:00:00.0Z",
+            "last_modified": "2017-01-06T00:00:00.0Z"
+        }
+    },
+    {
+        "model": "error.Error",
+        "pk": null,
+        "fields": {
+            "name": "system-timeout",
+            "title": "Timeout",
+            "description": "The system job exceeded its timeout threshold.",
             "category": "SYSTEM",
             "is_builtin": true,
             "created": "2017-01-06T00:00:00.0Z",

--- a/scale/job/tasks/base_task.py
+++ b/scale/job/tasks/base_task.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import logging
 import threading
 from abc import ABCMeta, abstractmethod
 
@@ -17,7 +18,10 @@ BASE_STAGING_TIMEOUT_THRESHOLD = datetime.timedelta(minutes=20)
 
 # Default reconciliation thresholds for tasks
 RUNNING_RECON_THRESHOLD = datetime.timedelta(minutes=10)
-STAGING_RECON_THRESHOLD = datetime.timedelta(minutes=1)
+STAGING_RECON_THRESHOLD = datetime.timedelta(seconds=30)
+
+
+logger = logging.getLogger(__name__)
 
 
 class Task(object):
@@ -225,6 +229,9 @@ class Task(object):
                 # Task is still staging so check staging threshold
                 staging_time = when - self._launched
                 timed_out = self._staging_timeout_threshold and staging_time > self._staging_timeout_threshold
+                if timed_out:
+                    timeout_in_mins = int(self._staging_timeout_threshold.total_seconds() / 60)
+                    logger.error('Task %s failed to start running within %d minutes', self._task_id, timeout_in_mins)
 
             if timed_out:
                 self._has_timed_out = True


### PR DESCRIPTION
Set up system jobs to have SYSTEM errors when they time out, including the option to have an error specific to the job type. For example, there is an error specifically for ingest time outs to give a specific, useful error description to the user.