### PR TITLE
Issue 614 - Pull Scale Docker image

### DIFF
--- a/scale/job/execution/tasks/cleanup_task.py
+++ b/scale/job/execution/tasks/cleanup_task.py
@@ -34,6 +34,7 @@ class CleanupTask(Task):
 
         self._uses_docker = False
         self._docker_image = None
+        self._force_docker_pull = False
         self._docker_params = []
         self._is_docker_privileged = False
         self._running_timeout_threshold = datetime.timedelta(minutes=10)

--- a/scale/job/execution/tasks/cleanup_task.py
+++ b/scale/job/execution/tasks/cleanup_task.py
@@ -2,38 +2,12 @@
 from __future__ import unicode_literals
 
 import datetime
-import threading
 
 from job.resources import NodeResources
-from job.tasks.base_task import Task
+from job.tasks.base_task import AtomicCounter, Task
 
 
 CLEANUP_TASK_ID_PREFIX = 'scale_cleanup'
-
-
-class AtomicCounter(object):
-    """Represents an atomic counter
-    """
-
-    def __init__(self):
-        """Constructor
-        """
-
-        self._counter = 0
-        self._lock = threading.Lock()
-
-    def get_next(self):
-        """Returns the next integer
-
-        :returns: The next integer
-        :rtype: int
-        """
-
-        with self._lock:
-            self._counter += 1
-            return self._counter
-
-
 COUNTER = AtomicCounter()
 
 

--- a/scale/job/execution/tasks/exe_task.py
+++ b/scale/job/execution/tasks/exe_task.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 
 from abc import ABCMeta, abstractmethod
 
-from django.conf import settings
-
 from error.models import Error
 from job.tasks.base_task import Task
 
@@ -75,15 +73,6 @@ class JobExecutionTask(Task):
             self._last_status_update = task_update.timestamp
 
             return False
-
-    def create_scale_image_name(self):
-        """Creates the full image name to use for running the Scale Docker image
-
-        :returns: The full Scale Docker image name
-        :rtype: string
-        """
-
-        return '%s:%s' % (settings.SCALE_DOCKER_IMAGE, settings.DOCKER_VERSION)
 
     @abstractmethod
     def determine_error(self, task_update):

--- a/scale/job/execution/tasks/job_task.py
+++ b/scale/job/execution/tasks/job_task.py
@@ -31,7 +31,7 @@ class JobTask(JobExecutionTask):
                 self._docker_image = self._create_scale_image_name()
             else:
                 self._docker_image = job_exe.get_docker_image()
-            self._force_docker_pull = True
+            self._force_docker_pull = not self._is_system  # Force pull non-system jobs
             self._docker_params = job_exe.get_job_configuration().get_job_task_docker_params()
             self._is_docker_privileged = job_exe.is_docker_privileged()
         self._command = job_exe.get_job_interface().get_command()

--- a/scale/job/execution/tasks/job_task.py
+++ b/scale/job/execution/tasks/job_task.py
@@ -28,7 +28,7 @@ class JobTask(JobExecutionTask):
         self._uses_docker = job_exe.uses_docker()
         if self._uses_docker:
             if self._is_system:
-                self._docker_image = self.create_scale_image_name()
+                self._docker_image = self._create_scale_image_name()
             else:
                 self._docker_image = job_exe.get_docker_image()
             self._docker_params = job_exe.get_job_configuration().get_job_task_docker_params()

--- a/scale/job/execution/tasks/job_task.py
+++ b/scale/job/execution/tasks/job_task.py
@@ -31,6 +31,7 @@ class JobTask(JobExecutionTask):
                 self._docker_image = self._create_scale_image_name()
             else:
                 self._docker_image = job_exe.get_docker_image()
+            self._force_docker_pull = True
             self._docker_params = job_exe.get_job_configuration().get_job_task_docker_params()
             self._is_docker_privileged = job_exe.is_docker_privileged()
         self._command = job_exe.get_job_interface().get_command()

--- a/scale/job/execution/tasks/post_task.py
+++ b/scale/job/execution/tasks/post_task.py
@@ -24,6 +24,7 @@ class PostTask(JobExecutionTask):
 
         self._uses_docker = True
         self._docker_image = self._create_scale_image_name()
+        self._force_docker_pull = False
         self._docker_params = job_exe.get_job_configuration().get_post_task_docker_params()
         self._is_docker_privileged = False
         self._command_arguments = 'scale_post_steps -i %i' % job_exe.id

--- a/scale/job/execution/tasks/post_task.py
+++ b/scale/job/execution/tasks/post_task.py
@@ -23,7 +23,7 @@ class PostTask(JobExecutionTask):
         super(PostTask, self).__init__(job_exe.get_post_task_id(), job_exe)
 
         self._uses_docker = True
-        self._docker_image = self.create_scale_image_name()
+        self._docker_image = self._create_scale_image_name()
         self._docker_params = job_exe.get_job_configuration().get_post_task_docker_params()
         self._is_docker_privileged = False
         self._command_arguments = 'scale_post_steps -i %i' % job_exe.id

--- a/scale/job/execution/tasks/pre_task.py
+++ b/scale/job/execution/tasks/pre_task.py
@@ -23,7 +23,7 @@ class PreTask(JobExecutionTask):
         super(PreTask, self).__init__(job_exe.get_pre_task_id(), job_exe)
 
         self._uses_docker = True
-        self._docker_image = self.create_scale_image_name()
+        self._docker_image = self._create_scale_image_name()
         self._docker_params = job_exe.get_job_configuration().get_pre_task_docker_params()
         self._is_docker_privileged = False
         self._command_arguments = 'scale_pre_steps -i %i' % job_exe.id

--- a/scale/job/execution/tasks/pre_task.py
+++ b/scale/job/execution/tasks/pre_task.py
@@ -24,6 +24,7 @@ class PreTask(JobExecutionTask):
 
         self._uses_docker = True
         self._docker_image = self._create_scale_image_name()
+        self._force_docker_pull = False
         self._docker_params = job_exe.get_job_configuration().get_pre_task_docker_params()
         self._is_docker_privileged = False
         self._command_arguments = 'scale_pre_steps -i %i' % job_exe.id

--- a/scale/job/tasks/base_task.py
+++ b/scale/job/tasks/base_task.py
@@ -85,6 +85,7 @@ class Task(object):
         # These values will vary by different task subclasses
         self._uses_docker = False
         self._docker_image = None
+        self._force_docker_pull = False
         self._docker_params = []
         self._is_docker_privileged = False
         self._command = 'echo "Hello Scale"'
@@ -151,6 +152,16 @@ class Task(object):
         """
 
         return self._docker_params
+
+    @property
+    def force_docker_pull(self):
+        """Indicates if a force pull of the Docker image should be done
+
+        :returns: True if force pull should be used, False otherwise
+        :rtype: bool
+        """
+
+        return self._force_docker_pull
 
     @property
     def has_been_launched(self):

--- a/scale/job/tasks/pull_task.py
+++ b/scale/job/tasks/pull_task.py
@@ -1,0 +1,53 @@
+"""Defines the class for a Docker pull task"""
+from __future__ import unicode_literals
+
+import datetime
+
+from job.resources import NodeResources
+from job.tasks.base_task import AtomicCounter, Task
+
+
+PULL_TASK_ID_PREFIX = 'scale_pull'
+COUNTER = AtomicCounter()
+
+
+class PullTask(Task):
+    """Represents a task that pulls Docker images from the registry. This class is thread-safe.
+    """
+
+    def __init__(self, framework_id, agent_id, image_name):
+        """Constructor
+
+        :param framework_id: The framework ID
+        :type framework_id: string
+        :param agent_id: The agent ID
+        :type agent_id: string
+        :param image_name: The name of the Docker image to pull. If None, pulls the Scale Docker image
+        :type image_name: string
+        """
+
+        task_id = '%s_%s_%d' % (PULL_TASK_ID_PREFIX, framework_id, COUNTER.get_next())
+        super(PullTask, self).__init__(task_id, 'Scale Docker Pull', agent_id)
+
+        if image_name:
+            self.image_name = image_name
+        else:
+            self.image_name = self._create_scale_image_name()
+
+        self._uses_docker = False
+        self._docker_image = None
+        self._docker_params = []
+        self._is_docker_privileged = False
+        self._running_timeout_threshold = datetime.timedelta(minutes=15)
+        self._staging_timeout_threshold = datetime.timedelta(minutes=2)
+
+        # Create command that pulls image and deletes any dangling images
+        pull_cmd = 'docker pull %s' % self.image_name
+        delete_cmd = 'for img in `docker images -q -f dangling=true`; do docker rmi $img; done'
+        self._command = '%s && %s' % (pull_cmd, delete_cmd)
+
+    def get_resources(self):
+        """See :meth:`job.tasks.base_task.Task.get_resources`
+        """
+
+        return NodeResources(cpus=0.1, mem=32)

--- a/scale/job/tasks/pull_task.py
+++ b/scale/job/tasks/pull_task.py
@@ -15,7 +15,7 @@ class PullTask(Task):
     """Represents a task that pulls Docker images from the registry. This class is thread-safe.
     """
 
-    def __init__(self, framework_id, agent_id, image_name):
+    def __init__(self, framework_id, agent_id, image_name=None):
         """Constructor
 
         :param framework_id: The framework ID

--- a/scale/job/tasks/pull_task.py
+++ b/scale/job/tasks/pull_task.py
@@ -36,6 +36,7 @@ class PullTask(Task):
 
         self._uses_docker = False
         self._docker_image = None
+        self._force_docker_pull = False
         self._docker_params = []
         self._is_docker_privileged = False
         self._running_timeout_threshold = datetime.timedelta(minutes=15)

--- a/scale/mesos_api/tasks.py
+++ b/scale/mesos_api/tasks.py
@@ -111,6 +111,6 @@ def _create_docker_task(task):
         mesos_task.command.uris.add().value = settings.CONFIG_URI
 
     mesos_task.container.docker.network = mesos_pb2.ContainerInfo.DockerInfo.Network.Value('BRIDGE')
-    mesos_task.container.docker.force_pull_image = True
+    mesos_task.container.docker.force_pull_image = task.force_docker_pull
 
     return mesos_task

--- a/scale/scheduler/cleanup/node.py
+++ b/scale/scheduler/cleanup/node.py
@@ -52,7 +52,7 @@ class NodeCleanup(object):
         with self._lock:
             self._create_next_task()
 
-            # No task returned if node is paused, no task to launched, or task has already been launched
+            # No task returned if node is paused, no task to launch, or task has already been launched
             if self._node.is_paused or self._current_task is None or self._current_task.has_been_launched:
                 return None
 

--- a/scale/scheduler/node/node_class.py
+++ b/scale/scheduler/node/node_class.py
@@ -182,6 +182,7 @@ class Node(object):
 
             if task_update.status == TaskStatusUpdate.FINISHED:
                 self._is_image_pulled = True
+                logger.info('Node %s has finished pulling the Scale image', self._hostname)
             elif task_update.status == TaskStatusUpdate.FAILED:
                 logger.warning('Scale image pull task on host %s failed', self._hostname)
             elif task_update.status == TaskStatusUpdate.KILLED:

--- a/scale/scheduler/node/node_class.py
+++ b/scale/scheduler/node/node_class.py
@@ -167,6 +167,7 @@ class Node(object):
             logger.warning('Scale image pull task on host %s timed out', self._hostname)
             if self._current_task.has_ended:
                 self._current_task = None
+            self._update_state()
 
     def handle_task_update(self, task_update):
         """Handles the given task update
@@ -187,6 +188,7 @@ class Node(object):
                 logger.warning('Scale image pull task on host %s killed', self._hostname)
             if self._current_task.has_ended:
                 self._current_task = None
+            self._update_state()
 
     def update_from_mesos(self, agent_id=None, port=None, is_online=None):
         """Updates this node's data from Mesos

--- a/scale/scheduler/test/node/test_manager.py
+++ b/scale/scheduler/test/node/test_manager.py
@@ -2,8 +2,13 @@ from __future__ import unicode_literals
 
 import django
 from django.test import TestCase
+from django.utils.timezone import now
 from mock import patch
 
+from job.tasks.manager import TaskManager
+from job.tasks.pull_task import PullTask
+from job.tasks.update import TaskStatusUpdate
+from job.test import utils as job_test_utils
 from mesos_api.api import SlaveInfo
 from node.test import utils as node_test_utils
 from scheduler.node.manager import NodeManager
@@ -99,3 +104,60 @@ class TestNodeManager(TestCase):
         node_2 = manager.get_node(self.node_agent_3)
         self.assertEqual(node_2.hostname, 'host_2')
         self.assertTrue(node_2.is_online)
+
+    @patch('scheduler.node.manager.api.get_slaves')
+    def test_get_pull_tasks(self, mock_get_slaves):
+        """Tests getting Docker pull tasks from the manager"""
+
+        mock_get_slaves.return_value = self.slave_infos
+
+        manager = NodeManager()
+        tasks = manager.get_next_tasks()
+        self.assertListEqual(tasks, [])  # No tasks yet due to no nodes
+
+        manager.register_agent_ids([self.node_agent_1, self.node_agent_2])
+        manager.sync_with_database('master_host', 5050)
+        for node in manager.get_nodes():
+            node.initial_cleanup_completed()
+
+        tasks = manager.get_next_tasks()
+        self.assertEqual(len(tasks), 2)
+        for task in tasks:
+            self.assertTrue(isinstance(task, PullTask))
+
+    @patch('scheduler.node.manager.api.get_slaves')
+    def test_pull_task_change_agent_id(self, mock_get_slaves):
+        """Tests the NodeManager where a node's agent ID changes during a pull task"""
+
+        mock_get_slaves.return_value = self.slave_infos
+
+        manager = NodeManager()
+        manager.register_agent_ids([self.node_agent_1, self.node_agent_2])
+        manager.sync_with_database('master_host', 5050)
+        for node in manager.get_nodes():
+            node.initial_cleanup_completed()
+        tasks = manager.get_next_tasks()
+
+        task_mgr = TaskManager()
+        task_2 = None
+        for task in tasks:
+            task_mgr.launch_tasks([task], now())
+            if task.agent_id == self.node_agent_2:
+                task_2 = task
+
+        # Node 2 changes agent ID to 3
+        mock_get_slaves.return_value = self.slave_infos_updated
+        manager.lost_node(self.node_agent_2)
+        manager.register_agent_ids([self.node_agent_3])
+        manager.sync_with_database('master_host', 5050)
+
+        # Should get new Docker pull task for node 1
+        tasks = manager.get_next_tasks()
+        self.assertEqual(len(tasks), 1)
+        new_task_2 = tasks[0]
+        self.assertEqual(new_task_2.agent_id, self.node_agent_3)
+
+        # Task update comes back for original node 2 Docker pull task, manager should ignore with no exception
+        update = job_test_utils.create_task_status_update(task_2.id, task_2.agent_id, TaskStatusUpdate.FAILED, now())
+        task_mgr.handle_task_update(update)
+        manager.handle_task_update(update)

--- a/scale/scheduler/test/node/test_node_class.py
+++ b/scale/scheduler/test/node/test_node_class.py
@@ -1,0 +1,158 @@
+from __future__ import unicode_literals
+
+import django
+from django.test import TestCase
+from django.utils.timezone import now
+
+from job.execution.job_exe import RunningJobExecution
+from job.tasks.manager import TaskManager
+from job.tasks.update import TaskStatusUpdate
+from job.test import utils as job_test_utils
+from node.test import utils as node_test_utils
+from scheduler.cleanup.node import NodeCleanup
+from scheduler.node.node_class import Node
+
+
+class TestNode(TestCase):
+
+    def setUp(self):
+        django.setup()
+
+        self.node_agent = 'agent_1'
+        self.node = node_test_utils.create_node(hostname='host_1', slave_id=self.node_agent)
+        self.job_exe = job_test_utils.create_job_exe(node=self.node)
+        self.task_mgr = TaskManager()
+
+    def test_handle_failed_pull_task(self):
+        """Tests handling failed Docker pull task"""
+
+        node = Node(self.node_agent, self.node)
+        node.initial_cleanup_completed()
+        # Get Docker pull task
+        task = node.get_next_task()
+        task_1_id = task.id
+        self.assertIsNotNone(task)
+
+        # Fail task after running and get different task next time
+        self.task_mgr.launch_tasks([task], now())
+        update = job_test_utils.create_task_status_update(task.id, task.agent_id, TaskStatusUpdate.RUNNING, now())
+        self.task_mgr.handle_task_update(update)
+        node.handle_task_update(update)
+        update = job_test_utils.create_task_status_update(task.id, task.agent_id, TaskStatusUpdate.FAILED, now())
+        self.task_mgr.handle_task_update(update)
+        node.handle_task_update(update)
+        task = node.get_next_task()
+        self.assertIsNotNone(task)
+        self.assertNotEqual(task.id, task_1_id)
+        self.assertFalse(node._is_image_pulled)
+
+    def test_handle_successful_pull_task(self):
+        """Tests handling the Docker pull task successfully"""
+
+        node = Node(self.node_agent, self.node)
+        node.initial_cleanup_completed()
+
+        # Get Docker pull task
+        task = node.get_next_task()
+        self.assertIsNotNone(task)
+        self.assertEqual(task.agent_id, self.node_agent)
+
+        # Schedule pull task and make sure no new task is ready
+        self.task_mgr.launch_tasks([task], now())
+        self.assertIsNone(node.get_next_task())
+        self.assertFalse(node._is_image_pulled)
+
+        # Complete pull task, verify no new task
+        update = job_test_utils.create_task_status_update(task.id, task.agent_id, TaskStatusUpdate.RUNNING, now())
+        self.task_mgr.handle_task_update(update)
+        node.handle_task_update(update)
+        update = job_test_utils.create_task_status_update(task.id, task.agent_id, TaskStatusUpdate.FINISHED, now())
+        self.task_mgr.handle_task_update(update)
+        node.handle_task_update(update)
+        self.assertIsNone(node.get_next_task())
+        self.assertTrue(node._is_image_pulled)
+        # Node should now be ready
+        self.assertEqual(node.READY, Node.READY)
+
+    def test_handle_killed_pull_task(self):
+        """Tests handling killed cleanup task"""
+
+        node = Node(self.node_agent, self.node)
+        node.initial_cleanup_completed()
+        # Get pull task
+        task = node.get_next_task()
+        task_1_id = task.id
+        self.assertIsNotNone(task)
+
+        # Kill task after running and get different task next time
+        self.task_mgr.launch_tasks([task], now())
+        update = job_test_utils.create_task_status_update(task.id, task.agent_id, TaskStatusUpdate.RUNNING, now())
+        self.task_mgr.handle_task_update(update)
+        node.handle_task_update(update)
+        update = job_test_utils.create_task_status_update(task.id, task.agent_id, TaskStatusUpdate.KILLED, now())
+        self.task_mgr.handle_task_update(update)
+        node.handle_task_update(update)
+        task = node.get_next_task()
+        self.assertIsNotNone(task)
+        self.assertNotEqual(task.id, task_1_id)
+        self.assertFalse(node._is_image_pulled)
+
+    def test_handle_lost_pull_task(self):
+        """Tests handling lost pull task"""
+
+        node = Node(self.node_agent, self.node)
+        node.initial_cleanup_completed()
+        # Get pull task
+        task = node.get_next_task()
+        task_1_id = task.id
+        self.assertIsNotNone(task)
+
+        # Lose task without scheduling and get same task again
+        update = job_test_utils.create_task_status_update(task.id, task.agent_id, TaskStatusUpdate.LOST, now())
+        node.handle_task_update(update)
+        task = node.get_next_task()
+        self.assertIsNotNone(task)
+        self.assertEqual(task.id, task_1_id)
+        self.assertFalse(node._is_image_pulled)
+
+        # Lose task with scheduling and get same task again
+        self.task_mgr.launch_tasks([task], now())
+        update = job_test_utils.create_task_status_update(task.id, task.agent_id, TaskStatusUpdate.LOST, now())
+        self.task_mgr.handle_task_update(update)
+        node.handle_task_update(update)
+        task = node.get_next_task()
+        self.assertIsNotNone(task)
+        self.assertEqual(task.id, task_1_id)
+        self.assertFalse(node._is_image_pulled)
+
+        # Lose task after running and get same task again
+        self.task_mgr.launch_tasks([task], now())
+        update = job_test_utils.create_task_status_update(task.id, task.agent_id, TaskStatusUpdate.RUNNING, now())
+        self.task_mgr.handle_task_update(update)
+        node.handle_task_update(update)
+        update = job_test_utils.create_task_status_update(task.id, task.agent_id, TaskStatusUpdate.LOST, now())
+        self.task_mgr.handle_task_update(update)
+        node.handle_task_update(update)
+        task = node.get_next_task()
+        self.assertIsNotNone(task)
+        self.assertEqual(task.id, task_1_id)
+        self.assertFalse(node._is_image_pulled)
+
+    def test_paused_node(self):
+        """Tests not returning tasks when its node is paused"""
+
+        paused_node = node_test_utils.create_node(hostname='host_1', slave_id=self.node_agent)
+        paused_node.is_paused = True
+        node = Node(self.node_agent, paused_node)
+        node.initial_cleanup_completed()
+        task = node.get_next_task()
+        # No task due to paused node
+        self.assertIsNone(task)
+
+    def test_node_that_is_not_cleaned_yet(self):
+        """Tests not returning tasks when the node hasn't been cleaned up yet"""
+
+        node = Node(self.node_agent, self.node)
+        task = node.get_next_task()
+        # No task due to node not cleaned yet
+        self.assertIsNone(task)

--- a/scale/scheduler/test/offer/test_manager.py
+++ b/scale/scheduler/test/offer/test_manager.py
@@ -26,6 +26,7 @@ class TestOfferManager(TestCase):
         self.node_agent_paused = 'agent_paused'
         self.node_model = node_test_utils.create_node(slave_id=self.node_agent)
         self.node = Node(self.node_agent, self.node_model)
+        self.node._is_image_pulled = True
         self.node.initial_cleanup_completed()
         self.paused_node_model = node_test_utils.create_node(slave_id=self.node_agent_paused)
         self.paused_node_model.is_paused = True

--- a/scale/scheduler/test/offer/test_node.py
+++ b/scale/scheduler/test/offer/test_node.py
@@ -26,6 +26,7 @@ class TestNodeOffers(TestCase):
         self.node_agent_paused = 'agent_paused'
         self.node_model = node_test_utils.create_node(slave_id=self.node_agent)
         self.node = Node(self.node_agent, self.node_model)
+        self.node._is_image_pulled = True
         self.node.initial_cleanup_completed()
         self.paused_node_model = node_test_utils.create_node(slave_id=self.node_agent_paused)
         self.paused_node_model.is_paused = True

--- a/scale/scheduler/test/threads/test_schedule.py
+++ b/scale/scheduler/test/threads/test_schedule.py
@@ -102,6 +102,10 @@ class TestSchedulingThread(TransactionTestCase):
         offer_2 = ResourceOffer('offer_2', self.node_agent_2, NodeResources(cpus=200.0, mem=204800.0, disk=204800.0))
         offer_mgr.add_new_offers([offer_1, offer_2])
 
+        # Ignore Docker pull tasks
+        for node in node_mgr.get_nodes():
+            node._is_image_pulled = True
+
         # Ignore cleanup tasks
         for node in node_mgr.get_nodes():
             node.initial_cleanup_completed()

--- a/scale/scheduler/threads/schedule.py
+++ b/scale/scheduler/threads/schedule.py
@@ -157,6 +157,16 @@ class SchedulingThread(object):
         for task in cleanup_mgr.get_next_tasks():
             offer_mgr.consider_task(task)
 
+    def _consider_node_tasks(self):
+        """Considers any node tasks to schedule
+        """
+
+        if scheduler_mgr.is_paused():
+            return
+
+        for task in node_mgr.get_next_tasks():
+            offer_mgr.consider_task(task)
+
     def _perform_scheduling(self):
         """Performs task reconciliation with the Mesos master
 
@@ -180,6 +190,7 @@ class SchedulingThread(object):
             if running_job_exe.job_type_id in self._job_type_limit_available:
                 self._job_type_limit_available[running_job_exe.job_type_id] -= 1
 
+        self._consider_node_tasks()
         self._consider_cleanup_tasks()
         self._consider_running_job_exes()
         self._consider_new_job_exes()


### PR DESCRIPTION
This PR updates the nodes so that they each pull the Scale Docker image upon registering with Scale (after initial cleanup). This ensures that a node has the Scale Docker image before it runs any jobs. The forcePull Docker flag is now turned off for all tasks that run the Scale Docker image (all system jobs and pre and post tasks).