### PR TITLE
Issue 708 - Scale file refactor

### DIFF
--- a/scale/cli/management/commands/migratedata.py
+++ b/scale/cli/management/commands/migratedata.py
@@ -105,7 +105,7 @@ class Command(BaseCommand):
                 logging.info("Processing ingest %s" % ingest.file_name)
                 with transaction.atomic():
                     ingest.ingest_started = datetime.utcnow()
-                    sf = ingest.source_file = SourceFile()
+                    sf = ingest.source_file = SourceFile.create()
                     sf.update_uuid(ingest.file_name)
                     for tag in ingest.get_data_type_tags():
                         sf.add_data_type_tag(tag)

--- a/scale/ingest/ingest_job.py
+++ b/scale/ingest/ingest_job.py
@@ -77,7 +77,7 @@ def perform_ingest(ingest_id):
 
         if ingest.new_workspace:
             # Copied file to new workspace, so delete file in old workspace (if workspace provides local path to do so)
-            file_with_old_path = SourceFile()
+            file_with_old_path = SourceFile.create()
             file_with_old_path.file_name = file_name
             file_with_old_path.file_path = ingest.file_path
             paths = ingest.workspace.get_file_system_paths([file_with_old_path])
@@ -150,7 +150,7 @@ def _get_source_file(file_name):
     try:
         src_file = SourceFile.objects.get_source_file_by_name(file_name)
     except ScaleFile.DoesNotExist:
-        src_file = SourceFile()  # New file
+        src_file = SourceFile.create()  # New file
         src_file.file_name = file_name
         src_file.is_deleted = True
     return src_file

--- a/scale/ingest/ingest_job.py
+++ b/scale/ingest/ingest_job.py
@@ -148,8 +148,8 @@ def _get_source_file(file_name):
     """
 
     try:
-        src_file = SourceFile.objects.get(file_name=file_name)
-    except SourceFile.DoesNotExist:
+        src_file = SourceFile.objects.get_source_file_by_name(file_name)
+    except ScaleFile.DoesNotExist:
         src_file = SourceFile()  # New file
         src_file.file_name = file_name
         src_file.is_deleted = True

--- a/scale/ingest/migrations/0007_auto_20170127_1327.py
+++ b/scale/ingest/migrations/0007_auto_20170127_1327.py
@@ -6,7 +6,7 @@ from django.db import connection, models, migrations
 
 def delete_constraint(apps, schema_editor):
     with connection.cursor() as cursor:
-        cursor.execute('ALTER TABLE "ingest" DROP CONSTRAINT "ingest_source_file_id_67e3c0c9_fk_source_file_file_id"')
+        cursor.execute('ALTER TABLE "ingest" DROP CONSTRAINT IF EXISTS "ingest_source_file_id_67e3c0c9_fk_source_file_file_id"')
 
 
 class Migration(migrations.Migration):

--- a/scale/ingest/migrations/0007_auto_20170127_1327.py
+++ b/scale/ingest/migrations/0007_auto_20170127_1327.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import connection, models, migrations
+
+
+def delete_constraint(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute('ALTER TABLE "ingest" DROP CONSTRAINT "ingest_source_file_id_67e3c0c9_fk_source_file_file_id"')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ingest', '0006_auto_20161202_1621'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ingest',
+            name='source_file',
+            field=models.ForeignKey(db_constraint=False, blank=True, to='source.SourceFile', null=True),
+            preserve_default=True,
+        ),
+        migrations.RunPython(delete_constraint),
+    ]

--- a/scale/ingest/migrations/0008_auto_20170127_1332.py
+++ b/scale/ingest/migrations/0008_auto_20170127_1332.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ingest', '0007_auto_20170127_1327'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ingest',
+            name='source_file',
+            field=models.ForeignKey(blank=True, to='storage.ScaleFile', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -352,7 +352,7 @@ class Ingest(models.Model):
     ingest_started = models.DateTimeField(blank=True, null=True)
     ingest_ended = models.DateTimeField(blank=True, null=True, db_index=True)
 
-    source_file = models.ForeignKey('source.SourceFile', blank=True, null=True)
+    source_file = models.ForeignKey('storage.ScaleFile', blank=True, null=True)
     data_started = models.DateTimeField(blank=True, null=True, db_index=True)
     data_ended = models.DateTimeField(blank=True, null=True, db_index=True)
 

--- a/scale/ingest/test/test_ingest_job.py
+++ b/scale/ingest/test/test_ingest_job.py
@@ -2,13 +2,9 @@ from __future__ import unicode_literals
 
 import django
 from django.test import TransactionTestCase
-from mock import patch
 
-import ingest.ingest_job as ingest_job
 import ingest.test.utils as ingest_test_utils
 import source.test.utils as source_test_utils
-from ingest.models import Ingest
-from job.models import JobExecution
 
 
 class TestPerformIngest(TransactionTestCase):

--- a/scale/ingest/test/triggers/test_ingest_trigger_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_trigger_handler.py
@@ -9,7 +9,7 @@ from job.models import JobExecution
 import job.test.utils as job_test_utils
 from queue.models import Queue
 import recipe.test.utils as recipe_test_utils
-from source.models import SourceFile
+from storage.models import ScaleFile
 import storage.test.utils as storage_test_utils
 import trigger.test.utils as trigger_test_utils
 
@@ -88,9 +88,9 @@ class TestIngestTriggerHandlerProcessIngestedSourceFile(TestCase):
         self.media_type = 'text/plain'
 
         self.workspace = storage_test_utils.create_workspace()
-        self.source_file = SourceFile.objects.create(file_name=self.file_name, media_type=self.media_type, file_size=10,
-                                                     data_type=self.data_type, file_path='the_path',
-                                                     workspace=self.workspace)
+        self.source_file = ScaleFile.objects.create(file_name=self.file_name, file_type='SOURCE',
+                                                    media_type=self.media_type, file_size=10, data_type=self.data_type,
+                                                    file_path='the_path', workspace=self.workspace)
         self.source_file.add_data_type_tag('type1')
         self.source_file.add_data_type_tag('type2')
         self.source_file.add_data_type_tag('type3')

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -211,14 +211,9 @@ class JobManager(models.Manager):
         input_files = input_files.order_by('id').distinct('id')
 
         # Attempt to get related products
-        # Use a localized import to make higher level application dependencies optional
-        try:
-            from product.models import ProductFile
-            output_files = ProductFile.objects.filter(job=job)
-            output_files = output_files.select_related('file', 'file__workspace').defer('file__workspace__json_config')
-            output_files = output_files.order_by('id').distinct('id')
-        except:
-            output_files = []
+        output_files = ScaleFile.objects.filter(job=job)
+        output_files = output_files.select_related('workspace').defer('workspace__json_config')
+        output_files = output_files.order_by('id').distinct('id')
 
         # Merge job interface definitions with mapped values
         job_interface_dict = job.get_job_interface().get_dict()

--- a/scale/product/migrations/0003_auto_20170127_1319.py
+++ b/scale/product/migrations/0003_auto_20170127_1319.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import connection, models, migrations
+import django.db.models.deletion
+
+
+def delete_constraint(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute('ALTER TABLE "file_ancestry_link" DROP CONSTRAINT "file_ancestry_li_descendant_id_34f8ed2a_fk_product_file_file_id"')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('product', '0002_auto_20160622_1344'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='fileancestrylink',
+            name='descendant',
+            field=models.ForeignKey(related_name='ancestors', on_delete=django.db.models.deletion.PROTECT, db_constraint=False, blank=True, to='product.ProductFile', null=True),
+            preserve_default=True,
+        ),
+        migrations.RunPython(delete_constraint),
+    ]

--- a/scale/product/migrations/0003_auto_20170127_1319.py
+++ b/scale/product/migrations/0003_auto_20170127_1319.py
@@ -7,7 +7,7 @@ import django.db.models.deletion
 
 def delete_constraint(apps, schema_editor):
     with connection.cursor() as cursor:
-        cursor.execute('ALTER TABLE "file_ancestry_link" DROP CONSTRAINT "file_ancestry_li_descendant_id_34f8ed2a_fk_product_file_file_id"')
+        cursor.execute('ALTER TABLE "file_ancestry_link" DROP CONSTRAINT IF EXISTS "file_ancestry_li_descendant_id_34f8ed2a_fk_product_file_file_id"')
 
 
 class Migration(migrations.Migration):

--- a/scale/product/migrations/0004_auto_20170127_1324.py
+++ b/scale/product/migrations/0004_auto_20170127_1324.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('product', '0003_auto_20170127_1319'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='fileancestrylink',
+            name='descendant',
+            field=models.ForeignKey(related_name='ancestors', on_delete=django.db.models.deletion.PROTECT, blank=True, to='storage.ScaleFile', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/scale/product/migrations/0005_auto_20170127_1344.py
+++ b/scale/product/migrations/0005_auto_20170127_1344.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import connection, models, migrations
+
+
+def copy_product_file(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute('SELECT * INTO product_file_temp FROM product_file')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('product', '0004_auto_20170127_1324'),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_product_file),
+    ]

--- a/scale/product/migrations/0006_auto_20170127_1348.py
+++ b/scale/product/migrations/0006_auto_20170127_1348.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storage', '0003_auto_20161202_1621'),
+        ('recipe', '0016_recipefile_data'),
+        ('ingest', '0008_auto_20170127_1332'),
+        ('product', '0005_auto_20170127_1344'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='productfile',
+            name='file',
+        ),
+        migrations.RemoveField(
+            model_name='productfile',
+            name='job',
+        ),
+        migrations.RemoveField(
+            model_name='productfile',
+            name='job_exe',
+        ),
+        migrations.RemoveField(
+            model_name='productfile',
+            name='job_type',
+        ),
+        migrations.DeleteModel(
+            name='ProductFile',
+        ),
+        migrations.CreateModel(
+            name='ProductFile',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('storage.scalefile',),
+        ),
+    ]

--- a/scale/product/models.py
+++ b/scale/product/models.py
@@ -364,7 +364,7 @@ class ProductFileManager(models.GeoManager):
         input_strings.extend(properties)
 
         # Determine if any input files are non-operational products
-        input_products = ScaleFile.objects.filter(file__in=[f['id'] for f in input_files], file_type='PRODUCT')
+        input_products = ScaleFile.objects.filter(id__in=[f['id'] for f in input_files], file_type='PRODUCT')
         input_products_operational = all([f.is_operational for f in input_products])
 
         products_to_save = []

--- a/scale/product/models.py
+++ b/scale/product/models.py
@@ -103,7 +103,6 @@ class FileAncestryLinkManager(models.Manager):
         :rtype: list[:class:`storage.models.ScaleFile`]
         """
 
-        # TODO: file refactor - might be able to make this more efficient
         potential_src_file_ids = list(file_ids)
         # Get all ancestors to include as possible source files
         for ancestor_link in self.filter(descendant_id__in=file_ids):

--- a/scale/product/models.py
+++ b/scale/product/models.py
@@ -108,7 +108,7 @@ class FileAncestryLinkManager(models.Manager):
         # Get all ancestors to include as possible source files
         for ancestor_link in self.filter(descendant_id__in=file_ids):
             potential_src_file_ids.append(ancestor_link.ancestor_id)
-        return ScaleFile.objects.filter(id__in=potential_src_file_ids, type='SOURCE')
+        return ScaleFile.objects.filter(id__in=potential_src_file_ids, file_type='SOURCE')
 
 
 class FileAncestryLink(models.Model):
@@ -373,7 +373,7 @@ class ProductFileManager(models.GeoManager):
             remote_path = entry[1]
             media_type = entry[2]
 
-            product = ProductFile()
+            product = ProductFile.create()
             product.job_exe = job_exe
             product.job = job_exe.job
             product.job_type = job_exe.job.job_type
@@ -416,6 +416,18 @@ class ProductFile(ScaleFile):
     :class:`storage.models.ScaleFile` model. It has the same set of fields, but a different manager that provides
     functionality specific to product files.
     """
+
+    @classmethod
+    def create(cls):
+        """Creates a new product file
+
+        :returns: The new product file
+        :rtype: :class:`product.models.ProductFile`
+        """
+
+        product_file = ProductFile()
+        product_file.file_type = 'PRODUCT'
+        return product_file
 
     objects = ProductFileManager()
 

--- a/scale/product/models.py
+++ b/scale/product/models.py
@@ -143,7 +143,7 @@ class FileAncestryLink(models.Model):
     """
 
     ancestor = models.ForeignKey('storage.ScaleFile', on_delete=models.PROTECT, related_name='descendants')
-    descendant = models.ForeignKey('product.ProductFile', blank=True, null=True, on_delete=models.PROTECT,
+    descendant = models.ForeignKey('storage.ScaleFile', blank=True, null=True, on_delete=models.PROTECT,
                                    related_name='ancestors')
 
     job_exe = models.ForeignKey('job.JobExecution', on_delete=models.PROTECT, related_name='file_links')
@@ -408,53 +408,13 @@ class ProductFileManager(models.GeoManager):
 
 
 class ProductFile(ScaleFile):
-    """Represents a product file that has been created by Scale. This is an extension of the
-    :class:`storage.models.ScaleFile` model.
-
-    :keyword file: The corresponding ScaleFile model
-    :type file: :class:`django.db.models.OneToOneField`
-    :keyword job_exe: The job execution that created this product
-    :type job_exe: :class:`django.db.models.ForeignKey`
-    :keyword job: The job that created this product
-    :type job: :class:`django.db.models.ForeignKey`
-    :keyword job_type: The type of the job that created this product
-    :type job_type: :class:`django.db.models.ForeignKey`
-    :keyword is_operational: Whether this product was produced by an operational job type (True) or by a job type that
-        is still in a research & development (R&D) phase (False)
-    :type is_operational: :class:`django.db.models.BooleanField`
-
-    :keyword has_been_published: Whether this product has ever been published. A product becomes published when its job
-        execution completes successfully. A product that has been published will appear in the API call to retrieve
-        product updates.
-    :type has_been_published: :class:`django.db.models.BooleanField`
-    :keyword is_published: Whether this product is currently published. A published product has had its job execution
-        complete successfully and has not been unpublished.
-    :type is_published: :class:`django.db.models.BooleanField`
-    :keyword is_superseded: Whether this product has been superseded by another product with the same UUID
-    :type is_superseded: :class:`django.db.models.BooleanField`
-    :keyword published: When this product was published (its job execution was completed)
-    :type published: :class:`django.db.models.DateTimeField`
-    :keyword unpublished: When this product was unpublished
-    :type unpublished: :class:`django.db.models.DateTimeField`
-    :keyword superseded: When this product was superseded
-    :type superseded: :class:`django.db.models.DateTimeField`
+    """Represents a product file that has been created by Scale. This is a proxy model of the
+    :class:`storage.models.ScaleFile` model. It has the same set of fields, but a different manager that provides
+    functionality specific to product files.
     """
-
-    file = models.OneToOneField('storage.ScaleFile', primary_key=True, parent_link=True)
-    job_exe = models.ForeignKey('job.JobExecution', on_delete=models.PROTECT)
-    job = models.ForeignKey('job.Job', on_delete=models.PROTECT)
-    job_type = models.ForeignKey('job.JobType', on_delete=models.PROTECT)
-    is_operational = models.BooleanField(default=True)
-
-    has_been_published = models.BooleanField(default=False)
-    is_published = models.BooleanField(default=False)
-    is_superseded = models.BooleanField(default=False)
-    published = models.DateTimeField(blank=True, null=True)
-    unpublished = models.DateTimeField(blank=True, null=True)
-    superseded = models.DateTimeField(blank=True, null=True)
 
     objects = ProductFileManager()
 
     class Meta(object):
         """meta information for the db"""
-        db_table = 'product_file'
+        proxy = True

--- a/scale/product/models.py
+++ b/scale/product/models.py
@@ -10,7 +10,6 @@ from django.db import transaction
 
 import storage.geospatial_utils as geo_utils
 from recipe.models import Recipe
-from source.models import SourceFile
 from storage.brokers.broker import FileUpload
 from storage.models import ScaleFile
 from util.parse import parse_datetime

--- a/scale/product/test/test_models.py
+++ b/scale/product/test/test_models.py
@@ -20,6 +20,7 @@ import trigger.test.utils as trigger_test_utils
 from job.execution.container import SCALE_JOB_EXE_OUTPUT_PATH
 from job.models import Job
 from product.models import FileAncestryLink, ProductFile
+from storage.models import ScaleFile
 
 
 class TestFileAncestryLinkManagerCreateFileAncestryLinks(TestCase):
@@ -224,9 +225,9 @@ class TestProductFileManager(TestCase):
         when = now()
         ProductFile.objects.publish_products(self.job_exe, when)
 
-        product_1 = ProductFile.objects.get(id=self.product_1.id)
-        product_2 = ProductFile.objects.get(id=self.product_2.id)
-        product_3 = ProductFile.objects.get(id=self.product_3.id)
+        product_1 = ScaleFile.objects.get(id=self.product_1.id)
+        product_2 = ScaleFile.objects.get(id=self.product_2.id)
+        product_3 = ScaleFile.objects.get(id=self.product_3.id)
         self.assertTrue(product_1.has_been_published)
         self.assertTrue(product_1.is_published)
         self.assertEqual(product_1.published, when)
@@ -244,9 +245,9 @@ class TestProductFileManager(TestCase):
         when = now()
         ProductFile.objects.publish_products(self.job_exe, when)
 
-        product_1 = ProductFile.objects.get(id=self.product_1.id)
-        product_2 = ProductFile.objects.get(id=self.product_2.id)
-        product_3 = ProductFile.objects.get(id=self.product_3.id)
+        product_1 = ScaleFile.objects.get(id=self.product_1.id)
+        product_2 = ScaleFile.objects.get(id=self.product_2.id)
+        product_3 = ScaleFile.objects.get(id=self.product_3.id)
         self.assertFalse(product_1.has_been_published)
         self.assertFalse(product_1.is_published)
         self.assertIsNone(product_1.published)
@@ -285,10 +286,10 @@ class TestProductFileManager(TestCase):
         ProductFile.objects.publish_products(job_exe_3, when)
 
         # Make sure products from Job 1 and Job 2 are unpublished
-        product_1_a = ProductFile.objects.get(id=product_1_a.id)
-        product_1_b = ProductFile.objects.get(id=product_1_b.id)
-        product_2_a = ProductFile.objects.get(id=product_2_a.id)
-        product_2_b = ProductFile.objects.get(id=product_2_b.id)
+        product_1_a = ScaleFile.objects.get(id=product_1_a.id)
+        product_1_b = ScaleFile.objects.get(id=product_1_b.id)
+        product_2_a = ScaleFile.objects.get(id=product_2_a.id)
+        product_2_b = ScaleFile.objects.get(id=product_2_b.id)
         self.assertTrue(product_1_a.has_been_published)
         self.assertFalse(product_1_a.is_published)
         self.assertEqual(product_1_a.unpublished, when)
@@ -303,8 +304,8 @@ class TestProductFileManager(TestCase):
         self.assertEqual(product_2_b.unpublished, when)
 
         # Make sure Job 3 products are published
-        product_3_a = ProductFile.objects.get(id=product_3_a.id)
-        product_3_b = ProductFile.objects.get(id=product_3_b.id)
+        product_3_a = ScaleFile.objects.get(id=product_3_a.id)
+        product_3_b = ScaleFile.objects.get(id=product_3_b.id)
         self.assertTrue(product_3_a.has_been_published)
         self.assertTrue(product_3_a.is_published)
         self.assertFalse(product_3_a.is_superseded)
@@ -333,18 +334,18 @@ class TestProductFileManager(TestCase):
         product_c = prod_test_utils.create_product(uuid=uuid_3, has_been_published=True, is_published=True)
 
         # Set the new products with the same UUIDs
-        ProductFile.objects.filter(id=self.product_1.id).update(uuid=uuid_1)
-        ProductFile.objects.filter(id=self.product_2.id).update(uuid=uuid_2)
-        ProductFile.objects.filter(id=self.product_3.id).update(uuid=uuid_3)
+        ScaleFile.objects.filter(id=self.product_1.id).update(uuid=uuid_1)
+        ScaleFile.objects.filter(id=self.product_2.id).update(uuid=uuid_2)
+        ScaleFile.objects.filter(id=self.product_3.id).update(uuid=uuid_3)
 
         # Publish new products
         when = now()
         ProductFile.objects.publish_products(self.job_exe, when)
 
         # Check old products to make sure they are superseded
-        product_a = ProductFile.objects.get(id=product_a.id)
-        product_b = ProductFile.objects.get(id=product_b.id)
-        product_c = ProductFile.objects.get(id=product_c.id)
+        product_a = ScaleFile.objects.get(id=product_a.id)
+        product_b = ScaleFile.objects.get(id=product_b.id)
+        product_c = ScaleFile.objects.get(id=product_c.id)
         self.assertFalse(product_a.is_published)
         self.assertTrue(product_a.is_superseded)
         self.assertEqual(product_a.superseded, when)
@@ -441,7 +442,7 @@ class TestProductFileManagerPopulateSourceAncestors(TestCase):
     def test_successful(self):
         """Tests calling ProductFileManager.populate_source_ancestors() successfully"""
 
-        products = ProductFile.objects.filter(id__in=[self.product_1.id, self.product_2.id, self.product_3.id])
+        products = ScaleFile.objects.filter(id__in=[self.product_1.id, self.product_2.id, self.product_3.id])
 
         ProductFile.objects.populate_source_ancestors(products)
 

--- a/scale/product/test/test_models.py
+++ b/scale/product/test/test_models.py
@@ -525,7 +525,7 @@ class TestProductFileManagerUploadFiles(TestCase):
         """Tests calling ProductFileManager.upload_files() with a non-operational input file"""
         products_no = ProductFile.objects.upload_files(self.files_no, [self.source_file.id], self.job_exe_no,
                                                        self.workspace)
-        products = ProductFile.objects.upload_files(self.files, [self.source_file.id, products_no[0].file.id],
+        products = ProductFile.objects.upload_files(self.files, [self.source_file.id, products_no[0].id],
                                                     self.job_exe, self.workspace)
         self.assertFalse(products[0].is_operational)
         self.assertFalse(products[1].is_operational)

--- a/scale/product/test/test_models.py
+++ b/scale/product/test/test_models.py
@@ -505,6 +505,7 @@ class TestProductFileManagerUploadFiles(TestCase):
         products = ProductFile.objects.upload_files(self.files, [self.source_file.id], self.job_exe, self.workspace)
 
         self.assertEqual('file.txt', products[0].file_name)
+        self.assertEqual('PRODUCT', products[0].file_type)
         self.assertEqual('remote/1/file.txt', products[0].file_path)
         self.assertEqual('text/plain', products[0].media_type)
         self.assertEqual(self.workspace.id, products[0].workspace_id)
@@ -512,6 +513,7 @@ class TestProductFileManagerUploadFiles(TestCase):
         self.assertTrue(products[0].is_operational)
 
         self.assertEqual('file.json', products[1].file_name)
+        self.assertEqual('PRODUCT', products[1].file_type)
         self.assertEqual('remote/2/file.json', products[1].file_path)
         self.assertEqual('application/x-custom-json', products[1].media_type)
         self.assertEqual(self.workspace.id, products[1].workspace_id)

--- a/scale/product/test/utils.py
+++ b/scale/product/test/utils.py
@@ -6,7 +6,8 @@ import hashlib
 import django.utils.timezone as timezone
 
 from job.test import utils as job_utils
-from product.models import FileAncestryLink, ProductFile
+from product.models import FileAncestryLink
+from storage.models import ScaleFile
 from storage.test import utils as storage_utils
 
 
@@ -38,7 +39,7 @@ def create_product(job_exe=None, workspace=None, has_been_published=False, is_pu
     """Creates a product file model for unit testing
 
     :returns: The product model
-    :rtype: :class:`product.models.ProductFile`
+    :rtype: :class:`storage.models.ScaleFile`
     """
 
     if not job_exe:
@@ -55,11 +56,11 @@ def create_product(job_exe=None, workspace=None, has_been_published=False, is_pu
     if is_superseded and not superseded:
         superseded = timezone.now()
 
-    product_file = ProductFile.objects.create(job_exe=job_exe, job=job_exe.job, job_type=job_exe.job.job_type,
-                                              has_been_published=has_been_published, is_published=is_published,
-                                              uuid=uuid, file_name=file_name, media_type=media_type,
-                                              file_size=file_size, file_path=file_path, workspace=workspace,
-                                              is_superseded=is_superseded, superseded=superseded)
+    product_file = ScaleFile.objects.create(file_type='PRODUCT', job_exe=job_exe, job=job_exe.job,
+                                            job_type=job_exe.job.job_type, has_been_published=has_been_published,
+                                            is_published=is_published, uuid=uuid, file_name=file_name,
+                                            media_type=media_type, file_size=file_size, file_path=file_path,
+                                            workspace=workspace, is_superseded=is_superseded, superseded=superseded)
     if countries:
         product_file.countries = countries
         product_file.save()

--- a/scale/product/views.py
+++ b/scale/product/views.py
@@ -10,13 +10,14 @@ from rest_framework.response import Response
 import util.rest as rest_util
 from product.models import ProductFile
 from product.serializers import ProductFileDetailsSerializer, ProductFileSerializer, ProductFileUpdateSerializer
+from storage.models import ScaleFile
 
 logger = logging.getLogger(__name__)
 
 
 class ProductsView(ListAPIView):
     """This view is the endpoint for retrieving a product by filename"""
-    queryset = ProductFile.objects.all()
+    queryset = ScaleFile.objects.all()
     serializer_class = ProductFileSerializer
 
     def list(self, request):
@@ -53,7 +54,7 @@ class ProductsView(ListAPIView):
 
 class ProductDetailsView(RetrieveAPIView):
     """This view is the endpoint for retrieving/updating details of a product file."""
-    queryset = ProductFile.objects.all()
+    queryset = ScaleFile.objects.all()
     serializer_class = ProductFileDetailsSerializer
 
     def retrieve(self, request, product_id=None, file_name=None):
@@ -71,14 +72,15 @@ class ProductDetailsView(RetrieveAPIView):
 
         # Support retrieving by file name in addition to the usual identifier
         if file_name:
-            products = ProductFile.objects.filter(file_name=file_name).values('id').order_by('-published')
+            products = ScaleFile.objects.filter(file_name=file_name, file_type='PRODUCT')
+            products = products.values('id').order_by('-published')
             if not products:
                 raise Http404
             product_id = products[0]['id']
 
         try:
             product = ProductFile.objects.get_details(product_id)
-        except ProductFile.DoesNotExist:
+        except ScaleFile.DoesNotExist:
             raise Http404
 
         serializer = self.get_serializer(product)
@@ -87,7 +89,7 @@ class ProductDetailsView(RetrieveAPIView):
 
 class ProductUpdatesView(ListAPIView):
     """This view is the endpoint for retrieving product updates over a given time range."""
-    queryset = ProductFile.objects.all()
+    queryset = ScaleFile.objects.all()
     serializer_class = ProductFileUpdateSerializer
 
     def list(self, request):

--- a/scale/queue/test/test_models.py
+++ b/scale/queue/test/test_models.py
@@ -595,7 +595,7 @@ class TestQueueManagerQueueNewRecipe(TransactionTestCase):
         queued_job_exe.accepted(node.id, JobResources(cpus=10, mem=1000, disk_in=1000, disk_out=1000, disk_total=2000))
         Queue.objects.schedule_job_executions('123', [queued_job_exe], {})
         results = JobResults()
-        results.add_file_list_parameter('Test Output 1', [product_test_utils.create_product().file_id])
+        results.add_file_list_parameter('Test Output 1', [product_test_utils.create_product().id])
         JobExecution.objects.filter(id=job_exe_1.id).update(results=results.get_dict())
         Queue.objects.handle_job_completion(job_exe_1.id, now(), [])
 

--- a/scale/recipe/test/test_models.py
+++ b/scale/recipe/test/test_models.py
@@ -18,6 +18,7 @@ from recipe.configuration.definition.recipe_definition import RecipeDefinition
 from recipe.exceptions import ReprocessError
 from recipe.handlers.graph_delta import RecipeGraphDelta
 from recipe.models import Recipe, RecipeFile, RecipeJob, RecipeType, RecipeTypeRevision
+from storage.models import ScaleFile
 from trigger.models import TriggerRule
 
 
@@ -577,7 +578,7 @@ class TestRecipeManagerCreateRecipe(TransactionTestCase):
 
         # Check that product of job 2 (which was superseded with no new job) was unpublished
         if product:
-            product = ProductFile.objects.get(id=product.id)
+            product = ScaleFile.objects.get(id=product.id)
             self.assertFalse(product.is_published)
             self.assertIsNotNone(product.unpublished)
 

--- a/scale/source/configuration/source_data_file.py
+++ b/scale/source/configuration/source_data_file.py
@@ -1,6 +1,7 @@
 """Defines the source data file input type contained within job data"""
 from job.configuration.data.data_file import AbstractDataFileParseSaver
 from source.models import SourceFile
+from storage.models import ScaleFile
 from util.parse import parse_datetime
 
 
@@ -13,7 +14,7 @@ class SourceDataFileParseSaver(AbstractDataFileParseSaver):
         """
 
         file_name_to_id = {}
-        source_files = SourceFile.objects.filter(id__in=input_file_ids)
+        source_files = ScaleFile.objects.filter(id__in=input_file_ids, file_type='SOURCE')
         for source_file in source_files:
             file_name_to_id[source_file.file_name] = source_file.id
 

--- a/scale/source/migrations/0002_auto_20170127_1336.py
+++ b/scale/source/migrations/0002_auto_20170127_1336.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import connection, models, migrations
+
+
+def copy_source_file(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute('SELECT * INTO source_file_temp FROM source_file')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('source', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_source_file),
+    ]

--- a/scale/source/migrations/0003_auto_20170127_1342.py
+++ b/scale/source/migrations/0003_auto_20170127_1342.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('product', '0004_auto_20170127_1324'),
+        ('storage', '0003_auto_20161202_1621'),
+        ('recipe', '0016_recipefile_data'),
+        ('ingest', '0008_auto_20170127_1332'),
+        ('source', '0002_auto_20170127_1336'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='sourcefile',
+            name='file',
+        ),
+        migrations.DeleteModel(
+            name='SourceFile',
+        ),
+        migrations.CreateModel(
+            name='SourceFile',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('storage.scalefile',),
+        ),
+    ]

--- a/scale/source/models.py
+++ b/scale/source/models.py
@@ -171,25 +171,13 @@ class SourceFileManager(models.GeoManager):
 
 
 class SourceFile(ScaleFile):
-    """Represents a source data file that is available for processing. This is an extension of the
-    :class:`storage.models.ScaleFile` model.
-
-    :keyword file: The corresponding ScaleFile model
-    :type file: :class:`django.db.models.OneToOneField`
-
-    :keyword is_parsed: Whether the source file has been parsed or not
-    :type is_parsed: :class:`django.db.models.BooleanField`
-    :keyword parsed: When the source file was parsed
-    :type parsed: :class:`django.db.models.DateTimeField`
+    """Represents a source data file that is available for processing. This is a proxy model of the
+    :class:`storage.models.ScaleFile` model. It has the same set of fields, but a different manager that provides
+    functionality specific to source files.
     """
-
-    file = models.OneToOneField('storage.ScaleFile', primary_key=True, parent_link=True)
-
-    is_parsed = models.BooleanField(default=False)
-    parsed = models.DateTimeField(blank=True, null=True)
 
     objects = SourceFileManager()
 
     class Meta(object):
         """meta information for the db"""
-        db_table = 'source_file'
+        proxy = True

--- a/scale/source/models.py
+++ b/scale/source/models.py
@@ -20,6 +20,19 @@ class SourceFileManager(models.GeoManager):
     """Provides additional methods for handling source files
     """
 
+    def get_source_file_by_name(self, file_name):
+        """Returns the source file with the given file name
+
+        :param file_name: The name of the source file
+        :type file_name: string
+        :returns: The list of source files that match the time range.
+        :rtype: :class:`storage.models.ScaleFile`
+
+        :raises :class:`storage.models.ScaleFile.DoesNotExist`: If the file does not exist
+        """
+
+        return ScaleFile.objects.get(file_name=file_name, file_type='SOURCE')
+
     def get_sources(self, started=None, ended=None, is_parsed=None, file_name=None, order=None):
         """Returns a list of source files within the given time range.
 
@@ -34,11 +47,11 @@ class SourceFileManager(models.GeoManager):
         :param order: A list of fields to control the sort order.
         :type order: list[str]
         :returns: The list of source files that match the time range.
-        :rtype: list[:class:`source.models.SourceFile`]
+        :rtype: list[:class:`storage.models.ScaleFile`]
         """
 
         # Fetch a list of source files
-        sources = SourceFile.objects.all()
+        sources = ScaleFile.objects.all()
         sources = sources.select_related('workspace').defer('workspace__json_config')
         sources = sources.prefetch_related('countries')
 
@@ -69,12 +82,14 @@ class SourceFileManager(models.GeoManager):
         :param include_superseded: Whether or not superseded products should be included.
         :type include_superseded: bool
         :returns: The source with extra related attributes: ingests and products.
-        :rtype: :class:`source.models.SourceFile`
+        :rtype: :class:`storage.models.ScaleFile`
+
+        :raises :class:`storage.models.ScaleFile.DoesNotExist`: If the file does not exist
         """
 
         # Attempt to fetch the requested source
-        source = SourceFile.objects.all().select_related('workspace')
-        source = source.get(pk=source_id)
+        source = ScaleFile.objects.all().select_related('workspace')
+        source = source.get(pk=source_id, file_type='SOURCE')
 
         # Attempt to fetch all ingests for the source
         # Use a localized import to make higher level application dependencies optional
@@ -128,7 +143,7 @@ class SourceFileManager(models.GeoManager):
             geom, props = geo_utils.parse_geo_json(geo_json)
 
         # Acquire model lock
-        src_file = SourceFile.objects.select_for_update().get(pk=src_file_id)
+        src_file = ScaleFile.objects.select_for_update().get(pk=src_file_id, file_type='SOURCE')
         src_file.is_parsed = True
         src_file.parsed = now()
         src_file.data_started = data_started

--- a/scale/source/models.py
+++ b/scale/source/models.py
@@ -100,20 +100,13 @@ class SourceFileManager(models.GeoManager):
             source.ingests = []
 
         # Attempt to fetch all products derived from the source
-        # Use a localized import to make higher level application dependencies optional
-        try:
-            from product.models import ProductFile
-            products = ProductFile.objects.filter(ancestors__ancestor_id=source.id)
-
-            # Exclude superseded products by default
-            if not include_superseded:
-                products = products.filter(is_superseded=False)
-
-            products = products.select_related('job_type', 'workspace').defer('workspace__json_config')
-            products = products.prefetch_related('countries').order_by('created')
-            source.products = products
-        except:
-            source.products = []
+        products = ScaleFile.objects.filter(ancestors__ancestor_id=source.id, file_type='PRODUCT')
+        # Exclude superseded products by default
+        if not include_superseded:
+            products = products.filter(is_superseded=False)
+        products = products.select_related('job_type', 'workspace').defer('workspace__json_config')
+        products = products.prefetch_related('countries').order_by('created')
+        source.products = products
 
         return source
 

--- a/scale/source/models.py
+++ b/scale/source/models.py
@@ -184,6 +184,18 @@ class SourceFile(ScaleFile):
     functionality specific to source files.
     """
 
+    @classmethod
+    def create(cls):
+        """Creates a new source file
+
+        :returns: The new source file
+        :rtype: :class:`source.models.SourceFile`
+        """
+
+        src_file = SourceFile()
+        src_file.file_type = 'SOURCE'
+        return src_file
+
     objects = SourceFileManager()
 
     class Meta(object):

--- a/scale/source/test/configuration/test_source_data_file.py
+++ b/scale/source/test/configuration/test_source_data_file.py
@@ -8,8 +8,7 @@ from django.test import TestCase
 from mock import call, patch
 
 from source.configuration.source_data_file import SourceDataFileParseSaver
-from source.models import SourceFile
-from storage.models import Workspace
+from storage.models import ScaleFile, Workspace
 from util.parse import parse_datetime
 
 
@@ -21,12 +20,14 @@ class TestSourceDataFileParseSaverSaveParseResults(TestCase):
         self.workspace = Workspace.objects.create(name='Test workspace')
         self.file_name_1 = 'my_file.txt'
         self.media_type_1 = 'text/plain'
-        self.source_file_1 = SourceFile.objects.create(file_name=self.file_name_1, media_type=self.media_type_1, file_size=10,
-                                                       data_type='Dummy', file_path='the_path', workspace=self.workspace)
+        self.source_file_1 = ScaleFile.objects.create(file_name=self.file_name_1, file_type='SOURCE',
+                                                      media_type=self.media_type_1, file_size=10, data_type='Dummy',
+                                                      file_path='the_path', workspace=self.workspace)
         self.file_name_2 = 'my_file.json'
         self.media_type_2 = 'application/json'
-        self.source_file_2 = SourceFile.objects.create(file_name=self.file_name_2, media_type=self.media_type_2, file_size=10,
-                                                       data_type='Dummy', file_path='the_path', workspace=self.workspace)
+        self.source_file_2 = ScaleFile.objects.create(file_name=self.file_name_2, file_type='SOURCE',
+                                                      media_type=self.media_type_2, file_size=10, data_type='Dummy',
+                                                      file_path='the_path', workspace=self.workspace)
 
         self.extra_source_file_id = 99999
 

--- a/scale/source/test/test_models.py
+++ b/scale/source/test/test_models.py
@@ -6,12 +6,12 @@ import os
 import django
 from django.test import TestCase
 from django.utils.timezone import now
-from mock import patch, MagicMock
+from mock import patch
 
 from job.test import utils as job_utils
 from source.models import SourceFile
 from storage.brokers.broker import FileMove
-from storage.models import Workspace
+from storage.models import ScaleFile, Workspace
 from storage.test import utils as storage_utils
 from trigger.models import TriggerEvent
 from trigger.test import utils as trigger_utils
@@ -28,9 +28,9 @@ class TestSourceFileManagerSaveParseResults(TestCase):
 
         workspace = Workspace.objects.create(name='Test Workspace', is_active=True, created=now(), last_modified=now())
 
-        self.src_file = SourceFile.objects.create(file_name='text.txt', media_type='text/plain', file_size=10,
-                                                  data_type='type', file_path='the_path', workspace=workspace)
-
+        self.src_file = ScaleFile.objects.create(file_name='text.txt', file_type='SOURCE', media_type='text/plain',
+                                                 file_size=10, data_type='type', file_path='the_path',
+                                                 workspace=workspace)
 
         self.started = now()
         self.ended = self.started + datetime.timedelta(days=1)
@@ -87,7 +87,7 @@ class TestSourceFileManagerSaveParseResults(TestCase):
                                               [], None)
 
         # Check results
-        src_file = SourceFile.objects.get(pk=self.src_file.id)
+        src_file = ScaleFile.objects.get(pk=self.src_file.id)
         self.assertEqual(src_file.is_parsed, True)
         self.assertIsNotNone(src_file.parsed)
         self.assertEqual(src_file.data_started, self.started)
@@ -103,7 +103,7 @@ class TestSourceFileManagerSaveParseResults(TestCase):
         SourceFile.objects.save_parse_results(self.src_file.id, FEATURE_GEOJSON, self.started, self.ended, [], None)
 
         # Check results
-        src_file = SourceFile.objects.get(pk=self.src_file.id)
+        src_file = ScaleFile.objects.get(pk=self.src_file.id)
         self.assertEqual(src_file.is_parsed, True)
         self.assertIsNotNone(src_file.parsed)
         self.assertEqual(src_file.data_started, self.started)
@@ -141,7 +141,7 @@ class TestSourceFileManagerSaveParseResults(TestCase):
         SourceFile.objects.save_parse_results(self.src_file.id, POLYGON_GEOJSON, None, None, [], None)
 
         # Check results
-        src_file = SourceFile.objects.get(pk=self.src_file.id)
+        src_file = ScaleFile.objects.get(pk=self.src_file.id)
         self.assertEqual(src_file.is_parsed, True)
         self.assertIsNotNone(src_file.parsed)
         self.assertIsNone(src_file.data_started)

--- a/scale/source/test/triggers/test_parse_trigger_handler.py
+++ b/scale/source/test/triggers/test_parse_trigger_handler.py
@@ -10,8 +10,8 @@ import storage.test.utils as storage_test_utils
 import trigger.test.utils as trigger_test_utils
 from job.models import JobExecution
 from queue.models import Queue
-from source.models import SourceFile
 from source.triggers.parse_trigger_handler import ParseTriggerHandler
+from storage.models import ScaleFile
 
 
 class TestParseTriggerHandlerProcessParsedSourceFile(TestCase):
@@ -100,9 +100,9 @@ class TestParseTriggerHandlerProcessParsedSourceFile(TestCase):
         self.file_name = 'my_file.txt'
         self.data_type = 'test_file_type'
         self.media_type = 'text/plain'
-        self.source_file = SourceFile.objects.create(file_name=self.file_name, media_type=self.media_type, file_size=10,
-                                                     data_type=self.data_type, file_path='the_path',
-                                                     workspace=self.workspace)
+        self.source_file = ScaleFile.objects.create(file_name=self.file_name, file_type='SOURCE',
+                                                    media_type=self.media_type, file_size=10, data_type=self.data_type,
+                                                    file_path='the_path', workspace=self.workspace)
         self.source_file.add_data_type_tag('type1')
         self.source_file.add_data_type_tag('type2')
         self.source_file.add_data_type_tag('type3')

--- a/scale/source/test/utils.py
+++ b/scale/source/test/utils.py
@@ -5,7 +5,7 @@ import hashlib
 
 import django.utils.timezone as timezone
 
-from source.models import SourceFile
+from storage.models import ScaleFile
 from storage.test import utils as storage_utils
 
 
@@ -15,7 +15,7 @@ def create_source(file_name='my_test_file.txt', file_size=100, media_type='text/
     """Creates a source file model for unit testing
 
     :returns: The source file model
-    :rtype: :class:`source.models.SourceFile`
+    :rtype: :class:`storage.models.ScaleFile`
     """
 
     if not data_started:
@@ -27,10 +27,10 @@ def create_source(file_name='my_test_file.txt', file_size=100, media_type='text/
     if not workspace:
         workspace = storage_utils.create_workspace()
 
-    source_file = SourceFile.objects.create(file_name=file_name, media_type=media_type, file_size=file_size,
-                                            file_path=file_path, data_started=data_started, data_ended=data_ended,
-                                            is_parsed=is_parsed, parsed=parsed, workspace=workspace,
-                                            uuid=hashlib.md5(file_name).hexdigest())
+    source_file = ScaleFile.objects.create(file_name=file_name, file_type='SOURCE', media_type=media_type,
+                                           file_size=file_size, file_path=file_path, data_started=data_started,
+                                           data_ended=data_ended, is_parsed=is_parsed, parsed=parsed,
+                                           workspace=workspace, uuid=hashlib.md5(file_name).hexdigest())
     if countries:
         source_file.countries = countries
         source_file.save()

--- a/scale/source/views.py
+++ b/scale/source/views.py
@@ -11,13 +11,14 @@ import util.rest as rest_util
 from source.models import SourceFile
 from source.serializers import SourceFileSerializer, SourceFileUpdateSerializer
 from source.serializers_extra import SourceFileDetailsSerializer
+from storage.models import ScaleFile
 
 logger = logging.getLogger(__name__)
 
 
 class SourcesView(ListAPIView):
     """This view is the endpoint for retrieving source files."""
-    queryset = SourceFile.objects.all()
+    queryset = ScaleFile.objects.all()
     serializer_class = SourceFileSerializer
 
     def list(self, request):
@@ -46,7 +47,7 @@ class SourcesView(ListAPIView):
 
 class SourceDetailsView(RetrieveAPIView):
     """This view is the endpoint for retrieving/updating details of a source file."""
-    queryset = SourceFile.objects.all()
+    queryset = ScaleFile.objects.all()
     serializer_class = SourceFileDetailsSerializer
 
     def retrieve(self, request, source_id=None, file_name=None):
@@ -64,7 +65,7 @@ class SourceDetailsView(RetrieveAPIView):
 
         # Support retrieving by file name in addition to the usual identifier
         if file_name:
-            sources = SourceFile.objects.filter(file_name=file_name).values('id').order_by('-parsed')
+            sources = ScaleFile.objects.filter(file_name=file_name, file_type='SOURCE').values('id').order_by('-parsed')
             if not sources:
                 raise Http404
             source_id = sources[0]['id']
@@ -73,7 +74,7 @@ class SourceDetailsView(RetrieveAPIView):
 
         try:
             source = SourceFile.objects.get_details(source_id, include_superseded=include_superseded)
-        except SourceFile.DoesNotExist:
+        except ScaleFile.DoesNotExist:
             raise Http404
 
         serializer = self.get_serializer(source)
@@ -82,7 +83,7 @@ class SourceDetailsView(RetrieveAPIView):
 
 class SourceUpdatesView(ListAPIView):
     """This view is the endpoint for retrieving source file updates over a given time range."""
-    queryset = SourceFile.objects.all()
+    queryset = ScaleFile.objects.all()
     serializer_class = SourceFileUpdateSerializer
 
     def list(self, request):

--- a/scale/storage/migrations/0004_auto_20170127_1408.py
+++ b/scale/storage/migrations/0004_auto_20170127_1408.py
@@ -8,6 +8,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
+        ('ingest', '0008_auto_20170127_1332'),
         ('product', '0006_auto_20170127_1348'),
         ('source', '0003_auto_20170127_1342'),
         ('job', '0022_jobtype_configuration'),

--- a/scale/storage/migrations/0004_auto_20170127_1408.py
+++ b/scale/storage/migrations/0004_auto_20170127_1408.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('product', '0006_auto_20170127_1348'),
+        ('source', '0003_auto_20170127_1342'),
+        ('job', '0022_jobtype_configuration'),
+        ('storage', '0003_auto_20161202_1621'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='scalefile',
+            name='file_type',
+            field=models.CharField(default='SOURCE', max_length=50, choices=[('SOURCE', 'SOURCE'), ('PRODUCT', 'PRODUCT')]),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='scalefile',
+            name='has_been_published',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='scalefile',
+            name='is_operational',
+            field=models.BooleanField(default=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='scalefile',
+            name='is_parsed',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='scalefile',
+            name='is_published',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='scalefile',
+            name='is_superseded',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='scalefile',
+            name='job',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, blank=True, to='job.Job', null=True, db_index=False),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='scalefile',
+            name='job_exe',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, blank=True, to='job.JobExecution', null=True, db_index=False),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='scalefile',
+            name='job_type',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, blank=True, to='job.JobType', null=True, db_index=False),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='scalefile',
+            name='parsed',
+            field=models.DateTimeField(null=True, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='scalefile',
+            name='published',
+            field=models.DateTimeField(null=True, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='scalefile',
+            name='superseded',
+            field=models.DateTimeField(null=True, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='scalefile',
+            name='unpublished',
+            field=models.DateTimeField(null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/scale/storage/migrations/0005_auto_20170127_1412.py
+++ b/scale/storage/migrations/0005_auto_20170127_1412.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import connection, models, migrations
+
+
+def populate_scale_file(apps, schema_editor):
+    with connection.cursor() as cursor:
+        cursor.execute('UPDATE scale_file f SET is_parsed = s.is_parsed, parsed = s.parsed FROM source_file_temp s WHERE f.id = s.file_id')
+        cursor.execute('UPDATE scale_file f SET file_type = \'PRODUCT\', job_exe_id = p.job_exe_id, job_id = p.job_id, job_type_id = p.job_type_id, is_operational = p.is_operational, has_been_published = p.has_been_published, is_published = p.is_published, is_superseded = p.is_superseded, published = p.published, unpublished = p.unpublished, superseded = p.superseded FROM product_file_temp p WHERE f.id = p.file_id')
+        cursor.execute('DROP TABLE source_file_temp')
+        cursor.execute('DROP TABLE product_file_temp')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storage', '0004_auto_20170127_1408'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_scale_file),
+    ]

--- a/scale/storage/migrations/0006_auto_20170127_1423.py
+++ b/scale/storage/migrations/0006_auto_20170127_1423.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storage', '0005_auto_20170127_1412'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='scalefile',
+            name='file_type',
+            field=models.CharField(default='SOURCE', max_length=50, db_index=True, choices=[('SOURCE', 'SOURCE'), ('PRODUCT', 'PRODUCT')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='scalefile',
+            name='job',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, blank=True, to='job.Job', null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='scalefile',
+            name='job_exe',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, blank=True, to='job.JobExecution', null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='scalefile',
+            name='job_type',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, blank=True, to='job.JobType', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/scale/storage/models.py
+++ b/scale/storage/models.py
@@ -308,10 +308,10 @@ class ScaleFileManager(models.Manager):
 class ScaleFile(models.Model):
     """Represents a file that is stored within a Scale workspace
 
-    :keyword id: The ID of the file
-    :type id: :class:`storage.models.BigAutoField`
     :keyword file_name: The name of the file
     :type file_name: :class:`django.db.models.CharField`
+    :keyword file_type: The (Scale) type of the file
+    :type file_type: :class:`django.db.models.CharField`
     :keyword media_type: The IANA media type of the file
     :type media_type: :class:`django.db.models.CharField`
     :keyword file_size: The size of the file in bytes
@@ -347,9 +347,45 @@ class ScaleFile(models.Model):
     :type meta_data: :class:`djorm_pgjson.fields.JSONField`
     :keyword countries: List of countries represented in this file as indicated by the file's geometry.
     :type countries: :class:`django.db.models.ManyToManyField` of :class:`storage.models.CountryData`
+
+    :keyword is_parsed: Whether the source file has been parsed or not
+    :type is_parsed: :class:`django.db.models.BooleanField`
+    :keyword parsed: When the source file was parsed
+    :type parsed: :class:`django.db.models.DateTimeField`
+
+    :keyword job_exe: The job execution that created this product
+    :type job_exe: :class:`django.db.models.ForeignKey`
+    :keyword job: The job that created this product
+    :type job: :class:`django.db.models.ForeignKey`
+    :keyword job_type: The type of the job that created this product
+    :type job_type: :class:`django.db.models.ForeignKey`
+    :keyword is_operational: Whether this product was produced by an operational job type (True) or by a job type that
+        is still in a research & development (R&D) phase (False)
+    :type is_operational: :class:`django.db.models.BooleanField`
+    :keyword has_been_published: Whether this product has ever been published. A product becomes published when its job
+        execution completes successfully. A product that has been published will appear in the API call to retrieve
+        product updates.
+    :type has_been_published: :class:`django.db.models.BooleanField`
+    :keyword is_published: Whether this product is currently published. A published product has had its job execution
+        complete successfully and has not been unpublished.
+    :type is_published: :class:`django.db.models.BooleanField`
+    :keyword is_superseded: Whether this product has been superseded by another product with the same UUID
+    :type is_superseded: :class:`django.db.models.BooleanField`
+    :keyword published: When this product was published (its job execution was completed)
+    :type published: :class:`django.db.models.DateTimeField`
+    :keyword unpublished: When this product was unpublished
+    :type unpublished: :class:`django.db.models.DateTimeField`
+    :keyword superseded: When this product was superseded
+    :type superseded: :class:`django.db.models.DateTimeField`
     """
 
+    FILE_TYPES = (
+        ('SOURCE', 'SOURCE'),
+        ('PRODUCT', 'PRODUCT'),
+    )
+
     file_name = models.CharField(max_length=250, db_index=True)
+    file_type = models.CharField(choices=FILE_TYPES, default='SOURCE', max_length=50, db_index=True)
     media_type = models.CharField(max_length=250)
     file_size = models.BigIntegerField()
     data_type = models.TextField(blank=True)
@@ -369,6 +405,22 @@ class ScaleFile(models.Model):
     center_point = models.PointField(blank=True, null=True, srid=4326)
     meta_data = djorm_pgjson.fields.JSONField()
     countries = models.ManyToManyField(CountryData)
+
+    # Source file fields
+    is_parsed = models.BooleanField(default=False)
+    parsed = models.DateTimeField(blank=True, null=True)
+
+    # Product file fields
+    job_exe = models.ForeignKey('job.JobExecution', blank=True, null=True, on_delete=models.PROTECT)
+    job = models.ForeignKey('job.Job', blank=True, null=True, on_delete=models.PROTECT)
+    job_type = models.ForeignKey('job.JobType', blank=True, null=True, on_delete=models.PROTECT)
+    is_operational = models.BooleanField(default=True)
+    has_been_published = models.BooleanField(default=False)
+    is_published = models.BooleanField(default=False)
+    is_superseded = models.BooleanField(default=False)
+    published = models.DateTimeField(blank=True, null=True)
+    unpublished = models.DateTimeField(blank=True, null=True)
+    superseded = models.DateTimeField(blank=True, null=True)
 
     objects = ScaleFileManager()
 


### PR DESCRIPTION
This PR refactors the scale_file table to improve query performance related to source and product files.

Through a series of migrations, the source_file and product_file fields are added to the scale_file table, which will now contain all file fields. A new file_type field has been added as well to distinguish between 'SOURCE' and 'PRODUCT' files. Moving everything to one table improves the ability to index the data appropriately and eliminates the joins previously needed to the source_file and product_file tables.

The SourceFile and ProductFile models are now Django proxy models, which basically have no affect on the database tables and offer model functionality specific to source/product files through their managers.

All Scale manager logic has been updated to reflect the model changes.