### PR TITLE
Issue 722 - Settings bug fix

### DIFF
--- a/scale/job/configuration/configuration/job_configuration.py
+++ b/scale/job/configuration/configuration/job_configuration.py
@@ -7,7 +7,7 @@ from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 
 from job.configuration.configuration import job_configuration_1_0 as previous_version
-from job.configuration.configuration.job_parameter import DockerParam, TaskWorkspace, TaskSetting
+from job.configuration.configuration.job_parameter import TaskSetting
 from job.configuration.configuration.exceptions import InvalidJobConfiguration
 
 
@@ -176,7 +176,7 @@ class JobConfiguration(previous_version.JobConfiguration):
         :type value: string
         """
 
-        self._configuration['job_task']['settings'].append({'name': name, 'value': value})
+        self._configuration['job_task']['settings'].append({'name': name, 'value': str(value)})
 
     def add_post_task_setting(self, name, value):
         """Adds a setting name/value to this job's post task
@@ -187,7 +187,7 @@ class JobConfiguration(previous_version.JobConfiguration):
         :type value: string
         """
 
-        self._configuration['post_task']['settings'].append({'name': name, 'value': value})
+        self._configuration['post_task']['settings'].append({'name': name, 'value': str(value)})
 
     def add_pre_task_setting(self, name, value):
         """Adds a setting name/value to this job's pre task
@@ -198,7 +198,7 @@ class JobConfiguration(previous_version.JobConfiguration):
         :type value: string
         """
 
-        self._configuration['pre_task']['settings'].append({'name': name, 'value': value})
+        self._configuration['pre_task']['settings'].append({'name': name, 'value': str(value)})
 
     def get_job_task_settings(self):
         """Returns the settings name/values needed for the job task

--- a/scale/job/configuration/interface/exceptions.py
+++ b/scale/job/configuration/interface/exceptions.py
@@ -10,6 +10,12 @@ class InvalidInterfaceDefinition(Exception):
     pass
 
 
+class InvalidJobTypeConfiguration(Exception):
+    """Exception indicating that the provided job type configuration was invalid
+    """
+    pass
+
+
 class InvalidEnvironment(Exception):
     """Exception indicating that the provided definition of a job interface was invalid
     """

--- a/scale/job/test/configuration/interface/test_configuration_interface.py
+++ b/scale/job/test/configuration/interface/test_configuration_interface.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import django
 from django.test import TestCase
 
-from job.configuration.interface.exceptions import InvalidInterfaceDefinition
+from job.configuration.interface.exceptions import InvalidJobTypeConfiguration
 from job.configuration.interface.job_type_configuration import JobTypeConfiguration
 
 
@@ -25,7 +25,7 @@ class TestJobTypeConfiguration(TestCase):
                       'name2': 'val2'
                   }}
 
-        self.assertRaises(InvalidInterfaceDefinition, JobTypeConfiguration, config)
+        self.assertRaises(InvalidJobTypeConfiguration, JobTypeConfiguration, config)
 
         # Missing value
         config = {'version': '1.0',
@@ -34,7 +34,7 @@ class TestJobTypeConfiguration(TestCase):
                       'name2': 'val2'
                   }}
 
-        self.assertRaises(InvalidInterfaceDefinition, JobTypeConfiguration, config)
+        self.assertRaises(InvalidJobTypeConfiguration, JobTypeConfiguration, config)
 
         # Wrong version
         config = {'version': '0.9',
@@ -42,4 +42,11 @@ class TestJobTypeConfiguration(TestCase):
                       'name1': 'val1',
                       'name2': 'val2'
                   }}
-        self.assertRaises(InvalidInterfaceDefinition, JobTypeConfiguration, config)
+        self.assertRaises(InvalidJobTypeConfiguration, JobTypeConfiguration, config)
+
+        # Invalid value (int)
+        config = {'version': '1.0',
+                  'default_settings': {
+                      'name1': 1234
+                  }}
+        self.assertRaises(InvalidJobTypeConfiguration, JobTypeConfiguration, config)


### PR DESCRIPTION
Added validation to job type configuration to ensure that settings values are always strings.
Also added automatic string conversion when settings are added to a job configuration.