### PR TITLE
Issue 729 - REST API for source products

### DIFF
--- a/scale/docs/rest/source_file.rst
+++ b/scale/docs/rest/source_file.rst
@@ -322,6 +322,193 @@ These services provide access to information about source files that Scale has i
 |    }                                                                                                                    |
 +-------------------------------------------------------------------------------------------------------------------------+
 
+.. _rest_source_file_products:
+
++-------------------------------------------------------------------------------------------------------------------------+
+| **Source File Product List**                                                                                            |
++=========================================================================================================================+
+| Returns a list of all products that were produced by the given source file ID                                           |
++-------------------------------------------------------------------------------------------------------------------------+
+| **GET** /sources/{id}/products/                                                                                         |
+|         Where {id} is the unique identifier of an existing model.                                                       |
++-------------------------------------------------------------------------------------------------------------------------+
+| **Query Parameters**                                                                                                    |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| page               | Integer           | Optional | The page of the results to return. Defaults to 1.                   |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| page_size          | Integer           | Optional | The size of the page to use for pagination of results.              |
+|                    |                   |          | Defaults to 100, and can be anywhere from 1-1000.                   |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| started            | ISO-8601 Datetime | Optional | The start of the time range to query.                               |
+|                    |                   |          | Supports the ISO-8601 date/time format, (ex: 2015-01-01T00:00:00Z). |
+|                    |                   |          | Supports the ISO-8601 duration format, (ex: PT3H0M0S).              |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| ended              | ISO-8601 Datetime | Optional | End of the time range to query, defaults to the current time.       |
+|                    |                   |          | Supports the ISO-8601 date/time format, (ex: 2015-01-01T00:00:00Z). |
+|                    |                   |          | Supports the ISO-8601 duration format, (ex: PT3H0M0S).              |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| order              | String            | Optional | One or more fields to use when ordering the results.                |
+|                    |                   |          | Duplicate it to multi-sort, (ex: order=file_name&order=created).    |
+|                    |                   |          | Nested objects require a delimiter (ex: order=job_type__name).      |
+|                    |                   |          | Prefix fields with a dash to reverse the sort, (ex: order=-created).|
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| batch_id           | Integer           | Optional | Return only products produced by the given batch identifier.        |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_type_id        | Integer           | Optional | Return only jobs with a given job type identifier.                  |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_type_name      | String            | Optional | Return only jobs with a given job type name.                        |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_type_category  | String            | Optional | Return only jobs with a given job type category.                    |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| is_operational     | Boolean           | Optional | Return only products flagged as operational status versus R&D.      |
+|                    |                   |          | Default is include all types of products.                           |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| is_published       | Boolean           | Optional | Return only products flagged as currently exposed for publication.  |
+|                    |                   |          | Default is include all products.                                    |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| file_name          | String            | Optional | Return only products with a given file name.                        |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| **Successful Response**                                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Status**         | 200 OK                                                                                             |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Content Type**   | *application/json*                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| count              | Integer           | The total number of results that match the query parameters.                   |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| next               | URL               | A URL to the next page of results.                                             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| previous           | URL               | A URL to the previous page of results.                                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| results            | Array             | List of result JSON objects that match the query parameters.                   |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .id                | Integer           | The unique identifier of the model. Can be passed to the details API call.     |
+|                    |                   | (See :ref:`Product Details <rest_product_details>`)                            |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .workspace         | JSON Object       | The workspace that has stored the product.                                     |
+|                    |                   | (See :ref:`Workspace Details <rest_workspace_details>`)                        |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .file_name         | String            | The name of the product file.                                                  |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .media_type        | String            | The IANA media type of the product file.                                       |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .file_size         | Integer           | The size of the product file in bytes.                                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .data_type         | Array             | List of strings describing the data type of the product.                       |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .is_deleted        | Boolean           | Whether the product file has been deleted.                                     |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .uuid              | String            | A unique identifier that stays stable across multiple job execution runs.      |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .url               | URL               | The absolute URL to use for downloading the file.                              |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .created           | ISO-8601 Datetime | When the associated database model was initially created.                      |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .deleted           | ISO-8601 Datetime | When the product file was deleted.                                             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .data_started      | ISO-8601 Datetime | When collection of the underlying data file started.                           |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .data_ended        | ISO-8601 Datetime | When collection of the underlying data file ended.                             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .geometry          | WKT String        | The full geospatial geometry footprint of the product.                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .center_point      | WKT String        | The central geospatial location of the product.                                |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .meta_data         | JSON Object       | A dictionary of key/value pairs that describe product-specific attributes.     |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .countries         | Array             | A list of zero or more strings with the ISO3 country codes for countries       |
+|                    |                   | contained in the geographic boundary of this file.                             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .last_modified     | ISO-8601 Datetime | When the associated database model was last saved.                             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .is_operational    | Boolean           | Whether this product was produced by an operational job type or a job type     |
+|                    |                   | still in research and development.                                             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .is_published      | Boolean           | Whether the product file is currently published.                               |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .has_been_published| Boolean           | Whether the product file has ever been published.                              |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .published         | ISO-8601 Datetime | When the product file was originally published by Scale.                       |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .unpublished       | ISO-8601 Datetime | When the product file was unpublished by Scale.                                |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .job_type          | JSON Object       | The type of job that generated the product.                                    |
+|                    |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .job               | JSON Object       | The job instance that generated the product.                                   |
+|                    |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .job_exe           | JSON Object       | The specific job execution that generated the product.                         |
+|                    |                   | (See :ref:`Job Execution Details <rest_job_execution_details>`)                |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .. code-block:: javascript                                                                                              |
+|                                                                                                                         |
+|    {                                                                                                                    |
+|        "count": 55,                                                                                                     |
+|        "next": null,                                                                                                    |
+|        "previous": null,                                                                                                |
+|        "results": [                                                                                                     |
+|            {                                                                                                            |
+|                "id": 465,                                                                                               |
+|                "workspace": {                                                                                           |
+|                    "id": 2,                                                                                             |
+|                    "name": "Products"                                                                                   |
+|                },                                                                                                       |
+|                "file_name": "my_file.kml",                                                                              |
+|                "media_type": "application/vnd.google-earth.kml+xml",                                                    |
+|                "file_size": 100,                                                                                        |
+|                "data_type": [],                                                                                         |
+|                "is_deleted": false,                                                                                     |
+|                "uuid": "c8928d9183fc99122948e7840ec9a0fd",                                                              |
+|                "url": "http://host.com/file/path/my_file.kml",                                                          |
+|                "created": "1970-01-01T00:00:00Z",                                                                       |
+|                "deleted": null,                                                                                         |
+|                "data_started": null,                                                                                    |
+|                "data_ended": null,                                                                                      |
+|                "geometry": null,                                                                                        |
+|                "center_point": null,                                                                                    |
+|                "meta_data": {...},                                                                                      |
+|                "countries": ["TCY", "TCT"],                                                                             |
+|                "last_modified": "1970-01-01T00:00:00Z",                                                                 |
+|                "is_operational": true,                                                                                  |
+|                "is_published": true,                                                                                    |
+|                "has_been_published": true,                                                                              |
+|                "published": "1970-01-01T00:00:00Z",                                                                     |
+|                "unpublished": null,                                                                                     |
+|                "job_type": {                                                                                            |
+|                    "id": 8,                                                                                             |
+|                    "name": "kml-footprint",                                                                             |
+|                    "version": "1.0.0",                                                                                  |
+|                    "title": "KML Footprint",                                                                            |
+|                    "description": "Creates a KML file.",                                                                |
+|                    "category": "footprint",                                                                             |
+|                    "author_name": null,                                                                                 |
+|                    "author_url": null,                                                                                  |
+|                    "is_system": false,                                                                                  |
+|                    "is_long_running": false,                                                                            |
+|                    "is_active": true,                                                                                   |
+|                    "is_operational": true,                                                                              |
+|                    "is_paused": false,                                                                                  |
+|                    "icon_code": "f0ac"                                                                                  |
+|                },                                                                                                       |
+|                "job": {                                                                                                 |
+|                    "id": 47                                                                                             |
+|                },                                                                                                       |
+|                "job_exe": {                                                                                             |
+|                    "id": 49                                                                                             |
+|                }                                                                                                        |
+|            },                                                                                                           |
+|            ...                                                                                                          |
+|        ]                                                                                                                |
+|    }                                                                                                                    |
++-------------------------------------------------------------------------------------------------------------------------+
+
 .. _rest_source_file_updates:
 
 +-------------------------------------------------------------------------------------------------------------------------+

--- a/scale/product/test/utils.py
+++ b/scale/product/test/utils.py
@@ -11,7 +11,7 @@ from storage.models import ScaleFile
 from storage.test import utils as storage_utils
 
 
-def create_file_link(ancestor=None, descendant=None, job=None, job_exe=None, recipe=None):
+def create_file_link(ancestor=None, descendant=None, job=None, job_exe=None, recipe=None, batch=None):
     """Creates a file ancestry link model for unit testing
 
     :returns: The file ancestry link model
@@ -30,7 +30,7 @@ def create_file_link(ancestor=None, descendant=None, job=None, job_exe=None, rec
             job_exe = job_utils.create_job_exe(job_type=job.job_type, job=job)
 
     return FileAncestryLink.objects.create(ancestor=ancestor, descendant=descendant, job=job, job_exe=job_exe,
-                                           recipe=recipe)
+                                           recipe=recipe, batch=batch)
 
 
 def create_product(job_exe=None, workspace=None, has_been_published=False, is_published=False, uuid=None,

--- a/scale/source/test/test_views.py
+++ b/scale/source/test/test_views.py
@@ -6,7 +6,9 @@ import django
 from django.test import TestCase
 from rest_framework import status
 
+import job.test.utils as job_test_utils
 import source.test.utils as source_test_utils
+import storage.test.utils as storage_test_utils
 import util.rest as rest_util
 
 
@@ -204,6 +206,189 @@ class TestSourceDetailsView(TestCase):
             self.assertEqual(len(result['products']), 2)
             for product in result['products']:
                 self.assertIn(product['id'], [self.product1.id, self.product2.id])
+
+
+class TestSourceProductsView(TestCase):
+
+    fixtures = ['batch_job_types.json']
+
+    def setUp(self):
+        django.setup()
+
+        from batch.test import utils as batch_test_utils
+        from product.test import utils as product_test_utils
+        self.country = storage_test_utils.create_country()
+        self.src_file = source_test_utils.create_source()
+        self.job_type1 = job_test_utils.create_job_type(name='test1', category='test-1', is_operational=True)
+        self.job1 = job_test_utils.create_job(job_type=self.job_type1)
+        self.job_exe1 = job_test_utils.create_job_exe(job=self.job1)
+        self.product1 = product_test_utils.create_product(job_exe=self.job_exe1, has_been_published=True,
+                                                          is_published=True, file_name='test.txt',
+                                                          countries=[self.country])
+        product_test_utils.create_file_link(ancestor=self.src_file, descendant=self.product1, job=self.job1,
+                                            job_exe=self.job_exe1)
+
+        self.batch = batch_test_utils.create_batch()
+        self.job_type2 = job_test_utils.create_job_type(name='test2', category='test-2', is_operational=False)
+        self.job2 = job_test_utils.create_job(job_type=self.job_type2)
+        self.job_exe2 = job_test_utils.create_job_exe(job=self.job2)
+        self.product2a = product_test_utils.create_product(job_exe=self.job_exe2, has_been_published=True,
+                                                           is_published=False, countries=[self.country])
+        product_test_utils.create_file_link(ancestor=self.src_file, descendant=self.product2a, job=self.job2,
+                                            job_exe=self.job_exe2, batch=self.batch)
+
+        self.product2b = product_test_utils.create_product(job_exe=self.job_exe2, has_been_published=True,
+                                                           is_published=True, is_superseded=True,
+                                                           countries=[self.country])
+        product_test_utils.create_file_link(ancestor=self.src_file, descendant=self.product2b, job=self.job2,
+                                            job_exe=self.job_exe2, batch=self.batch)
+
+        self.product2c = product_test_utils.create_product(job_exe=self.job_exe2, has_been_published=True,
+                                                           is_published=True, countries=[self.country])
+        product_test_utils.create_file_link(ancestor=self.src_file, descendant=self.product2c, job=self.job2,
+                                            job_exe=self.job_exe2, batch=self.batch)
+
+    def test_invalid_source_id(self):
+        """Tests calling the source products view when the source ID is invalid."""
+
+        url = rest_util.get_url('/sources/12345678/products/')
+        response = self.client.generic('GET', url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
+
+    def test_invalid_started(self):
+        """Tests calling the source products view when the started parameter is invalid."""
+
+        url = rest_util.get_url('/sources/%d/products/?started=hello' % self.src_file.id)
+        response = self.client.generic('GET', url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+
+    def test_missing_tz_started(self):
+        """Tests calling the source products view when the started parameter is missing timezone."""
+
+        url = rest_util.get_url('/sources/%d/products/?started=1970-01-01T00:00:00' % self.src_file.id)
+        response = self.client.generic('GET', url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+
+    def test_invalid_ended(self):
+        """Tests calling the source products view when the ended parameter is invalid."""
+
+        url = rest_util.get_url('/sources/%d/products/?started=1970-01-01T00:00:00Z&ended=hello' % self.src_file.id)
+        response = self.client.generic('GET', url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+
+    def test_missing_tz_ended(self):
+        """Tests calling the source products view when the ended parameter is missing timezone."""
+
+        url = '/sources/%d/products/?started=1970-01-01T00:00:00Z&ended=1970-01-02T00:00:00' % self.src_file.id
+        url = rest_util.get_url(url)
+        response = self.client.generic('GET', url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+
+    def test_negative_time_range(self):
+        """Tests calling the source products view with a negative time range."""
+
+        url = '/sources/%d/products/?started=1970-01-02T00:00:00Z&ended=1970-01-01T00:00:00' % self.src_file.id
+        url = rest_util.get_url(url)
+        response = self.client.generic('GET', url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+
+    def test_batch_id(self):
+        """Tests successfully calling the source products view filtered by batch identifier."""
+
+        url = rest_util.get_url('/sources/%d/products/?batch_id=%s' % (self.src_file.id, self.batch.id))
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 3)
+
+    def test_job_type_id(self):
+        """Tests successfully calling the source products view filtered by job type identifier."""
+
+        url = rest_util.get_url('/sources/%d/products/?job_type_id=%s' % (self.src_file.id, self.job_type1.id))
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['job_type']['id'], self.job_type1.id)
+
+    def test_job_type_name(self):
+        """Tests successfully calling the source products view filtered by job type name."""
+
+        url = rest_util.get_url('/sources/%d/products/?job_type_name=%s' % (self.src_file.id,  self.job_type1.name))
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['job_type']['name'], self.job_type1.name)
+
+    def test_job_type_category(self):
+        """Tests successfully calling the source products view filtered by job type category."""
+
+        url = '/sources/%d/products/?job_type_category=%s' % (self.src_file.id, self.job_type1.category)
+        url = rest_util.get_url(url)
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['job_type']['category'], self.job_type1.category)
+
+    def test_is_operational(self):
+        """Tests successfully calling the source products view filtered by is_operational flag."""
+
+        url = rest_util.get_url('/sources/%d/products/?is_operational=true' % self.src_file.id)
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['job_type']['is_operational'], self.job_type1.is_operational)
+
+    def test_is_published(self):
+        """Tests successfully calling the source products view filtered by is_published flag."""
+
+        url = rest_util.get_url('/sources/%d/products/?is_published=false' % self.src_file.id)
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['id'], self.product2a.id)
+        self.assertFalse(result['results'][0]['is_published'])
+
+    def test_file_name(self):
+        """Tests successfully calling the source products view filtered by file name."""
+
+        url = rest_util.get_url('/sources/%d/products/?file_name=test.txt' % self.src_file.id)
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['file_name'], self.product1.file_name)
+
+    def test_successful(self):
+        """Tests successfully calling the source products view."""
+
+        url = rest_util.get_url('/sources/%d/products/' % self.src_file.id)
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 4)
+
+        for entry in result['results']:
+            # Make sure country info is included
+            self.assertEqual(entry['countries'][0], self.country.iso3)
 
 
 class TestSourceUpdatesView(TestCase):

--- a/scale/source/urls.py
+++ b/scale/source/urls.py
@@ -9,4 +9,5 @@ urlpatterns = patterns(
     url(r'^sources/updates/$', views.SourceUpdatesView.as_view(), name='source_updates_view'),
     url(r'^sources/(?P<source_id>\d+)/$', views.SourceDetailsView.as_view(), name='source_details_view'),
     url(r'^sources/(?P<file_name>[\w.]{0,250})/$', views.SourceDetailsView.as_view(), name='source_details_view'),
+    url(r'^sources/(?P<source_id>\d+)/products/$', views.SourceProductsView.as_view(), name='source_products_view'),
 )

--- a/scale/source/views.py
+++ b/scale/source/views.py
@@ -8,6 +8,7 @@ from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.response import Response
 
 import util.rest as rest_util
+from product.serializers import ProductFileSerializer
 from source.models import SourceFile
 from source.serializers import SourceFileSerializer, SourceFileUpdateSerializer
 from source.serializers_extra import SourceFileDetailsSerializer
@@ -81,6 +82,52 @@ class SourceDetailsView(RetrieveAPIView):
 
         serializer = self.get_serializer(source)
         return Response(serializer.data)
+
+
+class SourceProductsView(ListAPIView):
+    """This view is the endpoint for retrieving products produced from a source file"""
+    queryset = ScaleFile.objects.all()
+    serializer_class = ProductFileSerializer
+
+    def list(self, request, source_id=None):
+        """Retrieves the products for a given source file ID and returns them in JSON form
+
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :param source_id: The id of the source
+        :type source_id: int encoded as a string
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+
+        try:
+            ScaleFile.objects.get(id=source_id, file_type='SOURCE')
+        except ScaleFile.DoesNotExist:
+            raise Http404
+
+        started = rest_util.parse_timestamp(request, 'started', required=False)
+        ended = rest_util.parse_timestamp(request, 'ended', required=False)
+        rest_util.check_time_range(started, ended)
+
+        batch_ids = rest_util.parse_int_list(request, 'batch_id', required=False)
+        job_type_ids = rest_util.parse_int_list(request, 'job_type_id', required=False)
+        job_type_names = rest_util.parse_string_list(request, 'job_type_name', required=False)
+        job_type_categories = rest_util.parse_string_list(request, 'job_type_category', required=False)
+        is_operational = rest_util.parse_bool(request, 'is_operational', required=False)
+        is_published = rest_util.parse_bool(request, 'is_published', required=False)
+        file_name = rest_util.parse_string(request, 'file_name', required=False)
+
+        order = rest_util.parse_string_list(request, 'order', required=False)
+
+        products = SourceFile.objects.get_source_products(source_id, started=started, ended=ended, batch_ids=batch_ids,
+                                                          job_type_ids=job_type_ids, job_type_names=job_type_names,
+                                                          job_type_categories=job_type_categories,
+                                                          is_operational=is_operational, is_published=is_published,
+                                                          file_name=file_name, order=order)
+
+        page = self.paginate_queryset(products)
+        serializer = self.get_serializer(page, many=True)
+        return self.get_paginated_response(serializer.data)
 
 
 class SourceUpdatesView(ListAPIView):


### PR DESCRIPTION
Created a new REST API to retrieve the products generated from a given source file, with the ability to filter by batch, along with other product field filtering.

/sources/{source-id}/products/?batch_id={batch-id} (along with other product field filtering)