### PR TITLE
Issue 740 - Source Jobs REST API

### DIFF
--- a/scale/docs/rest/source_file.rst
+++ b/scale/docs/rest/source_file.rst
@@ -322,6 +322,198 @@ These services provide access to information about source files that Scale has i
 |    }                                                                                                                    |
 +-------------------------------------------------------------------------------------------------------------------------+
 
+.. _rest_source_file_jobs:
+
++-------------------------------------------------------------------------------------------------------------------------+
+| **Source File Job List**                                                                                                |
++=========================================================================================================================+
+| Returns a list of all jobs related to the source file with the given ID. Jobs marked as superseded are excluded by      |
+| default.                                                                                                                |
++-------------------------------------------------------------------------------------------------------------------------+
+| **GET** /sources/{id}/jobs/                                                                                             |
+|         Where {id} is the unique identifier of an existing source file                                                  |
++-------------------------------------------------------------------------------------------------------------------------+
+| **Query Parameters**                                                                                                    |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| page               | Integer           | Optional | The page of the results to return. Defaults to 1.                   |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| page_size          | Integer           | Optional | The size of the page to use for pagination of results.              |
+|                    |                   |          | Defaults to 100, and can be anywhere from 1-1000.                   |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| started            | ISO-8601 Datetime | Optional | The start of the time range to query.                               |
+|                    |                   |          | Supports the ISO-8601 date/time format, (ex: 2015-01-01T00:00:00Z). |
+|                    |                   |          | Supports the ISO-8601 duration format, (ex: PT3H0M0S).              |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| ended              | ISO-8601 Datetime | Optional | End of the time range to query, defaults to the current time.       |
+|                    |                   |          | Supports the ISO-8601 date/time format, (ex: 2015-01-01T00:00:00Z). |
+|                    |                   |          | Supports the ISO-8601 duration format, (ex: PT3H0M0S).              |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| order              | String            | Optional | One or more fields to use when ordering the results.                |
+|                    |                   |          | Duplicate it to multi-sort, (ex: order=name&order=version).         |
+|                    |                   |          | Prefix fields with a dash to reverse the sort, (ex: order=-name).   |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| status             | String            | Optional | Return only jobs with a status matching this string.                |
+|                    |                   |          | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].            |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_id             | Integer           | Optional | Return only jobs with a given identifier.                           |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_type_id        | Integer           | Optional | Return only jobs with a given job type identifier.                  |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_type_name      | String            | Optional | Return only jobs with a given job type name.                        |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| job_type_category  | String            | Optional | Return only jobs with a given job type category.                    |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| error_category     | String            | Optional | Return only jobs that failed due to an error with a given category. |
+|                    |                   |          | Choices: [SYSTEM, DATA, ALGORITHM].                                 |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| include_superseded | Boolean           | Optional | Whether to include superseded job instances. Defaults to false.     |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| **Successful Response**                                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Status**         | 200 OK                                                                                             |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Content Type**   | *application/json*                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                         |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| count               | Integer           | The total number of results that match the query parameters.                  |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| next                | URL               | A URL to the next page of results.                                            |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| previous            | URL               | A URL to the previous page of results.                                        |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| results             | Array             | List of result JSON objects that match the query parameters.                  |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .id                 | Integer           | The unique identifier of the model. Can be passed to the details API call.    |
+|                     |                   | (See :ref:`Job Details <rest_job_details>`)                                   |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .job_type           | JSON Object       | The job type that is associated with the job.                                 |
+|                     |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                         |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .job_type_rev       | JSON Object       | The job type revision that is associated with the job.                        |
+|                     |                   | This represents the definition at the time the job was scheduled.             |
+|                     |                   | (See :ref:`Job Type Revision Details <rest_job_type_rev_details>`)            |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .event              | JSON Object       | The trigger event that is associated with the job.                            |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .error              | JSON Object       | The error that is associated with the job.                                    |
+|                     |                   | (See :ref:`Error Details <rest_error_details>`)                               |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .status             | String            | The current status of the job.                                                |
+|                     |                   | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].                      |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .priority           | Integer           | The priority of the job.                                                      |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .num_exes           | Integer           | The number of executions this job has had.                                    |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .timeout            | Integer           | The maximum amount of time this job can run before being killed (in seconds). |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .max_tries          | Integer           | The maximum number of times to attempt this job when failed (minimum one).    |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .cpus_required      | Decimal           | The number of CPUs needed for a job of this type.                             |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .mem_required       | Decimal           | The amount of RAM in MiB needed for a job of this type.                       |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .disk_in_required   | Decimal           | The amount of disk space in MiB required for input files for this job.        |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .disk_out_required  | Decimal           | The amount of disk space in MiB required for output files for this job.       |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .is_superseded      | Boolean           | Whether this job has been replaced and is now obsolete.                       |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .root_superseded_job| JSON Object       | The first job in the current chain of superseded jobs.                        |
+|                     |                   | (See :ref:`Job Details <rest_job_details>`)                                   |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .superseded_job     | JSON Object       | The previous job in the chain that was superseded by this job.                |
+|                     |                   | (See :ref:`Job Details <rest_job_details>`)                                   |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .superseded_by_job  | JSON Object       | The next job in the chain that superseded this job.                           |
+|                     |                   | (See :ref:`Job Details <rest_job_details>`)                                   |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .delete_superseded  | Boolean           | Whether the products of the previous job should be deleted when superseded.   |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .created            | ISO-8601 Datetime | When the associated database model was initially created.                     |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .queued             | ISO-8601 Datetime | When the job was added to the queue to be run when resources are available.   |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .started            | ISO-8601 Datetime | When the job started running.                                                 |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .ended              | ISO-8601 Datetime | When the job stopped running, which could be due to success or failure.       |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .last_status_change | ISO-8601 Datetime | When the status of the job was last changed.                                  |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .superseded         | ISO-8601 Datetime | When the the job became superseded by another job.                            |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .last_modified      | ISO-8601 Datetime | When the associated database model was last saved.                            |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| .. code-block:: javascript                                                                                              |
+|                                                                                                                         |
+|    {                                                                                                                    |
+|        "count": 68,                                                                                                     |
+|        "next": null,                                                                                                    |
+|        "previous": null,                                                                                                |
+|        "results": [                                                                                                     |
+|            {                                                                                                            |
+|                "id": 3,                                                                                                 |
+|                "job_type": {                                                                                            |
+|                    "id": 1,                                                                                             |
+|                    "name": "scale-ingest",                                                                              |
+|                    "version": "1.0",                                                                                    |
+|                    "title": "Scale Ingest",                                                                             |
+|                    "description": "Ingests a source file into a workspace",                                             |
+|                    "is_system": true,                                                                                   |
+|                    "is_long_running": false,                                                                            |
+|                    "is_active": true,                                                                                   |
+|                    "is_operational": true,                                                                              |
+|                    "is_paused": false,                                                                                  |
+|                    "icon_code": "f013"                                                                                  |
+|                },                                                                                                       |
+|                "job_type_rev": {                                                                                        |
+|                    "id": 5,                                                                                             |
+|                    "job_type": {                                                                                        |
+|                        "id": 1                                                                                          |
+|                    },                                                                                                   |
+|                    "revision_num": 1                                                                                    |
+|                },                                                                                                       |
+|                "event": {                                                                                               |
+|                    "id": 3,                                                                                             |
+|                    "type": "STRIKE_TRANSFER",                                                                           |
+|                    "rule": null,                                                                                        |
+|                    "occurred": "2015-08-28T17:57:24.261Z"                                                               |
+|                },                                                                                                       |
+|                "error": null,                                                                                           |
+|                "status": "COMPLETED",                                                                                   |
+|                "priority": 10,                                                                                          |
+|                "num_exes": 1,                                                                                           |
+|                "timeout": 1800,                                                                                         |
+|                "max_tries": 3,                                                                                          |
+|                "cpus_required": 1.0,                                                                                    |
+|                "mem_required": 64.0,                                                                                    |
+|                "disk_in_required": 0.0,                                                                                 |
+|                "disk_out_required": 64.0,                                                                               |
+|                "is_superseded": false,                                                                                  |
+|                "root_superseded_job": null,                                                                             |
+|                "superseded_job": null,                                                                                  |
+|                "superseded_by_job": null,                                                                               |
+|                "delete_superseded": true,                                                                               |
+|                "created": "2015-08-28T17:55:41.005Z",                                                                   |
+|                "queued": "2015-08-28T17:56:41.005Z",                                                                    |
+|                "started": "2015-08-28T17:57:41.005Z",                                                                   |
+|                "ended": "2015-08-28T17:58:41.005Z",                                                                     |
+|                "last_status_change": "2015-08-28T17:58:45.906Z",                                                        |
+|                "superseded": null,                                                                                      |
+|                "last_modified": "2015-08-28T17:58:46.001Z"                                                              |
+|            },                                                                                                           |
+|            ...                                                                                                          |
+|        ]                                                                                                                |
+|    }                                                                                                                    |
++-------------------------------------------------------------------------------------------------------------------------+
+
 .. _rest_source_file_products:
 
 +-------------------------------------------------------------------------------------------------------------------------+
@@ -330,7 +522,7 @@ These services provide access to information about source files that Scale has i
 | Returns a list of all products that were produced by the given source file ID                                           |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /sources/{id}/products/                                                                                         |
-|         Where {id} is the unique identifier of an existing model.                                                       |
+|         Where {id} is the unique identifier of an existing source file                                                  |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Query Parameters**                                                                                                    |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -113,9 +113,11 @@ class JobManager(models.Manager):
 
         return job
 
-    def get_jobs(self, started=None, ended=None, statuses=None, job_ids=None, job_type_ids=None, job_type_names=None,
-                 job_type_categories=None, error_categories=None, include_superseded=False, order=None):
-        """Returns a list of jobs within the given time range.
+    def filter_jobs(self, started=None, ended=None, statuses=None, job_ids=None, job_type_ids=None, job_type_names=None,
+                    job_type_categories=None, error_categories=None, include_superseded=False, order=None):
+        """Returns a query for job models that filters on the given fields. The returned query includes the related
+        job_type, job_type_rev, event, and error fields, except for the job_type.interface and job_type_rev.interface
+        fields.
 
         :param started: Query jobs updated after this amount of time.
         :type started: :class:`datetime.datetime`
@@ -137,8 +139,8 @@ class JobManager(models.Manager):
         :type include_superseded: bool
         :param order: A list of fields to control the sort order.
         :type order: [string]
-        :returns: The list of jobs that match the time range.
-        :rtype: [:class:`job.models.Job`]
+        :returns: The job query
+        :rtype: :class:`django.db.models.QuerySet`
         """
 
         # Fetch a list of jobs
@@ -173,6 +175,39 @@ class JobManager(models.Manager):
         else:
             jobs = jobs.order_by('last_modified')
         return jobs
+
+    def get_jobs(self, started=None, ended=None, statuses=None, job_ids=None, job_type_ids=None, job_type_names=None,
+                 job_type_categories=None, error_categories=None, include_superseded=False, order=None):
+        """Returns a list of jobs within the given time range.
+
+        :param started: Query jobs updated after this amount of time.
+        :type started: :class:`datetime.datetime`
+        :param ended: Query jobs updated before this amount of time.
+        :type ended: :class:`datetime.datetime`
+        :param statuses: Query jobs with the a specific execution status.
+        :type statuses: [string]
+        :param job_ids: Query jobs associated with the identifier.
+        :type job_ids: [int]
+        :param job_type_ids: Query jobs of the type associated with the identifier.
+        :type job_type_ids: [int]
+        :param job_type_names: Query jobs of the type associated with the name.
+        :type job_type_names: [string]
+        :param job_type_categories: Query jobs of the type associated with the category.
+        :type job_type_categories: [string]
+        :param error_categories: Query jobs that failed due to errors associated with the category.
+        :type error_categories: [string]
+        :param include_superseded: Whether to include jobs that are superseded.
+        :type include_superseded: bool
+        :param order: A list of fields to control the sort order.
+        :type order: [string]
+        :returns: The list of jobs that match the time range.
+        :rtype: [:class:`job.models.Job`]
+        """
+
+        return self.filter_jobs(started=started, ended=ended, statuses=statuses, job_ids=job_ids,
+                                job_type_ids=job_type_ids, job_type_names=job_type_names,
+                                job_type_categories=job_type_categories, error_categories=error_categories,
+                                include_superseded=include_superseded, order=order)
 
     def get_details(self, job_id):
         """Gets additional details for the given job model based on related model attributes.

--- a/scale/product/migrations/0009_auto_20170301_1130.py
+++ b/scale/product/migrations/0009_auto_20170301_1130.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('product', '0008_auto_20170221_1413'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='fileancestrylink',
+            name='ancestor_job',
+            field=models.ForeignKey(related_name='ancestor_job_file_links', on_delete=django.db.models.deletion.PROTECT, blank=True, to='job.Job', null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='fileancestrylink',
+            name='ancestor_job_exe',
+            field=models.ForeignKey(related_name='ancestor_job_exe_file_links', on_delete=django.db.models.deletion.PROTECT, blank=True, to='job.JobExecution', null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='fileancestrylink',
+            name='job',
+            field=models.ForeignKey(related_name='job_file_links', on_delete=django.db.models.deletion.PROTECT, to='job.Job'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='fileancestrylink',
+            name='job_exe',
+            field=models.ForeignKey(related_name='job_exe_file_links', on_delete=django.db.models.deletion.PROTECT, to='job.JobExecution'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='fileancestrylink',
+            name='recipe',
+            field=models.ForeignKey(related_name='recipe_file_links', on_delete=django.db.models.deletion.PROTECT, blank=True, to='recipe.Recipe', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/scale/product/models.py
+++ b/scale/product/models.py
@@ -157,16 +157,16 @@ class FileAncestryLink(models.Model):
     descendant = models.ForeignKey('storage.ScaleFile', blank=True, null=True, on_delete=models.PROTECT,
                                    related_name='ancestors')
 
-    job_exe = models.ForeignKey('job.JobExecution', on_delete=models.PROTECT, related_name='file_links')
-    job = models.ForeignKey('job.Job', on_delete=models.PROTECT, related_name='file_links')
+    job_exe = models.ForeignKey('job.JobExecution', on_delete=models.PROTECT, related_name='job_exe_file_links')
+    job = models.ForeignKey('job.Job', on_delete=models.PROTECT, related_name='job_file_links')
     recipe = models.ForeignKey('recipe.Recipe', blank=True, on_delete=models.PROTECT, null=True,
-                               related_name='file_links')
+                               related_name='recipe_file_links')
     batch = models.ForeignKey('batch.Batch', blank=True, on_delete=models.PROTECT, null=True)
 
     ancestor_job = models.ForeignKey('job.Job', blank=True, on_delete=models.PROTECT,
-                                     related_name='ancestor_file_links', null=True)
+                                     related_name='ancestor_job_file_links', null=True)
     ancestor_job_exe = models.ForeignKey('job.JobExecution', blank=True, on_delete=models.PROTECT,
-                                         related_name='ancestor_file_links', null=True)
+                                         related_name='ancestor_job_exe_file_links', null=True)
 
     created = models.DateTimeField(auto_now_add=True)
 

--- a/scale/source/test/test_models.py
+++ b/scale/source/test/test_models.py
@@ -39,6 +39,25 @@ class TestSourceFileManager(TestCase):
         self.started = now()
         self.ended = self.started + datetime.timedelta(days=1)
 
+    def test_get_source_jobs(self):
+        """Tests calling get_source_jobs()"""
+
+        from product.test import utils as product_test_utils
+        job_exe = job_utils.create_job_exe()
+        product_1 = product_test_utils.create_product(job_exe=job_exe, has_been_published=True,
+                                                      workspace=self.workspace)
+        product_2 = product_test_utils.create_product(job_exe=job_exe, has_been_published=True,
+                                                      workspace=self.workspace)
+        product_test_utils.create_file_link(ancestor=self.src_file, descendant=product_1, job=job_exe.job,
+                                            job_exe=job_exe)
+        product_test_utils.create_file_link(ancestor=self.src_file, descendant=product_2, job=job_exe.job,
+                                            job_exe=job_exe)
+
+        jobs = SourceFile.objects.get_source_jobs(self.src_file.id)
+        # Should only return one job despite two file_ancestry_link models
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs[0].id, job_exe.job.id)
+
     def test_get_source_products(self):
         """Tests calling get_source_products()"""
 

--- a/scale/source/urls.py
+++ b/scale/source/urls.py
@@ -9,5 +9,6 @@ urlpatterns = patterns(
     url(r'^sources/updates/$', views.SourceUpdatesView.as_view(), name='source_updates_view'),
     url(r'^sources/(?P<source_id>\d+)/$', views.SourceDetailsView.as_view(), name='source_details_view'),
     url(r'^sources/(?P<file_name>[\w.]{0,250})/$', views.SourceDetailsView.as_view(), name='source_details_view'),
+    url(r'^sources/(?P<source_id>\d+)/jobs/$', views.SourceJobsView.as_view(), name='source_jobs_view'),
     url(r'^sources/(?P<source_id>\d+)/products/$', views.SourceProductsView.as_view(), name='source_products_view'),
 )


### PR DESCRIPTION
This PR adds a REST API call to retrieve the jobs associated with a source file. It includes all standard filtering query parameters available on the normal /jobs/ API.

URL: /sources/{source-id}/jobs/