### PR TITLE
Issue 585 - Batch trigger files for recipes

### DIFF
--- a/scale/batch/configuration/definition/batch_definition.py
+++ b/scale/batch/configuration/definition/batch_definition.py
@@ -6,6 +6,9 @@ from jsonschema.exceptions import ValidationError
 
 import util.parse as parse
 from batch.configuration.definition.exceptions import InvalidDefinition
+from storage.models import Workspace
+from trigger.configuration.exceptions import InvalidTriggerRule
+from trigger.configuration.trigger_rule import TriggerRuleConfiguration
 
 
 DEFAULT_VERSION = '1.0'
@@ -37,6 +40,9 @@ BATCH_DEFINITION_SCHEMA = {
             'description': 'The priority to use when creating new jobs for the batch',
             'type': 'integer',
         },
+        'trigger_rule': {
+            '$ref': '#/definitions/trigger_rule_item',
+        }
     },
     'definitions': {
         'date_range_item': {
@@ -63,8 +69,63 @@ BATCH_DEFINITION_SCHEMA = {
                 },
             },
         },
+        'trigger_rule_item': {
+            'description': 'A range of dates used to determine which recipes should be re-processed',
+            'type': ['object', 'boolean'],
+            'condition': {
+                'description': 'Condition for an input file to trigger an event',
+                'type': 'object',
+                'additionalProperties': False,
+                'properties': {
+                    'media_type': {
+                        'description': 'Media type required by an input file to trigger an event',
+                        'type': 'string',
+                    },
+                    'data_types': {
+                        'description': 'Data types required by an input file to trigger an event',
+                        'type': 'array',
+                        'items': {'$ref': '#/definitions/data_type_tag'}
+                    },
+                }
+            },
+            'data': {
+                'description': 'The input data to pass to a triggered job/recipe',
+                'type': 'object',
+                'required': ['input_data_name', 'workspace_name'],
+                'additionalProperties': False,
+                'properties': {
+                    'input_data_name': {
+                        'description': 'The name of the job/recipe input data to pass the input file to',
+                        'type': 'string',
+                    },
+                    'workspace_name': {
+                        'description': 'The name of the workspace to use for the triggered job/recipe',
+                        'type': 'string',
+                    }
+                }
+            }
+        },
+        'data_type_tag': {
+            'description': 'A simple data type tag string',
+            'type': 'string',
+        },
     },
 }
+
+
+class ValidationWarning(object):
+    """Tracks batch definition warnings during validation that may not prevent the batch from working."""
+
+    def __init__(self, key, details):
+        """Constructor sets basic attributes.
+
+        :param key: A unique identifier clients can use to recognize the warning.
+        :type key: string
+        :param details: A user-friendly description of the problem, including field names and/or associated values.
+        :type details: string
+        """
+        self.key = key
+        self.details = details
 
 
 class BatchDefinition(object):
@@ -119,6 +180,14 @@ class BatchDefinition(object):
             except ValueError:
                 raise InvalidDefinition('Invalid priority: %s' % self._definition['priority'])
 
+        self.trigger_rule = False
+        self.trigger_config = None
+        if 'trigger_rule' in self._definition:
+            if isinstance(self._definition['trigger_rule'], bool):
+                self.trigger_rule = self._definition['trigger_rule']
+            else:
+                self.trigger_config = BatchTriggerConfiguration('BATCH', self._definition['trigger_rule'])
+
     def get_dict(self):
         """Returns the internal dictionary that represents this batch definition
 
@@ -127,6 +196,24 @@ class BatchDefinition(object):
         """
 
         return self._definition
+
+    def validate(self, recipe_type):
+        """Validates the given recipe type to make sure it is valid with respect to the batch definition.
+
+        :param recipe_type: The recipe type associated with the batch.
+        :type recipe_type: :class:`recipe.models.RecipeType`
+        :returns: A list of warnings discovered during validation.
+        :rtype: [:class:`batch.configuration.definition.batch_definition.ValidationWarning`]
+        """
+
+        if self.trigger_config:
+            self.trigger_config.validate()
+
+        warnings = []
+        if self._definition['trigger_rule'] is True and recipe_type.trigger_rule is None:
+            warnings.append(ValidationWarning('trigger_rule',
+                                              'Recipe type does not have a trigger rule: %i' % recipe_type.id))
+        return warnings
 
     def _populate_default_values(self):
         """Goes through the definition and populates any missing values with defaults"""
@@ -142,3 +229,117 @@ class BatchDefinition(object):
             self._definition['job_names'] = None
         if 'all_jobs' not in self._definition:
             self._definition['all_jobs'] = False
+
+        if 'trigger_rule' not in self._definition:
+            self._definition['trigger_rule'] = False
+
+
+class BatchTriggerConfiguration(TriggerRuleConfiguration):
+
+    def __init__(self, trigger_rule_type, configuration):
+        """Creates a batch trigger from the given configuration
+
+        :param trigger_rule_type: The trigger rule type
+        :type trigger_rule_type: string
+        :param configuration: The batch trigger configuration
+        :type configuration: dict
+
+        :raises trigger.configuration.exceptions.InvalidTriggerRule: If the configuration is invalid
+        """
+
+        super(BatchTriggerConfiguration, self).__init__(trigger_rule_type, configuration)
+
+        self._populate_default_values()
+
+    def get_condition(self):
+        """Returns the condition for this batch trigger rule
+
+        :return: The trigger condition
+        :rtype: :class:`batch.configuration.definition.batch_definition.BatchTriggerCondition`
+        """
+
+        media_type = None
+        if self._dict['condition']['media_type']:
+            media_type = self._dict['condition']['media_type']
+
+        data_types = set(self._dict['condition']['data_types'])
+
+        return BatchTriggerCondition(media_type, data_types)
+
+    def get_input_data_name(self):
+        """Returns the name of the input data that the triggered input files should be passed to.
+
+        :return: The input data name
+        :rtype: string
+        """
+
+        return self._dict['data']['input_data_name']
+
+    def get_workspace_name(self):
+        """Returns the name of the workspace to use for the triggered input files.
+
+        :return: The workspace name
+        :rtype: string
+        """
+
+        return self._dict['data']['workspace_name']
+
+    def validate(self):
+        """Validates the trigger rule configuration. This is a more thorough validation than the basic schema checks
+        performed in trigger rule constructors and may include database queries.
+
+        :raises trigger.configuration.exceptions.InvalidTriggerRule: If the configuration is invalid
+        """
+
+        workspace_name = self.get_workspace_name()
+        if Workspace.objects.filter(name=workspace_name).count() == 0:
+            raise InvalidTriggerRule('%s is an invalid workspace name' % workspace_name)
+
+    def _populate_default_values(self):
+        """Goes through the definition and populates any missing values with defaults"""
+
+        if 'condition' not in self._dict:
+            self._dict['condition'] = {}
+        if 'media_type' not in self._dict['condition']:
+            self._dict['condition']['media_type'] = ''
+        if 'data_types' not in self._dict['condition']:
+            self._dict['condition']['data_types'] = []
+
+
+class BatchTriggerCondition(object):
+    """Represents the condition for a batch trigger rule."""
+
+    def __init__(self, media_type, data_types):
+        """Creates a batch trigger condition.
+
+        :param media_type: The media type that a file must match, possibly None
+        :type media_type: string
+        :param data_types: The set of data types that a file must match, possibly None
+        :type data_types: {string}
+        """
+
+        self._media_type = media_type
+        self._data_types = data_types if data_types is not None else set()
+
+    def get_media_type(self):
+        """Returns the file media type for this batch trigger condition.
+
+        :return: The media type
+        :rtype: string
+        """
+
+        return self._media_type
+
+    def is_condition_met(self, input_file):
+        """Indicates whether the given input file meets this batch trigger condition.
+
+        :param input_file: The input file to test
+        :type input_file: :class:`source.models.ScaleFile`
+        :return: True if the condition is met, False otherwise
+        :rtype: bool
+        """
+
+        if self._media_type and self._media_type != input_file.media_type:
+            return False
+
+        return self._data_types <= input_file.get_data_type_tags()

--- a/scale/batch/configuration/definition/batch_definition.py
+++ b/scale/batch/configuration/definition/batch_definition.py
@@ -70,7 +70,7 @@ BATCH_DEFINITION_SCHEMA = {
             },
         },
         'trigger_rule_item': {
-            'description': 'A range of dates used to determine which recipes should be re-processed',
+            'description': 'Configuration used to evaluate a file for potential batch processing',
             'type': ['object', 'boolean'],
             'condition': {
                 'description': 'Condition for an input file to trigger an event',

--- a/scale/batch/test/configuration/definition/test_batch_definition.py
+++ b/scale/batch/test/configuration/definition/test_batch_definition.py
@@ -138,3 +138,44 @@ class TestBatchDefinition(TestCase):
         }
 
         self.assertRaises(InvalidDefinition, BatchDefinition, definition)
+
+    def test_trigger_default(self):
+        """Tests defining the current recipe type trigger should be used."""
+
+        definition = {
+            'version': '1.0',
+            'trigger_rule': True,
+        }
+
+        # No exception means success
+        BatchDefinition(definition)
+
+    def test_trigger_custom(self):
+        """Tests defining a custom trigger to use."""
+
+        definition = {
+            'version': '1.0',
+            'trigger_rule':   {
+                'condition': {
+                    'media_type': 'text/plain',
+                    'data_types': ['foo', 'bar'],
+                },
+                'data': {
+                    'input_data_name': 'my_file',
+                    'workspace_name': 'my_workspace',
+                },
+            },
+        }
+
+        # No exception means success
+        BatchDefinition(definition)
+
+    def test_trigger_invalid(self):
+        """Tests defining a custom trigger that is invalid."""
+
+        definition = {
+            'version': '1.0',
+            'trigger_rule': 'BAD',
+        }
+
+        self.assertRaises(InvalidDefinition, BatchDefinition, definition)

--- a/scale/docs/rest/batch.rst
+++ b/scale/docs/rest/batch.rst
@@ -351,6 +351,9 @@ These services provide access to information about registered batch re-processin
 +--------------------+---------------------+------------------------------------------------------------------------------+
 | recipe_count       | Integer             | The estimated total count of the recipes that might be affected by the batch.|
 +--------------------+---------------------+------------------------------------------------------------------------------+
+| file_count         | Integer             | The estimated total count of the input files that might be affected by the   |
+|                    |                     | batch when using a trigger rule.                                             |
++--------------------+---------------------+------------------------------------------------------------------------------+
 | warnings           | Array               | A list of warnings discovered during validation.                             |
 +--------------------+---------------------+------------------------------------------------------------------------------+
 | .id                | String              | An identifier for the warning.                                               |

--- a/scale/storage/test/utils.py
+++ b/scale/storage/test/utils.py
@@ -34,7 +34,7 @@ def create_country(name=None, fips='TT', gmi='TT', iso2='TT', iso3='TST', iso_nu
 
 
 def create_file(file_name='my_test_file.txt', media_type='text/plain', file_size=100, file_path=None, workspace=None,
-                countries=None, is_deleted=False):
+                countries=None, is_deleted=False, data_type=''):
     """Creates a Scale file model for unit testing
 
     :returns: The file model
@@ -50,7 +50,7 @@ def create_file(file_name='my_test_file.txt', media_type='text/plain', file_size
 
     scale_file = ScaleFile.objects.create(file_name=file_name, media_type=media_type, file_size=file_size,
                                           file_path=file_path or 'file/path/' + file_name, workspace=workspace,
-                                          is_deleted=is_deleted, deleted=deleted)
+                                          is_deleted=is_deleted, deleted=deleted, data_type=data_type)
     if countries:
         scale_file.countries = countries
         scale_file.save()


### PR DESCRIPTION
- Updated batch definition to support trigger rules for existing files using either the recipe types's default rule or a completely custom rule.
- Trigger rule implementation is modeled after the existing ingest triggers.
- Updated batch processor, REST views create/validate, tests, and docs to support the new definition.