### PR TITLE
Issue 754 - Performance improvements to queries

### DIFF
--- a/scale/product/models.py
+++ b/scale/product/models.py
@@ -214,7 +214,12 @@ class ProductFileManager(models.GeoManager):
 
         # Fetch a list of product files
         products = ScaleFile.objects.filter(file_type='PRODUCT', has_been_published=True)
-        products = products.select_related('workspace', 'job_type', 'job', 'job_exe').defer('workspace__json_config')
+        products = products.select_related('workspace', 'job_type', 'job', 'job_exe')
+        products = products.defer('workspace__json_config', 'job__data', 'job__configuration', 'job__results',
+                                  'job_exe__environment', 'job_exe__configuration', 'job_exe__job_metrics',
+                                  'job_exe__stdout', 'job_exe__stderr', 'job_exe__results', 'job_exe__results_manifest',
+                                  'job_type__interface', 'job_type__docker_params', 'job_type__configuration',
+                                  'job_type__error_mapping')
         products = products.prefetch_related('countries')
 
         # Apply time range filtering


### PR DESCRIPTION
This PR has some quick performance improvements to queries by using select_related() and defer().

This is obviously not the best solution; in a future issue the base serializer that only renders an ID will be changed so it doesn't require a elated model to be fetched.