### PR TITLE
Issue 757 - Metrics Page Total Cut Off

### DIFF
--- a/scale-ui/app/modules/common/services/scaleService.js
+++ b/scale-ui/app/modules/common/services/scaleService.js
@@ -54,7 +54,7 @@
                     height: y
                 };
             },
-            calculateDuration: function (start, stop) {
+            calculateDuration: function (start, stop, noPadding) {
                 var to = moment.utc(stop),
                     from = moment.utc(start),
                     diff = moment.utc(to).diff(moment.utc(from)),
@@ -62,12 +62,21 @@
 
                 var duration = moment.duration(diff);
 
-                durationStr = duration.years() > 0 ? durationStr + padWithZero(duration.years(), 2) + 'Y, ' : durationStr;
-                durationStr = duration.months() > 0 ? durationStr + padWithZero(duration.months(), 2) + 'M, ' : durationStr;
-                durationStr = duration.days() > 0 ? durationStr + padWithZero(duration.days(), 2) + 'D, ' : durationStr;
-                durationStr = duration.hours() > 0 ? durationStr + padWithZero(duration.hours(), 2) + 'h, ' : durationStr;
-                durationStr = duration.minutes() > 0 ? durationStr + padWithZero(duration.minutes(), 2) + 'm, ' : durationStr;
-                durationStr = durationStr + padWithZero(duration.seconds(), 2) + 's';
+                if (!noPadding) {
+                    durationStr = duration.years() > 0 ? durationStr + padWithZero(duration.years(), 2) + 'Y, ' : durationStr;
+                    durationStr = duration.months() > 0 ? durationStr + padWithZero(duration.months(), 2) + 'M, ' : durationStr;
+                    durationStr = duration.days() > 0 ? durationStr + padWithZero(duration.days(), 2) + 'D, ' : durationStr;
+                    durationStr = duration.hours() > 0 ? durationStr + padWithZero(duration.hours(), 2) + 'h, ' : durationStr;
+                    durationStr = duration.minutes() > 0 ? durationStr + padWithZero(duration.minutes(), 2) + 'm, ' : durationStr;
+                    durationStr = durationStr + padWithZero(duration.seconds(), 2) + 's';
+                } else {
+                    durationStr = duration.years() > 0 ? durationStr + duration.years() + 'Y, ' : durationStr;
+                    durationStr = duration.months() > 0 ? durationStr + duration.months() + 'M, ' : durationStr;
+                    durationStr = duration.days() > 0 ? durationStr + duration.days() + 'D, ' : durationStr;
+                    durationStr = duration.hours() > 0 ? durationStr + duration.hours() + 'h, ' : durationStr;
+                    durationStr = duration.minutes() > 0 ? durationStr + duration.minutes() + 'm, ' : durationStr;
+                    durationStr = durationStr + duration.seconds() + 's';
+                }
 
                 return durationStr;
             },

--- a/scale-ui/app/modules/common/services/scaleService.js
+++ b/scale-ui/app/modules/common/services/scaleService.js
@@ -62,11 +62,13 @@
 
                 var duration = moment.duration(diff);
 
-                durationStr = duration.days() > 0 ? durationStr + padWithZero(duration.days(), 2) + 'd, ' : durationStr;
+                durationStr = duration.years() > 0 ? durationStr + padWithZero(duration.years(), 2) + 'Y, ' : durationStr;
+                durationStr = duration.months() > 0 ? durationStr + padWithZero(duration.months(), 2) + 'M, ' : durationStr;
+                durationStr = duration.days() > 0 ? durationStr + padWithZero(duration.days(), 2) + 'D, ' : durationStr;
                 durationStr = duration.hours() > 0 ? durationStr + padWithZero(duration.hours(), 2) + 'h, ' : durationStr;
                 durationStr = duration.minutes() > 0 ? durationStr + padWithZero(duration.minutes(), 2) + 'm, ' : durationStr;
                 durationStr = durationStr + padWithZero(duration.seconds(), 2) + 's';
-                
+
                 return durationStr;
             },
             getDayString: function(dayNumber){

--- a/scale-ui/app/modules/metrics/controllers/metricsController.js
+++ b/scale-ui/app/modules/metrics/controllers/metricsController.js
@@ -490,7 +490,7 @@
 
             if (vm.metricsTotal) {
                 vm.metricsTotal = formatYValues(vm.metricsTotal);
-                vm.chartTitle = '<span class="label label-success">' + vm.metricsTotal.toLocaleString() + '</span> ' + vm.chartData[0].query.selectedMetrics[0].title + ' for ' + moment.utc(vm.inputStartDate).format('DD MMM YYYY') + ' - ' + moment.utc(vm.inputEndDate).format('DD MMM YYYY');
+                vm.chartTitle = '<div class="label label-success">' + vm.metricsTotal.toLocaleString() + '</div> ' + vm.chartData[0].query.selectedMetrics[0].title + ' for ' + moment.utc(vm.inputStartDate).format('DD MMM YYYY') + ' - ' + moment.utc(vm.inputEndDate).format('DD MMM YYYY');
             } else {
                 vm.chartTitle = vm.chartData[0].query.selectedMetrics[0].title + ' ' + moment.utc(vm.inputStartDate).format('DD MMM YYYY') + ' - ' + moment.utc(vm.inputEndDate).format('DD MMM YYYY');
             }

--- a/scale-ui/app/modules/metrics/controllers/metricsController.js
+++ b/scale-ui/app/modules/metrics/controllers/metricsController.js
@@ -272,9 +272,10 @@
             console.log(value)
         });
 
-        var formatYValues = function (data) {
+        var formatYValues = function (data, noPadding) {
+            noPadding = noPadding || false;
             if (yUnits[0] === 'seconds') {
-                return scaleService.calculateDuration(moment.utc().startOf('d'), moment.utc().startOf('d').add(data, 's'));
+                return scaleService.calculateDuration(moment.utc().startOf('d'), moment.utc().startOf('d').add(data, 's'), noPadding);
             } else if (yUnits[0] === 'bytes') {
                 return scaleService.calculateFileSizeFromBytes(data, 1);
             }
@@ -489,7 +490,7 @@
             }
 
             if (vm.metricsTotal) {
-                vm.metricsTotal = formatYValues(vm.metricsTotal);
+                vm.metricsTotal = formatYValues(vm.metricsTotal, true);
                 vm.chartTitle = '<div class="label label-success">' + vm.metricsTotal.toLocaleString() + '</div> ' + vm.chartData[0].query.selectedMetrics[0].title + ' for ' + moment.utc(vm.inputStartDate).format('DD MMM YYYY') + ' - ' + moment.utc(vm.inputEndDate).format('DD MMM YYYY');
             } else {
                 vm.chartTitle = vm.chartData[0].query.selectedMetrics[0].title + ' ' + moment.utc(vm.inputStartDate).format('DD MMM YYYY') + ' - ' + moment.utc(vm.inputEndDate).format('DD MMM YYYY');

--- a/scale-ui/app/styles/main.less
+++ b/scale-ui/app/styles/main.less
@@ -20,3 +20,4 @@
 @import 'pages/jobTypesErrorRates';
 @import 'pages/overview';
 @import 'pages/nodes';
+@import 'pages/metrics';

--- a/scale-ui/app/styles/pages/metrics.less
+++ b/scale-ui/app/styles/pages/metrics.less
@@ -1,0 +1,6 @@
+.metrics-title {
+    .label {
+        display: table;
+        margin-bottom: 5px;
+    }
+}


### PR DESCRIPTION
Fixes #757

Added formatters to account for months and years.  Years, months, and days are labeled with capital letters, while hours, minutes, and seconds are labeled with lower-case letters.

This was not a bug confined to the metrics page, as the same duration formatter is used to display durations in data grids.

![image](https://cloud.githubusercontent.com/assets/15909071/23962169/9ab95856-0983-11e7-95ea-c6461ee07401.png)
