### PR TITLE
Issue 767 - Debounce filename search for ingest records

### DIFF
--- a/scale-ui/app/modules/feed/controllers/ingestRecordsController.js
+++ b/scale-ui/app/modules/feed/controllers/ingestRecordsController.js
@@ -197,6 +197,13 @@
             });
         };
 
+        vm.filterByFilename = function (keyEvent) {
+            if (!keyEvent || (keyEvent && keyEvent.which === 13)) {
+                vm.ingestsParams.file_name = vm.searchText;
+                vm.filterResults();
+            }
+        };
+
         vm.initialize = function () {
             stateService.setIngestsParams(vm.ingestsParams);
             vm.updateColDefs();
@@ -240,13 +247,6 @@
                 vm.ingestsParams.ended = value.toISOString();
                 vm.filterResults();
             }
-        });
-
-        $scope.$watch('vm.searchText', function (value) {
-           if (!vm.loading){
-               vm.ingestsParams.file_name = value;
-               vm.filterResults();
-           }
         });
 
         $scope.$watchCollection('vm.stateService.getIngestsColDefs()', function (newValue, oldValue) {

--- a/scale-ui/app/modules/feed/partials/ingestRecordsTemplate.html
+++ b/scale-ui/app/modules/feed/partials/ingestRecordsTemplate.html
@@ -2,7 +2,10 @@
 <div class="form-inline margin-bottom-md">
     <div class="input-group margin-right-md">
         <span class="input-group-addon" id="search-input">Search:</span>
-        <input ng-model="vm.searchText" ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }" class="form-control" placeholder="Filename">
+        <input ng-model="vm.searchText" class="form-control" placeholder="Filename" ng-keypress="vm.filterByFilename($event)">
+        <span class="input-group-btn">
+            <button class="btn btn-default" ng-click="vm.filterByFilename()" ng-disabled="vm.searchText.length === 0"><i class="fa fa-chevron-circle-right"></i></button>
+        </span>
     </div>
     <div class="input-group margin-right-md">
         <span class="input-group-addon" id="from-input">From:</span>


### PR DESCRIPTION
This field was already debounced, and to increase the delay didn't seem like it would solve the problem.  As a result I added a button that can be used to apply the filename filter when the user is ready.  Pressing the "enter" key will also apply the filter.

![image](https://cloud.githubusercontent.com/assets/15909071/24460210/a108631c-146b-11e7-8798-6711afc95ec0.png)
