### PR TITLE
#784: VIP updates and DCOS package cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,7 @@ EXPOSE 80
 # CONFIG_URI
 # DCOS_OAUTH_TOKEN authentication for Marathon deployments when DCOS OAuth is enabled
 # DCOS_PACKAGE_FRAMEWORK_NAME used to inject a configurable framework name allowing for multiple scale frameworks per cluster
-# DCOS_PASS authentication for Marathon deployments when using DCOS enterprise
 # DCOS_SERVICE_ACCOUNT a DCOS account name with read/update/create/delete access to the secrets store
-# DCOS_USER authentication for Marathon deployments when using DCOS enterprise
 # DEPLOY_WEBSERVER to start the web server container
 # ENABLE_BOOTSTRAP true to initialize database and bootstrap supporting containers, should only be set on scheduler in DCOS
 # ENABLE_WEBSERVER true to start the RESTful API server, should only be set on webserver app

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ Alternatively, your own local_settings.py can be volume mounted into `/opt/scale
 | CONFIG_URI                  | None                            | A URI or URL to docker credentials file    |
 | DCOS_OAUTH_TOKEN            | None                            | Authentication token for DCOS bootstrap    |
 | DCOS_PACKAGE_FRAMEWORK_NAME | None                            | Unique name for Scale cluster framework    |
-| DCOS_PASS                   | None                            | Password for DCOS bootstrap                |
 | DCOS_SERVICE_ACCOUNT        | None                            | DCOS account name with access to secrets   |
-| DCOS_USER                   | None                            | Privileged username for DCOS bootstrap     |
 | DEPLOY_WEBSERVER            | 'true'                          | Should UI and API be installed?            |
 | ENABLE_BOOTSTRAP            | 'true'                          | Bootstrap Scale support containers         |
 | ENABLE_WEBSERVER            | 'true' or None                  | Used by bootstrap to enable UI and API     |

--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -41,7 +41,8 @@ def run(client):
     db_port = os.getenv('SCALE_DB_PORT', '')
     if not len(db_host):
         app_name = '%s-db' % FRAMEWORK_NAME
-        db_port = deploy_database(client, app_name)
+        deploy_database(client, app_name)
+        db_port = 5432
         db_host = "%s.marathon.l4lb.thisdcos.directory" % app_name
         print("DB_HOST=%s" % db_host)
         print("DB_PORT=%s" % db_port)

--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -13,18 +13,13 @@ DEPLOY_WEBSERVER = os.getenv('DEPLOY_WEBSERVER', 'true')
 
 
 def dcos_login():
-    # Defaults servers for both DCOS 1.7 and 1.8. 1.8 added HTTPS within DCOS EE clusters.
+    # Defaults Marathon endpoints for both DCOS Community  and EE clusters.
     servers = os.getenv('MARATHON_SERVERS', 'http://marathon.mesos:8080,https://marathon.mesos:8443').split(',')
     oauth_token = os.getenv('DCOS_OAUTH_TOKEN', '').strip()
-    username = os.getenv('DCOS_USER', '').strip()
-    password = os.getenv('DCOS_PASS', '').strip()
 
     if len(oauth_token):
         print('Attempting token auth to Marathon...')
         client = MarathonClient(servers, auth_token=oauth_token)
-    elif len(username) and len(password):
-        print('Attempting basic auth to Marathon...')
-        client = MarathonClient(servers, username=username, password=password)
     else:
         print('Attempting unauthenticated access to Marathon...')
         client = MarathonClient(servers)
@@ -47,22 +42,22 @@ def run(client):
     if not len(db_host):
         app_name = '%s-db' % FRAMEWORK_NAME
         db_port = deploy_database(client, app_name)
-        db_host = "%s.marathon.mesos" % app_name
+        db_host = "%s.marathon.l4lb.thisdcos.directory" % app_name
         print("DB_HOST=%s" % db_host)
         print("DB_PORT=%s" % db_port)
 
     # Determine if logstash should be deployed.
     if not len(SCALE_LOGGING_ADDRESS):
         app_name = '%s-logstash' % FRAMEWORK_NAME
-        log_port = deploy_logstash(client, app_name, es_urls)
-        print("LOGGING_ADDRESS=tcp://%s.marathon.mesos:%s" % (app_name, log_port))
+        deploy_logstash(client, app_name, es_urls)
+        print("LOGGING_ADDRESS=tcp://%s.marathon.l4lb.thisdcos.directory:8000" % app_name)
         print("LOGGING_HEALTH_ADDRESS=%s.marathon.l4lb.thisdcos.directory:80" % app_name)
 
     # Determine if Web Server should be deployed.
     if DEPLOY_WEBSERVER.lower() == 'true':
         app_name = '%s-webserver' % FRAMEWORK_NAME
-        webserver_port = deploy_webserver(client, app_name, es_urls, db_host, db_port)
-        print("WEBSERVER_ADDRESS=http://%s.marathon.mesos:%s" % (app_name, webserver_port))
+        deploy_webserver(client, app_name, es_urls, db_host, db_port)
+        print("WEBSERVER_ADDRESS=http://%s.marathon.l4lb.thisdcos.directory:80" % app_name)
 
 
 def delete_marathon_app(client, app_name, fail_on_error=False, sleep_secs=5):
@@ -146,7 +141,10 @@ def deploy_webserver(client, app_name, es_urls, db_host, db_port):
                 'network': 'BRIDGE',
                 'portMappings': [{
                     'containerPort': 80,
-                    'hostPort': 0
+                    'hostPort': 0,
+                    'labels': {
+                        'VIP_0': '%s:80' % app_name
+                    }
                 }
                 ],
                 'forcePullImage': True
@@ -202,20 +200,15 @@ def deploy_webserver(client, app_name, es_urls, db_host, db_port):
     deploy_marathon_app(client, marathon)
     wait_app_healthy(client, app_name)
 
-    webserver_port = get_marathon_app_single_task_host_port(client, app_name, 0)
-
-    return webserver_port
-
 
 def deploy_database(client, app_name):
     # Check if scale-db is already running
     if not check_app_exists(client, app_name):
         cfg = {
             'scaleDBName': os.environ.get('SCALE_DB_NAME', 'scale'),
-            'scaleDBHost': '%s.marathon.mesos' % app_name,
             'scaleDBUser': os.environ.get('SCALE_DB_USER', 'scale'),
             'scaleDBPass': os.environ.get('SCALE_DB_PASS', 'scale'),
-            'db_docker_image': os.environ.get('DB_DOCKER_IMAGE', 'mdillon/postgis'),
+            'db_docker_image': os.environ.get('DB_DOCKER_IMAGE', 'mdillon/postgis:9.5'),
             'dbHostVol': os.environ.get('SCALE_DB_HOST_VOL', '')
         }
         if cfg['dbHostVol'] == '':
@@ -234,7 +227,10 @@ def deploy_database(client, app_name):
                     'network': 'BRIDGE',
                     'portMappings': [{
                         'containerPort': 5432,
-                        'hostPort': 0
+                        'hostPort': 0,
+                        'labels': {
+                            'VIP_0': '%s:5432' % app_name
+                        }
                     }
                     ],
                     'forcePullImage': True
@@ -266,10 +262,6 @@ def deploy_database(client, app_name):
         deploy_marathon_app(client, marathon)
         wait_app_healthy(client, app_name)
 
-    db_port = get_marathon_app_single_task_host_port(client, app_name, 0)
-
-    return db_port
-
 
 def get_elasticsearch_urls():
     response = requests.get('http://elasticsearch.marathon.mesos:31105/v1/tasks')
@@ -283,7 +275,7 @@ def deploy_logstash(client, app_name, es_urls):
     delete_marathon_app(client, app_name)
 
     # get the Logstash container API endpoints
-    logstash_image = os.getenv('LOGSTASH_DOCKER_IMAGE', 'geoint/logstash-elastic-ha')
+    logstash_image = os.getenv('LOGSTASH_DOCKER_IMAGE', 'geoint/scale-logstash')
     marathon = {
         'id': app_name,
         'cpus': 0.5,
@@ -296,7 +288,7 @@ def deploy_logstash(client, app_name, es_urls):
                 'network': 'BRIDGE',
                 'portMappings': [{
                     'containerPort': 8000,
-                    'hostPort': 9229,
+                    'hostPort': 0,
                     'protocol': 'tcp',
                     'labels': {
                         'VIP_0': '%s:8000' % app_name
@@ -348,10 +340,6 @@ def deploy_logstash(client, app_name, es_urls):
 
     deploy_marathon_app(client, marathon)
     wait_app_healthy(client, app_name)
-
-    logstash_port = get_marathon_app_single_task_host_port(client, app_name, 0)
-
-    return logstash_port
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I noticed that we had inconsistent use of host port and VIP in the bootstrap, so this has been corrected. I've tested this in our dev cluster and everything appears to be correctly routing via the VIPs. This further solidifies our dependence on DCOS 1.8+ and we should *ABSOLUTELY* call this out in the upcoming 4.4.0 release.

I also cleaned out the `DCOS_USER` and `DCOS_PASS` environment variables which I had discovered to be irrelevant since `DCOS_OAUTH_TOKEN` is the only value that correctly allows bootstrapping apps within Marathon when authentication is enforced (EE). All this is to prep for the DCOS Universe updates I'm also working on for 4.4.0 release.

 