### PR TITLE
#790: Docker 1.11+ logging fix.

### DIFF
--- a/scale/README.md
+++ b/scale/README.md
@@ -113,7 +113,7 @@ Scale development requires a local Postgres database with PostGIS extensions ins
 on most platforms is with a Docker container and all the bootstrap configurations described, except Cloud9, use this
 method. The following are the baseline prerequisites for Scale development:
 
-- Running Docker Community Edition 1.10+ Engine (use Docker for Windows or Mac on those platforms)
+- Running Docker Community Edition 1.11+ Engine (use Docker for Windows or Mac on those platforms)
 - Python 2.7.x
 
 The core Scale team uses JetBrains PyCharm or Cloud9 IDE for development. These are in no way required but are
@@ -193,7 +193,7 @@ Platform specific prerequisites:
 - Python 2.7 installed and included in PATH
 - Virtualenv installed and included in PATH (Usually installed to `C:\Python27\Scripts\virtualenv.exe`)
 - OSGeo4W install of GDAL, GEOS and PROJ included in PATH
-(https://docs.djangoproject.com/en/1.10/ref/contrib/gis/install/#modify-windows-environment)
+(https://docs.djangoproject.com/en/1.11/ref/contrib/gis/install/#modify-windows-environment)
 - Docker for Windows 1.17 installed and included in PATH
 
 From a fresh clone of Scale run the following commands to initialize your environment:

--- a/scale/job/configuration/json/execution/exe_config_1_0.py
+++ b/scale/job/configuration/json/execution/exe_config_1_0.py
@@ -263,16 +263,18 @@ class ExecutionConfiguration(object):
 
         if settings.LOGGING_ADDRESS is not None:
             log_driver = DockerParam('log-driver', 'syslog')
+            # Must explicitly specify RFC3164 to ensure compatability with logstash in Docker 1.11+
+            syslog_format = DockerParam('log-opt', 'syslog-format=rfc3164')
             log_address = DockerParam('log-opt', 'syslog-address=%s' % settings.LOGGING_ADDRESS)
             if not job_exe.is_system:
                 pre_task_tag = DockerParam('log-opt', 'tag=%s' % job_exe.get_pre_task_id())
-                self.add_pre_task_docker_params([log_driver, log_address, pre_task_tag])
+                self.add_pre_task_docker_params([log_driver, syslog_format, log_address, pre_task_tag])
                 post_task_tag = DockerParam('log-opt', 'tag=%s' % job_exe.get_post_task_id())
                 # Post task needs ElasticSearch URL to grab logs for old artifact registration
                 es_urls = DockerParam('env', 'SCALE_ELASTICSEARCH_URLS=%s' % es_urls)
-                self.add_post_task_docker_params([log_driver, log_address, post_task_tag, es_urls])
+                self.add_post_task_docker_params([log_driver, syslog_format, log_address, post_task_tag, es_urls])
             job_task_tag = DockerParam('log-opt', 'tag=%s' % job_exe.get_job_task_id())
-            self.add_job_task_docker_params([log_driver, log_address, job_task_tag])
+            self.add_job_task_docker_params([log_driver, syslog_format, log_address, job_task_tag])
 
     def get_job_task_docker_params(self):
         """Returns the Docker parameters needed for the job task

--- a/scale/job/configuration/json/execution/exe_config_1_0.py
+++ b/scale/job/configuration/json/execution/exe_config_1_0.py
@@ -263,7 +263,7 @@ class ExecutionConfiguration(object):
 
         if settings.LOGGING_ADDRESS is not None:
             log_driver = DockerParam('log-driver', 'syslog')
-            # Must explicitly specify RFC3164 to ensure compatability with logstash in Docker 1.11+
+            # Must explicitly specify RFC3164 to ensure compatibility with logstash in Docker 1.11+
             syslog_format = DockerParam('log-opt', 'syslog-format=rfc3164')
             log_address = DockerParam('log-opt', 'syslog-address=%s' % settings.LOGGING_ADDRESS)
             if not job_exe.is_system:


### PR DESCRIPTION
This is a backwards incompatible change and should NOT be merged until after the 4.4.0 release.

Until this is merged in, we do not support Docker engine v1.11 or newer on cluster nodes running Scale jobs. Jobs will run and execute to completion, but the format of the syslog messages sent to logstash will be invalid, rendering all logging APIs useless.