### PR TITLE
Issue 775 - Improve scheduler resilience with handling nodes

### DIFF
--- a/scale/scheduler/node/manager.py
+++ b/scale/scheduler/node/manager.py
@@ -182,7 +182,12 @@ class NodeManager(object):
                 logger.info('Node %s registered with new agent ID %s', hostname, slave_info.slave_id)
             # Update nodes from database models
             for node_model in existing_node_models:
-                self._nodes[node_model.hostname].update_from_model(node_model)
+                if node_model.hostname in self._nodes:
+                    node = self._nodes[node_model.hostname]
+                    node.update_from_model(node_model)
+                    if node.should_be_removed():
+                        del self._agent_ids[node.agent_id]
+                        del self._nodes[node_model.hostname]
             # Update online flag for nodes with new agent IDs
             for new_agent_id in new_agent_ids:
                 hostname = self._agent_ids[new_agent_id]

--- a/scale/scheduler/node/manager.py
+++ b/scale/scheduler/node/manager.py
@@ -188,6 +188,8 @@ class NodeManager(object):
                     if node.should_be_removed():
                         del self._agent_ids[node.agent_id]
                         del self._nodes[node_model.hostname]
+                else:
+                    logger.error('Node %s appears to have been removed from the database', node_model.hostname)
             # Update online flag for nodes with new agent IDs
             for new_agent_id in new_agent_ids:
                 hostname = self._agent_ids[new_agent_id]

--- a/scale/scheduler/node/node_class.py
+++ b/scale/scheduler/node/node_class.py
@@ -210,6 +210,16 @@ class Node(object):
 
         return self._state not in [Node.INACTIVE, Node.OFFLINE]
 
+    def should_be_removed(self):
+        """Indicates whether this node should be removed from the scheduler. If the node is no longer active and is also
+        no longer online, there's no reason for the scheduler to continue to track it.
+
+        :returns: True if this node should be removed from the scheduler
+        :rtype: bool
+        """
+
+        return not self._is_active and not self._is_online
+
     def update_from_mesos(self, agent_id=None, port=None, is_online=None):
         """Updates this node's data from Mesos
 


### PR DESCRIPTION
This PR improves the scheduler's handling of nodes.

1. If a node model has its hostname renamed in the database (not a supported feature), the scheduler now logs an error message of throwing an exception and halting progress of the background thread.
2. If a node is both inactive and offline, the scheduler removes the node from its in-memory data structures. There is no point in the scheduler keeping the node around and it will prevent memory growing over time due to accruing data from nodes that are no longer used.