### PR TITLE
Issue 765 - Create Strike API fails without description

### DIFF
--- a/scale/ingest/migrations/0013_auto_20170406_1517.py
+++ b/scale/ingest/migrations/0013_auto_20170406_1517.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ingest', '0012_scan_file_count'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='scan',
+            name='description',
+            field=models.TextField(null=True, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='strike',
+            name='description',
+            field=models.TextField(null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -812,7 +812,7 @@ class Scan(models.Model):
     :keyword title: The human-readable name of this Scan process
     :type title: :class:`django.db.models.CharField`
     :keyword description: An optional description of this Scan process
-    :type description: :class:`django.db.models.CharField`
+    :type description: :class:`django.db.models.TextField`
 
     :keyword configuration: JSON configuration for this Scan process
     :type configuration: :class:`djorm_pgjson.fields.JSONField`
@@ -831,7 +831,7 @@ class Scan(models.Model):
 
     name = models.CharField(max_length=50, unique=True)
     title = models.CharField(blank=True, max_length=50, null=True)
-    description = models.CharField(blank=True, max_length=500)
+    description = models.TextField(blank=True, null=True)
 
     configuration = djorm_pgjson.fields.JSONField()
 
@@ -1011,7 +1011,7 @@ class Strike(models.Model):
     :keyword title: The human-readable name of this Strike process
     :type title: :class:`django.db.models.CharField`
     :keyword description: An optional description of this Strike process
-    :type description: :class:`django.db.models.CharField`
+    :type description: :class:`django.db.models.TextField`
 
     :keyword configuration: JSON configuration for this Strike process
     :type configuration: :class:`djorm_pgjson.fields.JSONField`
@@ -1026,7 +1026,7 @@ class Strike(models.Model):
 
     name = models.CharField(max_length=50, unique=True)
     title = models.CharField(blank=True, max_length=50, null=True)
-    description = models.CharField(blank=True, max_length=500)
+    description = models.TextField(blank=True, null=True)
 
     configuration = djorm_pgjson.fields.JSONField()
     job = models.ForeignKey('job.Job', blank=True, null=True, on_delete=models.PROTECT)


### PR DESCRIPTION
I changed the description fields for Strike and Scan to be text fields that allow nulls. This is consistent with other models (e.g. job type).