### PR TITLE
Issue 815 - Create UI for scan ingests

### DIFF
--- a/scale-ui/app/modules/app.js
+++ b/scale-ui/app/modules/app.js
@@ -162,7 +162,12 @@
             .when('/feed/strikes/:id?', {
                 controller: 'strikesController',
                 controllerAs: 'vm',
-                templateUrl: 'modules/feed/partials/strikesTemplate.html'
+                templateUrl: 'modules/feed/partials/scans   Template.html'
+            })
+            .when('/feed/scans/:id?', {
+                controller: 'scansController',
+                controllerAs: 'vm',
+                templateUrl: 'modules/feed/partials/scansTemplate.html'
             })
             .when('/batch', {
                 controller: 'batchesController',

--- a/scale-ui/app/modules/app.js
+++ b/scale-ui/app/modules/app.js
@@ -162,12 +162,17 @@
             .when('/feed/strikes/:id?', {
                 controller: 'strikesController',
                 controllerAs: 'vm',
-                templateUrl: 'modules/feed/partials/scans   Template.html'
+                templateUrl: 'modules/feed/partials/strikesTemplate.html'
             })
-            .when('/feed/scans/:id?', {
+            .when('/feed/scans/', {
                 controller: 'scansController',
                 controllerAs: 'vm',
                 templateUrl: 'modules/feed/partials/scansTemplate.html'
+            })
+            .when('/feed/scans/:id', {
+                controller: 'scanDetailsController',
+                controllerAs: 'vm',
+                templateUrl: 'modules/feed/partials/scanDetailsTemplate.html'
             })
             .when('/batch', {
                 controller: 'batchesController',

--- a/scale-ui/app/modules/common/services/stateService.js
+++ b/scale-ui/app/modules/common/services/stateService.js
@@ -12,6 +12,8 @@
             recipesParams = {},
             ingestsColDefs = [],
             ingestsParams = {},
+            scansColDefs = [],
+            scansParams = {},
             nodesColDefs = [],
             nodeStatusParams = {},
             batchesColDefs = [],
@@ -110,6 +112,17 @@
                 status: data.status ? data.status : null,
                 file_name: data.file_name ? data.file_name : null,
                 strike_id: data.strike_id ? parseInt(data.strike_id) : null
+            };
+        };
+
+        var initScansParams = function (data) {
+            return {
+                page: data.page ? parseInt(data.page) : 1,
+                page_size: data.page_size ? parseInt(data.page_size) : 25,
+                started: data.started ? data.started : moment.utc().subtract(1, 'weeks').startOf('d').toISOString(),
+                ended: data.ended ? data.ended : moment.utc().endOf('d').toISOString(),
+                name: data.name ? data.name : null,
+                order: data.order ? Array.isArray(data.order) ? data.order : [data.order] : ['-last_modified']
             };
         };
 
@@ -223,6 +236,12 @@
             setIngestsColDefs: function (data) {
                 ingestsColDefs = data;
             },
+            getScansColDefs: function () {
+                return scansColDefs;
+            },
+            setScansColDefs: function (data) {
+                scansColDefs = data;
+            },
             getIngestsParams: function () {
                 if (_.keys(ingestsParams).length === 0) {
                     return initIngestsParams($location.search());
@@ -232,6 +251,16 @@
             setIngestsParams: function (data) {
                 ingestsParams = initIngestsParams(data);
                 updateQuerystring(ingestsParams);
+            },
+            getScansParams: function () {
+                if (_.keys(scansParams).length === 0) {
+                    return initScansParams($location.search());
+                }
+                return scansParams;
+            },
+            setScansParams: function (data) {
+                scansParams = initScansParams(data);
+                updateQuerystring(scansParams);
             },
             getNodesColDefs: function () {
                 return nodesColDefs;

--- a/scale-ui/app/modules/feed/controllers/scanDetailsController.js
+++ b/scale-ui/app/modules/feed/controllers/scanDetailsController.js
@@ -50,7 +50,11 @@
                 if (scaleConfig.static) {
                     localStorage.setItem('scan' + vm.activeScan.id, JSON.stringify(vm.activeScan));
                 }
-                $route.reload();
+                if ($routeParams.id === '0') {
+                    $location.path('/feed/scans/' + vm.activeScan.id);
+                } else {
+                    $route.reload();
+                }
             }).catch(function () {
 
             });
@@ -150,7 +154,8 @@
             if (file.new_workspace) {
                 file.new_workspace = file.new_workspace.name;
             }
-            return JSON.stringify(file, null, 4);
+            var jsonStr = JSON.stringify(file, null, 4);
+            return jsonStr.replace(/\\\\/g, '\\');
         };
 
         var getWorkspaceDetails = function (id) {

--- a/scale-ui/app/modules/feed/controllers/scanDetailsController.js
+++ b/scale-ui/app/modules/feed/controllers/scanDetailsController.js
@@ -1,0 +1,208 @@
+(function () {
+    'use strict';
+
+    angular.module('scaleApp').controller('scanDetailsController', function ($scope, $route, $location, $routeParams, Scan, ScanIngestFile, scaleConfig, navService, subnavService, scanService, workspacesService, scaleService, stateService, userService, toastr) {
+        var vm = this,
+            currScan = {};
+
+        vm.loading = true;
+        vm.scaleConfig = scaleConfig;
+        vm.workspaces = [];
+        vm.newWorkspaces = [];
+        vm.activeWorkspace = {};
+        vm.localScans = [];
+        vm.activeScan = new Scan();
+        vm.activeScanIngestFile = new ScanIngestFile();
+        vm.dataType = '';
+        vm.availableWorkspaceTypes = _.cloneDeep(scaleConfig.workspaceTypes);
+        vm.addBtnClass = 'btn-primary';
+        vm.addBtnIcon = 'fa-plus-circle';
+        vm.saveBtnClass = 'btn-default';
+        vm.mode = 'view';
+        vm.user = userService.getUserCreds();
+        vm.readonly = !(vm.user && vm.user.is_admin);
+        vm.JSON = JSON;
+
+        vm.cancelCreate = function () {
+            vm.mode = 'view';
+            // revert any changes to the scan
+            vm.activeScan = Scan.transformer(_.cloneDeep(currScan));
+            if ($routeParams.id === '0') {
+                $location.path('/feed/scans');
+            }
+        };
+
+        vm.editScan = function () {
+            // store a reference of the scan as it currently exists in case the user cancels the edit
+            currScan = Scan.transformer(_.cloneDeep(vm.activeScan));
+            vm.mode = 'edit';
+        };
+
+        vm.saveScan = function () {
+            scanService.saveScan(vm.activeScan).then(function (scan) {
+                vm.activeScan = Scan.transformer(scan);
+                // only store the new workspace name, not the entire object
+                _.forEach(vm.activeScan.configuration.files_to_ingest, function (file) {
+                    if (file.new_workspace) {
+                        file.new_workspace = file.new_workspace.name;
+                    }
+                });
+                if (scaleConfig.static) {
+                    localStorage.setItem('scan' + vm.activeScan.id, JSON.stringify(vm.activeScan));
+                }
+                $route.reload();
+            }).catch(function () {
+
+            });
+        };
+
+        vm.clearLocalScans = function () {
+            _.forEach(vm.localScans, function (scan) {
+                localStorage.removeItem('scan' + scan.id);
+            });
+            $location.path('/feed/scans');
+        };
+
+        vm.newScan = function () {
+            vm.mode = 'add';
+            vm.loadScan(0);
+        };
+
+        vm.loadScan = function (id) {
+            $location.path('feed/scans/' + id);
+        };
+
+        var getWarningsHtml = function (warnings) {
+            var warningsHtml = '';
+            _.forEach(warnings, function (warning) {
+                warningsHtml += '<b>' + warning.id + ':</b> ' + warning.details + '<br /><br />';
+            });
+            warningsHtml += '<button type="button" class="btn btn-default btn-xs clear">Hide</button>';
+            return warningsHtml;
+        };
+
+        vm.validateScan = function () {
+            vm.loading = true;
+            scanService.validateScan(vm.activeScan).then(function (data) {
+                if (data.warnings && data.warnings.length > 0) {
+                    // display the warnings
+                    var warningsHtml = getWarningsHtml(data.warnings);
+                    toastr['error'](warningsHtml);
+                } else {
+                    toastr['success']('Scan is valid.');
+                }
+            }).catch(function (error) {
+                if (error && error.detail) {
+                    toastr['error'](error.detail);
+                } else {
+                    toastr['error']('Error validating scan');
+                }
+            }).finally(function () {
+                vm.loading = false;
+            });
+        };
+
+        vm.disableSaveBtn = function (invalid) {
+            var returnVal = !(!invalid && vm.activeScan.configuration.files_to_ingest.length > 0);
+            vm.saveBtnClass = returnVal ? 'btn-default' : 'btn-success';
+            return returnVal;
+        };
+
+        vm.addScanIngestFile = function () {
+            if (_.keys(vm.activeScanIngestFile).length > 0) {
+                vm.activeScan.configuration.files_to_ingest.push(ScanIngestFile.transformer(vm.activeScanIngestFile));
+                vm.activeScanIngestFile = new ScanIngestFile();
+            }
+        };
+
+        vm.deleteScanIngestFile = function (file) {
+            _.remove(vm.activeScan.configuration.files_to_ingest, function (f) {
+                return angular.equals(f, file);
+            });
+        };
+
+        vm.addDataType = function () {
+            if (vm.dataType) {
+                vm.activeScanIngestFile.data_types.push(vm.dataType);
+                vm.dataType = '';
+            }
+        };
+
+        vm.removeDataType = function (dataType) {
+            _.remove(vm.activeScanIngestFile.data_types, function (d) {
+                return d === dataType;
+            });
+        };
+
+        vm.updateWorkspace = function () {
+            if (vm.activeScan) {
+                var workspaceObj = _.find(vm.workspaces, {name: vm.activeScan.configuration.workspace});
+                if (workspaceObj) {
+                    vm.newWorkspaces = _.cloneDeep(vm.workspaces);
+                    _.remove(vm.newWorkspaces, workspaceObj);
+                    getWorkspaceDetails(workspaceObj.id);
+                }
+            }
+        };
+
+        vm.formatJSON = function (file) {
+            file = _.omit(file, '$$hashKey');
+            if (file.new_workspace) {
+                file.new_workspace = file.new_workspace.name;
+            }
+            return JSON.stringify(file, null, 4);
+        };
+
+        var getWorkspaceDetails = function (id) {
+            vm.loading = true;
+            workspacesService.getWorkspaceDetails(id).then(function (data) {
+                vm.activeWorkspace = data;
+                if (vm.activeWorkspace.json_config.broker.type === 'host') {
+                    vm.activeScan.configuration.scanner.type = 'dir';
+                } else if (vm.activeWorkspace.json_config.broker.type === 's3') {
+                    vm.activeScan.configuration.scanner.type = 's3';
+                } else {
+                    vm.activeScan.configuration.monitor.type = null;
+                }
+            }).catch(function (error) {
+                console.log(error);
+            }).finally(function () {
+                vm.loading = false;
+            });
+        };
+
+        var getWorkspaces = function () {
+            workspacesService.getWorkspaces().then(function (data) {
+                vm.workspaces = data;
+                vm.newWorkspaces = data;
+                vm.updateWorkspace();
+            }).catch(function (error) {
+                console.log(error);
+            }).finally(function () {
+                vm.loading = false;
+            });
+        };
+
+        var initialize = function () {
+            getWorkspaces();
+            vm.activeScan = null;
+            vm.mode = 'view';
+
+            if ($routeParams.id) {
+                var id = parseInt($routeParams.id);
+                if (id === 0) {
+                    vm.mode = 'add';
+                    vm.activeScan = new Scan();
+                } else {
+                    scanService.getScanDetails(id).then(function (data) {
+                        vm.activeScan = Scan.transformer(data);
+                    });
+                }
+            }
+            navService.updateLocation('feed');
+            subnavService.setCurrentPath('feed/scans');
+        };
+
+        initialize();
+    });
+})();

--- a/scale-ui/app/modules/feed/controllers/scanDetailsController.js
+++ b/scale-ui/app/modules/feed/controllers/scanDetailsController.js
@@ -162,7 +162,7 @@
                 } else if (vm.activeWorkspace.json_config.broker.type === 's3') {
                     vm.activeScan.configuration.scanner.type = 's3';
                 } else {
-                    vm.activeScan.configuration.monitor.type = null;
+                    vm.activeScan.configuration.scanner.type = null;
                 }
             }).catch(function (error) {
                 console.log(error);

--- a/scale-ui/app/modules/feed/controllers/scansController.js
+++ b/scale-ui/app/modules/feed/controllers/scansController.js
@@ -7,7 +7,6 @@
         var vm = this;
 
         vm.scansParams = stateService.getScansParams();
-
         vm.stateService = stateService;
         vm.loading = true;
         vm.subnavLinks = scaleConfig.subnavLinks.feed;
@@ -64,7 +63,7 @@
             {
                 field: 'job',
                 enableFiltering: false,
-                cellTemplate: '<div class="ui-grid-cell-contents">{{ row.entity.job.title }}</div>'
+                cellTemplate: '<div class="ui-grid-cell-contents">{{ row.entity.job.job_type.title }}</div>'
             },
             {
                 field: 'created',

--- a/scale-ui/app/modules/feed/controllers/scansController.js
+++ b/scale-ui/app/modules/feed/controllers/scansController.js
@@ -33,6 +33,9 @@
         vm.searchText = vm.scansParams.name || '';
         vm.gridOptions = gridFactory.defaultGridOptions();
         vm.gridOptions.data = [];
+        vm.sortableOptions = {
+            handle: '.sortable-handle'
+        };
 
         $timeout(function () {
             vm.gridOptions.paginationCurrentPage = vm.scansParams.page || 1;

--- a/scale-ui/app/modules/feed/controllers/scansController.js
+++ b/scale-ui/app/modules/feed/controllers/scansController.js
@@ -1,0 +1,182 @@
+(function () {
+    'use strict';
+
+    angular.module('scaleApp').controller('scansController', function ($scope, $location, $timeout, scaleConfig, scaleService, stateService, scanService, Scan, navService, subnavService, gridFactory) {
+        subnavService.setCurrentPath('feed/scans');
+
+        var vm = this;
+
+        vm.scansParams = stateService.getScansParams();
+
+        vm.stateService = stateService;
+        vm.loading = true;
+        vm.subnavLinks = scaleConfig.subnavLinks.feed;
+        vm.lastModifiedStart = moment.utc(vm.scansParams.started).toDate();
+        vm.lastModifiedStartPopup = {
+            opened: false
+        };
+        vm.openLastModifiedStartPopup = function ($event) {
+            $event.stopPropagation();
+            vm.lastModifiedStartPopup.opened = true;
+        };
+        vm.lastModifiedStop = moment.utc(vm.scansParams.ended).toDate();
+        vm.lastModifiedStopPopup = {
+            opened: false
+        };
+        vm.openLastModifiedStopPopup = function ($event) {
+            $event.stopPropagation();
+            vm.lastModifiedStopPopup.opened = true;
+        };
+        vm.dateModelOptions = {
+            timezone: '+000'
+        };
+        vm.scanData = [];
+        vm.searchText = vm.scansParams.name || '';
+        vm.gridOptions = gridFactory.defaultGridOptions();
+        vm.gridOptions.data = [];
+
+        $timeout(function () {
+            vm.gridOptions.paginationCurrentPage = vm.scansParams.page || 1;
+            vm.gridOptions.paginationPageSize = vm.scansParams.page_size || vm.gridOptions.paginationPageSize;
+        });
+
+        vm.refreshData = function () {
+            var filteredData = _.filter(vm.scanData, function (d) {
+                return d.name.toLowerCase().includes(vm.searchText.toLowerCase());
+            });
+            vm.gridOptions.data = filteredData.length > 0 ? filteredData : vm.gridOptions.data;
+        };
+
+        var filteredByOrder = vm.scansParams.order ? true : false;
+
+        vm.colDefs = [
+            {
+                field: 'name',
+                displayName: 'Name',
+                //filterHeaderTemplate: '<div class="ui-grid-filter-container"><input ng-model="grid.appScope.vm.searchText" ng-change="grid.appScope.vm.refreshData()" class="form-control" placeholder="Search"></div>'
+                enableFiltering: false
+            },
+            {
+                field: 'file_count',
+                displayName: 'File Count',
+                enableFiltering: false
+            },
+            {
+                field: 'job',
+                enableFiltering: false,
+                cellTemplate: '<div class="ui-grid-cell-contents">{{ row.entity.job.title }}</div>'
+            },
+            {
+                field: 'created',
+                enableFiltering: false,
+                cellTemplate: '<div class="ui-grid-cell-contents">{{ row.entity.created_formatted }}</div>'
+            },
+            {
+                field: 'last_modified',
+                enableFiltering: false,
+                cellTemplate: '<div class="ui-grid-cell-contents">{{ row.entity.last_modified_formatted }}</div>'
+            }
+        ];
+
+        vm.getScans = function () {
+            vm.loading = true;
+            scanService.getScans(vm.scansParams).then(function (data) {
+                vm.scanData = Scan.transformer(data.results);
+                vm.gridOptions.minRowsToShow = data.results.length;
+                vm.gridOptions.virtualizationThreshold = data.results.length;
+                vm.gridOptions.totalItems = data.count;
+                vm.gridOptions.data = vm.scanData = Scan.transformer(data.results);;
+            }).catch(function (error) {
+                console.log(error);
+            }).finally(function () {
+                vm.loading = false;
+            });
+        };
+
+        vm.filterResults = function () {
+            stateService.setScansParams(vm.scansParams);
+            vm.getScans();
+        };
+
+        vm.updateColDefs = function () {
+            vm.gridOptions.columnDefs = gridFactory.applySortConfig(vm.colDefs, vm.scansParams);
+        };
+
+        vm.updateScanOrder = function (sortArr) {
+            vm.scansParams.order = sortArr.length > 0 ? sortArr : null;
+            filteredByOrder = sortArr.length > 0;
+            vm.filterResults();
+        };
+
+        vm.gridOptions.onRegisterApi = function (gridApi) {
+            //set gridApi on scope
+            vm.gridApi = gridApi;
+            vm.gridApi.pagination.on.paginationChanged($scope, function (currentPage, pageSize) {
+                vm.scansParams.page = currentPage;
+                vm.scansParams.page_size = pageSize;
+                vm.filterResults();
+            });
+            vm.gridApi.selection.on.rowSelectionChanged($scope, function (row) {
+                $location.path('/feed/scans/' + row.entity.id).search('');
+
+            });
+            vm.gridApi.core.on.sortChanged($scope, function (grid, sortColumns) {
+                _.forEach(vm.gridApi.grid.columns, function (col) {
+                    col.colDef.sort = col.sort;
+                });
+                stateService.setScansColDefs(vm.gridApi.grid.options.columnDefs);
+                var sortArr = [];
+                _.forEach(sortColumns, function (col) {
+                    sortArr.push(col.sort.direction === 'desc' ? '-' + col.field : col.field);
+                });
+                vm.updateScanOrder(sortArr);
+            });
+        };
+
+        vm.filterByName = function (keyEvent) {
+            if (!keyEvent || (keyEvent && keyEvent.which === 13)) {
+                vm.scansParams.name = vm.searchText;
+                vm.filterResults();
+            }
+        };
+
+        vm.initialize = function () {
+            vm.getScans();
+            stateService.setScansParams(vm.scansParams);
+            vm.updateColDefs();
+            navService.updateLocation('feed');
+        };
+
+        vm.initialize();
+
+        $scope.$watch('vm.lastModifiedStart', function (value) {
+            if (!vm.loading) {
+                vm.scansParams.started = value.toISOString();
+                vm.filterResults();
+            }
+        });
+
+        $scope.$watch('vm.lastModifiedStop', function (value) {
+            if (!vm.loading) {
+                vm.scansParams.ended = value.toISOString();
+                vm.filterResults();
+            }
+        });
+
+        $scope.$watchCollection('vm.stateService.getScansColDefs()', function (newValue, oldValue) {
+            if (angular.equals(newValue, oldValue)) {
+                return;
+            }
+            vm.colDefs = newValue;
+            vm.updateColDefs();
+        });
+
+        $scope.$watchCollection('vm.stateService.getScansParams()', function (newValue, oldValue) {
+            if (angular.equals(newValue, oldValue)) {
+                return;
+            }
+            vm.scansParams = newValue;
+            vm.updateColDefs();
+        });
+    });
+})();

--- a/scale-ui/app/modules/feed/models/Scan.js
+++ b/scale-ui/app/modules/feed/models/Scan.js
@@ -19,12 +19,22 @@
 
         Scan.prototype = {
             clean: function () {
-                return {
+                var returnObj = {
                     name: this.name,
                     title: this.title,
                     description: this.description,
                     configuration: this.configuration
                 };
+                if (returnObj.configuration && returnObj.configuration.scanner.type === 's3') {
+                    delete returnObj.configuration.scanner.transfer_suffix;
+                }
+                if (returnObj.configuration.files_to_ingest) {
+                    _.forEach(returnObj.configuration.files_to_ingest, function (f) {
+                        delete f.$$hashKey;
+                    });
+                }
+                // remove empty/null/undefined values from returnObj
+                return _.pick(returnObj, _.identity);
             }
         };
 

--- a/scale-ui/app/modules/feed/models/Scan.js
+++ b/scale-ui/app/modules/feed/models/Scan.js
@@ -1,0 +1,52 @@
+(function () {
+    'use strict';
+
+    angular.module('scaleApp').factory('Scan', function (scaleConfig, Job, ScanConfiguration) {
+        var Scan = function (id, name, title, description, file_count, job, dry_run_job, created, last_modified, configuration) {
+            this.id = id;
+            this.name = name;
+            this.title = title;
+            this.description = description;
+            this.file_count = file_count;
+            this.job = Job.transformer(job);
+            this.dry_run_job = Job.transformer(dry_run_job);
+            this.created = created;
+            this.created_formatted = moment.utc(created).format(scaleConfig.dateFormats.day_second_utc);
+            this.last_modified = last_modified;
+            this.last_modified_formatted = moment.utc(last_modified).format(scaleConfig.dateFormats.day_second_utc);
+            this.configuration = ScanConfiguration.transformer(configuration);
+        };
+
+        Scan.prototype = {
+
+        };
+
+        // static methods, assigned to class
+        Scan.build = function (data) {
+            if (data) {
+                return new Scan(
+                    data.id,
+                    data.name,
+                    data.title,
+                    data.description,
+                    data.file_count,
+                    data.job,
+                    data.dry_run_job,
+                    data.created,
+                    data.last_modified,
+                    data.configuration
+                );
+            }
+            return new Scan();
+        };
+
+        Scan.transformer = function (data) {
+            if (angular.isArray(data)) {
+                return data.map(Scan.build);
+            }
+            return Scan.build(data);
+        };
+
+        return Scan;
+    });
+})();

--- a/scale-ui/app/modules/feed/models/Scan.js
+++ b/scale-ui/app/modules/feed/models/Scan.js
@@ -18,7 +18,14 @@
         };
 
         Scan.prototype = {
-
+            clean: function () {
+                return {
+                    name: this.name,
+                    title: this.title,
+                    description: this.description,
+                    configuration: this.configuration
+                };
+            }
         };
 
         // static methods, assigned to class

--- a/scale-ui/app/modules/feed/models/ScanConfiguration.js
+++ b/scale-ui/app/modules/feed/models/ScanConfiguration.js
@@ -1,0 +1,42 @@
+(function () {
+    'use strict';
+
+    angular.module('scaleApp').factory('ScanConfiguration', function (scaleConfig, ScanIngestFile) {
+        var ScanConfiguration = function (version, workspace, scanner, recursive, files_to_ingest) {
+            this.version = scaleConfig.ScanConfigurationVersion;
+            this.workspace = workspace;
+            this.scanner = scanner ? scanner : {
+                type: '',
+                transfer_suffix: ''
+            };
+            this.recursive = recursive;
+            this.files_to_ingest = files_to_ingest ? StrikeIngestFile.transformer(files_to_ingest) : [];
+        };
+
+        ScanConfiguration.prototype = {
+
+        };
+
+        // static methods, assigned to class
+        ScanConfiguration.build = function (data) {
+            if (data) {
+                return new ScanConfiguration(
+                    data.version,
+                    data.workspace,
+                    data.monitor,
+                    data.files_to_ingest
+                );
+            }
+            return new ScanConfiguration();
+        };
+
+        ScanConfiguration.transformer = function (data) {
+            if (angular.isArray(data)) {
+                return data.map(ScanConfiguration.build);
+            }
+            return ScanConfiguration.build(data);
+        };
+
+        return ScanConfiguration;
+    });
+})();

--- a/scale-ui/app/modules/feed/models/ScanConfiguration.js
+++ b/scale-ui/app/modules/feed/models/ScanConfiguration.js
@@ -2,15 +2,14 @@
     'use strict';
 
     angular.module('scaleApp').factory('ScanConfiguration', function (scaleConfig, ScanIngestFile) {
-        var ScanConfiguration = function (version, workspace, scanner, recursive, files_to_ingest) {
-            this.version = scaleConfig.ScanConfigurationVersion;
+        var ScanConfiguration = function (version, workspace, scanner, files_to_ingest) {
+            this.version = scaleConfig.scanConfigurationVersion;
             this.workspace = workspace;
             this.scanner = scanner ? scanner : {
                 type: '',
                 transfer_suffix: ''
             };
-            this.recursive = recursive;
-            this.files_to_ingest = files_to_ingest ? StrikeIngestFile.transformer(files_to_ingest) : [];
+            this.files_to_ingest = files_to_ingest ? ScanIngestFile.transformer(files_to_ingest) : [];
         };
 
         ScanConfiguration.prototype = {
@@ -20,12 +19,14 @@
         // static methods, assigned to class
         ScanConfiguration.build = function (data) {
             if (data) {
-                return new ScanConfiguration(
+                var returnObj = new ScanConfiguration(
                     data.version,
                     data.workspace,
-                    data.monitor,
+                    data.scanner,
                     data.files_to_ingest
                 );
+                // remove empty/null/undefined values from returnObj
+                return _.pick(returnObj, _.identity);
             }
             return new ScanConfiguration();
         };

--- a/scale-ui/app/modules/feed/models/ScanConfiguration.js
+++ b/scale-ui/app/modules/feed/models/ScanConfiguration.js
@@ -19,14 +19,12 @@
         // static methods, assigned to class
         ScanConfiguration.build = function (data) {
             if (data) {
-                var returnObj = new ScanConfiguration(
+                return new ScanConfiguration(
                     data.version,
                     data.workspace,
                     data.scanner,
                     data.files_to_ingest
                 );
-                // remove empty/null/undefined values from returnObj
-                return _.pick(returnObj, _.identity);
             }
             return new ScanConfiguration();
         };

--- a/scale-ui/app/modules/feed/models/ScanIngestFile.js
+++ b/scale-ui/app/modules/feed/models/ScanIngestFile.js
@@ -1,0 +1,43 @@
+(function () {
+    'use strict';
+
+    angular.module('scaleApp').factory('ScanIngestFile', function () {
+        var ScanIngestFile = function (filename_regex, data_types, new_workspace, new_file_path) {
+            this.filename_regex = filename_regex;
+            this.data_types = data_types || [];
+            this.new_workspace = new_workspace || '';
+            this.new_file_path = new_file_path || '';
+        };
+
+        ScanIngestFile.prototype = {
+
+        };
+
+        // static methods, assigned to class
+        ScanIngestFile.build = function (data) {
+            if (data) {
+                var returnObj = new ScanIngestFile(
+                    data.filename_regex,
+                    data.data_types,
+                    data.new_workspace,
+                    data.new_file_path
+                );
+                if (data.data_types && data.data_types.length === 0) {
+                    delete returnObj.data_types;
+                }
+                // remove empty/null/undefined values from returnObj
+                return _.pick(returnObj, _.identity);
+            }
+            return new ScanIngestFile();
+        };
+
+        ScanIngestFile.transformer = function (data) {
+            if (angular.isArray(data)) {
+                return data.map(ScanIngestFile.build);
+            }
+            return ScanIngestFile.build(data);
+        };
+
+        return ScanIngestFile;
+    });
+})();

--- a/scale-ui/app/modules/feed/partials/scanDetailsTemplate.html
+++ b/scale-ui/app/modules/feed/partials/scanDetailsTemplate.html
@@ -133,9 +133,9 @@
                 <b class="margin-bottom-md">Current Rules</b>
                 <p ng-if="vm.activeScan.configuration.files_to_ingest.length === 0">No files in configuration.</p>
                 <div ng-if="vm.activeScan.configuration.files_to_ingest.length > 0">
-                    <ul ng-repeat="file in vm.activeScan.configuration.files_to_ingest" class="list-unstyled">
-                        <li>
-                            <pre><button class="btn btn-danger btn-sm pull-right" ng-click="vm.deleteScanIngestFile(file)" tooltip-append-to-body="true" uib-tooltip="Delete" tooltip-placement="left"><i class="fa fa-remove"></i></button><span ng-bind-html="vm.formatJSON(file)"></span></pre>
+                    <ul ui-sortable="vm.sortableOptions" ng-model="vm.activeScan.configuration.files_to_ingest" class="list-unstyled">
+                        <li ng-repeat="file in vm.activeScan.configuration.files_to_ingest">
+                            <pre><span class="pull-right"><span class="btn btn-default btn-sm sortable-handle" title="Reorder" ng-if="vm.activeScan.configuration.files_to_ingest.length > 1"><i class="fa fa-bars"></i></span><button class="btn btn-danger btn-sm pull-right" ng-click="vm.deleteScanIngestFile(file)" title="Delete"><i class="fa fa-remove"></i></button></span><span ng-bind-html="vm.formatJSON(file)"></span></pre>
                         </li>
                     </ul>
                 </div>

--- a/scale-ui/app/modules/feed/partials/scanDetailsTemplate.html
+++ b/scale-ui/app/modules/feed/partials/scanDetailsTemplate.html
@@ -1,0 +1,145 @@
+<ais-header show-title="false" loading="vm.loading" show-subnav="true" subnav-links="vm.scaleConfig.subnavLinks.feed"></ais-header>
+
+<div ng-if="vm.activeScan">
+    <form name="scansForm" novalidate>
+        <div class="pull-right">
+            <div class="btn-group btn-group-sm" ng-show="!vm.readonly">
+                <button class="btn btn-default" ng-click="vm.validateScan()" ng-if="vm.mode === 'edit' || vm.mode === 'add'" tooltip-append-to-body="true" uib-tooltip="Validate"><i class="fa fa-check"></i></button>
+                <button class="btn" ng-class="vm.saveBtnClass" ng-click="vm.saveScan()" ng-disabled="vm.disableSaveBtn(scansForm.$invalid)" ng-if="vm.mode === 'edit' || vm.mode === 'add'" tooltip-append-to-body="true" uib-tooltip="Save Scan" tooltip-placement="left"><i class="fa fa-save"></i></button>
+                <button class="btn btn-warning" ng-click="vm.cancelCreate()" ng-if="vm.mode === 'add' || vm.mode === 'edit'" tooltip-append-to-body="true" uib-tooltip="Cancel" tooltip-placement="left"><i class="fa fa-close"></i></button>
+                <button class="btn btn-success" ng-click="vm.editScan()" ng-if="vm.mode === 'view'" tooltip-append-to-body="true" uib-tooltip="Edit Scan" tooltip-placement="left"><i class="fa fa-edit"></i></button>
+            </div>
+        </div>
+        <h3 ng-show="!vm.activeScan.title">Untitled Scan</h3>
+        <h3 ng-show="vm.activeScan.title !== ''">{{ vm.activeScan.title }}</h3>
+        <div ng-if="vm.mode==='view'">
+            <dl>
+                <dt>Description:</dt>
+                <dd>{{ vm.activeScan.description }}</dd>
+                <dt ng-if="vm.activeScan.job.id">Job:</dt>
+                <dd ng-if="vm.activeScan.job.id"><a ng-href="/#/jobs/job/{{ vm.activeScan.job.id }}"> <span class="fa" ng-bind-html="'&#x' + vm.activeScan.job.job_type.icon_code"></span> View Job Details ({{ vm.activeScan.job.status }})</a></dd>
+                <dt>Created:</dt>
+                <dd>{{ vm.activeScan.created_formatted }}</dd>
+                <dt>Last Modified:</dt>
+                <dd>{{ vm.activeScan.last_modified_formatted }}</dd>
+                <dt>Configuration:</dt>
+                <dd><pre>{{ vm.JSON.stringify(vm.activeScan.configuration, null, 4) }}</pre></dd>
+            </dl>
+        </div>
+        <div ng-if="vm.mode === 'edit' || vm.mode === 'add'">
+            <div class="row">
+                <div class="col-xs-12 col-md-6">
+                    <div class="form-group" ng-class="{ 'has-error': scansForm.sName.$invalid }">
+                        <label for="sName">Name</label>
+                        <input id="sName" name="sName" type="text" ng-disabled="vm.mode === 'edit'" class="form-control" ng-model="vm.activeScan.name" placeholder="Name" required>
+                        <p ng-show="scansForm.sName.$invalid && !scansForm.sName.$pristine" class="help-block">Name is required.</p>
+                    </div>
+                </div>
+                <div class="col-xs-12 col-md-6">
+                    <div class="form-group" ng-class="{ 'has-error': scansForm.sTitle.$invalid }">
+                        <label for="sTitle">Title</label>
+                        <input id="sTitle" name="sTitle" type="text" class="form-control" ng-model="vm.activeScan.title" placeholder="Title" required>
+                        <p ng-show="scansForm.sTitle.$invalid && !scansForm.sTitle.$pristine" class="help-block">Title is required.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-xs-12 col-md-6">
+                    <div class="form-group" ng-class="{ 'has-error': scansForm.sDescription.$invalid }">
+                        <label for="sDescription">Description</label>
+                        <textarea id="sDescription" name="sDescription" class="form-control" ng-model="vm.activeScan.description" placeholder="Description" rows="5" required></textarea>
+                        <p ng-show="scansForm.sDescription.$invalid && !scansForm.sDescription.$pristine" class="help-block">Description is required.</p>
+                    </div>
+                </div>
+                <div class="col-xs-12 col-md-6">
+                    <div class="form-group" ng-class="{ 'has-error': scansForm.scWorkspace.$invalid }">
+                        <label for="scWorkspace">Workspace</label>
+                        <select id="scWorkspace" name="scWorkspace" class="form-control" ng-model="vm.activeScan.configuration.workspace" ng-options="w.name as w.title for w in vm.workspaces" ng-change="vm.updateWorkspace()" required></select>
+                    </div>
+                    <div class="row" ng-if="vm.activeScan.configuration.workspace !== null">
+                        <div class="col-xs-12 col-md-6">
+                            <div class="form-group">
+                                <label>Scanner Type:</label>
+                                <input type="text" class="form-control" value="s3" disabled ng-if="vm.activeWorkspace.json_config.broker.type === 's3'">
+                                <input type="text" class="form-control" value="dir" disabled ng-if="vm.activeWorkspace.json_config.broker.type === 'host'">
+                                <input type="text" class="form-control" value="Unavailable for NFS workspaces" disabled ng-if="vm.activeWorkspace.json_config.broker.type === 'nfs'">
+                            </div>
+                        </div>
+                        <div class="col-xs-12 col-md-6">
+                            <div class="form-group" ng-if="vm.activeScan.configuration.scanner.type === 'dir'">
+                                <label for="transfer_suffix">Transfer Suffix</label>
+                                <input id="transfer_suffix" name="transfer_suffix" type="text" class="form-control" placeholder="Transfer Suffix" ng-model="vm.activeScan.configuration.scanner.transfer_suffix">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+    <form name="ingestFileForm" novalidate ng-if="vm.mode === 'edit' || vm.mode === 'add'">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title"><b>Ingest File Rules</b> <span ng-if="vm.activeScan.configuration.files_to_ingest.length === 0">(at least 1 is required)</span></h3>
+            </div>
+            <div class="panel-body">
+                <!-- scif = (S)canner (C)onfig (I)ngest (F)ile -->
+                <div class="row">
+                    <div class="col-xs-6">
+                        <div class="form-group" ng-class="{ 'has-error': ingestFileForm.scifFilenameRegex.$invalid }">
+                            <label for="scifFilenameRegex">Filename Regex</label>
+                            <input id="scifFilenameRegex" name="scifFilenameRegex" type="text" class="form-control" ng-model="vm.activeScanIngestFile.filename_regex" placeholder="Filename Regex" required>
+                            <p class="help-block">A regular expression to check against the names of newly copied files (required)</p>
+                        </div>
+                    </div>
+                    <div class="col-xs-6">
+                        <div class="form-group">
+                            <label for="scifDataTypes">Data Types</label>
+                            <div class="input-group">
+                                <input id="scifDataTypes" name="scifDataTypes" type="text" class="form-control" ng-model="vm.dataType" placeholder="Data Types">
+                                <span class="input-group-btn">
+                                    <button class="btn btn-default" ng-click="vm.addDataType()"><i class="fa fa-plus"></i></button>
+                                </span>
+                            </div>
+                            <div class="help-block">
+                                <ul class="list-inline">
+                                    <li ng-repeat="dataType in vm.activeScanIngestFile.data_types"><span class="label label-default strike-data-type" ng-click="vm.removeDataType(dataType)">{{ dataType }} <i class="fa fa-close"></i></span></li>
+                                </ul>
+                            </div>
+                            <p class="help-block">Any file that matches the corresponding file name regular expression will have these data type strings "tagged" with the file (optional)</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-xs-6">
+                        <div class="form-group">
+                            <label for="scifNewWorkspace">New Workspace</label>
+                            <select id="scifNewWorkspace" name="scifNewWorkspace" class="form-control" ng-model="vm.activeScanIngestFile.new_workspace" ng-options="w as w.title for w in vm.newWorkspaces"></select>
+                            <p class="help-block">New workspace to which the file should be copied (optional)</p>
+                        </div>
+                    </div>
+                    <div class="col-xs-6">
+                        <div class="form-group">
+                            <label for="scifNewFilePath">New File Path</label>
+                            <input id="scifNewFilePath" name="scifNewFilePath" type="text" class="form-control" ng-model="vm.activeScanIngestFile.new_file_path" placeholder="New File Path">
+                            <p class="help-block">String that specifies a new relative path for storing new files (optional)</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-xs-4 col-xs-offset-4">
+                        <button class="btn btn-default btn-block margin-bottom-md" ng-click="vm.addScanIngestFile()" ng-disabled="ingestFileForm.$invalid"><i class="fa fa-plus"></i> Add Rule to Configuration</button>
+                    </div>
+                </div>
+                <b class="margin-bottom-md">Current Rules</b>
+                <p ng-if="vm.activeScan.configuration.files_to_ingest.length === 0">No files in configuration.</p>
+                <div ng-if="vm.activeScan.configuration.files_to_ingest.length > 0">
+                    <ul ng-repeat="file in vm.activeScan.configuration.files_to_ingest" class="list-unstyled">
+                        <li>
+                            <pre><button class="btn btn-danger btn-sm pull-right" ng-click="vm.deleteScanIngestFile(file)" tooltip-append-to-body="true" uib-tooltip="Delete" tooltip-placement="left"><i class="fa fa-remove"></i></button><span ng-bind-html="vm.formatJSON(file)"></span></pre>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>

--- a/scale-ui/app/modules/feed/partials/scanDetailsTemplate.html
+++ b/scale-ui/app/modules/feed/partials/scanDetailsTemplate.html
@@ -23,7 +23,7 @@
                 <dt>Last Modified:</dt>
                 <dd>{{ vm.activeScan.last_modified_formatted }}</dd>
                 <dt>Configuration:</dt>
-                <dd><pre>{{ vm.JSON.stringify(vm.activeScan.configuration, null, 4) }}</pre></dd>
+                <dd><pre ng-bind="vm.formatJSON(vm.activeScan.configuration)"></pre></dd>
             </dl>
         </div>
         <div ng-if="vm.mode === 'edit' || vm.mode === 'add'">

--- a/scale-ui/app/modules/feed/partials/scansTemplate.html
+++ b/scale-ui/app/modules/feed/partials/scansTemplate.html
@@ -1,19 +1,32 @@
-<ais-header name="'Scans (' + vm.gridOptions.totalItems + ')'" loading="vm.loading" show-subnav="true" subnav-links="vm.subnavLinks" ></ais-header>
-<div class="form-inline margin-bottom-md">
-    <div class="input-group margin-right-md">
-        <span class="input-group-addon" id="search-input">Search:</span>
-        <input ng-model="vm.searchText" class="form-control" placeholder="Name" ng-keypress="vm.filterByName($event)">
-        <span class="input-group-btn">
+<ais-header hide-title="true" loading="vm.loading" show-subnav="true" subnav-links="vm.subnavLinks" ></ais-header>
+<div class="page-header">
+    <h1>
+        Scans ({{ vm.gridOptions.totalItems }})
+        <small ng-if="!vm.readonly">
+            <a href="/#/feed/scans/0/" class="btn btn-default"><i class="fa fa-plus-circle"></i> Create Scan</a>
+        </small>
+    </h1>
+    <hr />
+</div>
+<div class="row">
+    <div class="col-xs-9">
+        <div class="form-inline margin-bottom-md">
+            <div class="input-group margin-right-md">
+                <span class="input-group-addon" id="search-input">Search:</span>
+                <input ng-model="vm.searchText" class="form-control" placeholder="Name" ng-keypress="vm.filterByName($event)">
+                <span class="input-group-btn">
             <button class="btn btn-default" ng-click="vm.filterByName()" ng-disabled="vm.searchText.length === 0"><i class="fa fa-chevron-circle-right"></i></button>
         </span>
-    </div>
-    <div class="input-group margin-right-md">
-        <span class="input-group-addon" id="from-input">From:</span>
-        <input id="lastModifiedStart" type="text" class="form-control" aria-describedby="from-input" uib-datepicker-popup="yyyy-MM-dd" ng-model="vm.lastModifiedStart" ng-model-options="vm.dateModelOptions" is-open="vm.lastModifiedStartPopup.opened" close-text="Close" datepicker-append-to-body="true" ng-click="vm.openLastModifiedStartPopup($event)" />
-    </div>
-    <div class="input-group margin-right-md">
-        <span class="input-group-addon" id="to-input">To:</span>
-        <input id="lastModifiedStop" type="text" class="form-control" aria-describedby="to-input" uib-datepicker-popup="yyyy-MM-dd" ng-model="vm.lastModifiedStop" ng-model-options="vm.dateModelOptions" is-open="vm.lastModifiedStopPopup.opened" close-text="Close" datepicker-append-to-body="true" ng-click="vm.openLastModifiedStopPopup($event)" />
+            </div>
+            <div class="input-group margin-right-md">
+                <span class="input-group-addon" id="from-input">From:</span>
+                <input id="lastModifiedStart" type="text" class="form-control" aria-describedby="from-input" uib-datepicker-popup="yyyy-MM-dd" ng-model="vm.lastModifiedStart" ng-model-options="vm.dateModelOptions" is-open="vm.lastModifiedStartPopup.opened" close-text="Close" datepicker-append-to-body="true" ng-click="vm.openLastModifiedStartPopup($event)" />
+            </div>
+            <div class="input-group margin-right-md">
+                <span class="input-group-addon" id="to-input">To:</span>
+                <input id="lastModifiedStop" type="text" class="form-control" aria-describedby="to-input" uib-datepicker-popup="yyyy-MM-dd" ng-model="vm.lastModifiedStop" ng-model-options="vm.dateModelOptions" is-open="vm.lastModifiedStopPopup.opened" close-text="Close" datepicker-append-to-body="true" ng-click="vm.openLastModifiedStopPopup($event)" />
+            </div>
+        </div>
     </div>
 </div>
 <div class="row">

--- a/scale-ui/app/modules/feed/partials/scansTemplate.html
+++ b/scale-ui/app/modules/feed/partials/scansTemplate.html
@@ -1,0 +1,26 @@
+<ais-header name="'Scans (' + vm.gridOptions.totalItems + ')'" loading="vm.loading" show-subnav="true" subnav-links="vm.subnavLinks" ></ais-header>
+<div class="form-inline margin-bottom-md">
+    <div class="input-group margin-right-md">
+        <span class="input-group-addon" id="search-input">Search:</span>
+        <input ng-model="vm.searchText" class="form-control" placeholder="Name" ng-keypress="vm.filterByName($event)">
+        <span class="input-group-btn">
+            <button class="btn btn-default" ng-click="vm.filterByName()" ng-disabled="vm.searchText.length === 0"><i class="fa fa-chevron-circle-right"></i></button>
+        </span>
+    </div>
+    <div class="input-group margin-right-md">
+        <span class="input-group-addon" id="from-input">From:</span>
+        <input id="lastModifiedStart" type="text" class="form-control" aria-describedby="from-input" uib-datepicker-popup="yyyy-MM-dd" ng-model="vm.lastModifiedStart" ng-model-options="vm.dateModelOptions" is-open="vm.lastModifiedStartPopup.opened" close-text="Close" datepicker-append-to-body="true" ng-click="vm.openLastModifiedStartPopup($event)" />
+    </div>
+    <div class="input-group margin-right-md">
+        <span class="input-group-addon" id="to-input">To:</span>
+        <input id="lastModifiedStop" type="text" class="form-control" aria-describedby="to-input" uib-datepicker-popup="yyyy-MM-dd" ng-model="vm.lastModifiedStop" ng-model-options="vm.dateModelOptions" is-open="vm.lastModifiedStopPopup.opened" close-text="Close" datepicker-append-to-body="true" ng-click="vm.openLastModifiedStopPopup($event)" />
+    </div>
+</div>
+<div class="row">
+    <div class="col-xs-12">
+        <div class="grid-container">
+            <div ui-grid="vm.gridOptions" ui-grid-selection ui-grid-pagination ui-grid-resize-columns class="scale-grid"></div>
+        </div>
+        <ais-grid-pagination></ais-grid-pagination>
+    </div>
+</div>

--- a/scale-ui/app/modules/feed/services/scanService.js
+++ b/scale-ui/app/modules/feed/services/scanService.js
@@ -36,7 +36,7 @@
             validateScan: function (scan) {
                 var d = $q.defer();
 
-                $http.post(scaleConfig.urls.apiPrefix + 'scans/validation/', scan.configuration).success(function (result) {
+                $http.post(scaleConfig.urls.apiPrefix + 'scans/validation/', scan).success(function (result) {
                     d.resolve(result);
                 }).error(function(error){
                     d.reject(error);

--- a/scale-ui/app/modules/feed/services/scanService.js
+++ b/scale-ui/app/modules/feed/services/scanService.js
@@ -35,8 +35,9 @@
             },
             validateScan: function (scan) {
                 var d = $q.defer();
+                var cleanScan = scan.clean();
 
-                $http.post(scaleConfig.urls.apiPrefix + 'scans/validation/', scan).success(function (result) {
+                $http.post(scaleConfig.urls.apiPrefix + 'scans/validation/', cleanScan).success(function (result) {
                     d.resolve(result);
                 }).error(function(error){
                     d.reject(error);

--- a/scale-ui/app/modules/feed/services/scanService.js
+++ b/scale-ui/app/modules/feed/services/scanService.js
@@ -1,0 +1,69 @@
+(function () {
+    'use strict';
+
+    angular.module('scaleApp').service('scanService', function ($http, $q, $resource, scaleConfig) {
+        return {
+            getScans: function (params) {
+                var d = $q.defer();
+                var url = scaleConfig.urls.apiPrefix + 'scans/';
+
+                $http({
+                    url: url,
+                    method: 'GET',
+                    params: params
+                }).success(function (data) {
+                    d.resolve(data);
+                }).error(function (error) {
+                    d.reject(error);
+                });
+                return d.promise;
+            },
+            getScanDetails: function (id) {
+                var d = $q.defer();
+                var url = scaleConfig.urls.apiPrefix + 'scans/' + id + '/';
+
+                $http({
+                    url: url,
+                    method: 'GET'
+                }).success(function (data) {
+                    d.resolve(data);
+                }).error(function (error) {
+                    d.reject(error);
+                });
+                return d.promise;
+
+            },
+            validateScan: function (scan) {
+                var d = $q.defer();
+
+                $http.post(scaleConfig.urls.apiPrefix + 'scans/validation/', scan.configuration).success(function (result) {
+                    d.resolve(result);
+                }).error(function(error){
+                    d.reject(error);
+                });
+
+                return d.promise;
+            },
+            saveScan: function (scan) {
+                var d = $q.defer();
+
+                if (!scan.id) {
+                    $http.post(scaleConfig.urls.apiPrefix + 'scans/', scan).success(function (result) {
+                        d.resolve(result);
+                    }).error(function (error) {
+                        d.reject(error);
+                    });
+                } else {
+                    $http.patch(scaleConfig.urls.apiPrefix + 'scans/' + scan.id + '/', scan).success(function (result) {
+                        scan = result;
+                        d.resolve(scan);
+                    }).error(function (error) {
+                        d.reject(error);
+                    });
+                }
+
+                return d.promise;
+            }
+        };
+    });
+})();

--- a/scale-ui/app/test/data/scans.json
+++ b/scale-ui/app/test/data/scans.json
@@ -1,0 +1,83 @@
+{
+    "count": 2,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 1,
+            "name": "scan1",
+            "title": "Scan 1",
+            "description": "First scan",
+            "file_count": 5,
+            "job": {
+                "id": 7,
+                "job_type": {
+                    "id": 2,
+                    "name": "scale-strike",
+                    "version": "1.0",
+                    "title": "Scale Strike",
+                    "description": "Monitors a directory for incoming source files to ingest",
+                    "category": "system",
+                    "author_name": null,
+                    "author_url": null,
+                    "is_system": true,
+                    "is_long_running": true,
+                    "is_active": true,
+                    "is_operational": true,
+                    "is_paused": false,
+                    "icon_code": "f0e7"
+                },
+                "job_type_rev": {
+                    "id": 2
+                },
+                "event": {
+                    "id": 1
+                },
+                "status": "RUNNING",
+                "priority": 10,
+                "num_exes": 1
+            },
+            "dry_run_job": {},
+            "created": "2015-10-05T21:26:04.876Z",
+            "last_modified": "2015-10-05T21:26:04.876Z"
+        },
+        {
+            "id": 2,
+            "name": "scan2",
+            "title": "Scan 2",
+            "description": "Second scan",
+            "file_count": 17,
+            "job": {
+                "id": 7,
+                "job_type": {
+                    "id": 2,
+                    "name": "scale-strike",
+                    "version": "1.0",
+                    "title": "Scale Strike",
+                    "description": "Monitors a directory for incoming source files to ingest",
+                    "category": "system",
+                    "author_name": null,
+                    "author_url": null,
+                    "is_system": true,
+                    "is_long_running": true,
+                    "is_active": true,
+                    "is_operational": true,
+                    "is_paused": false,
+                    "icon_code": "f0e7"
+                },
+                "job_type_rev": {
+                    "id": 2
+                },
+                "event": {
+                    "id": 1
+                },
+                "status": "RUNNING",
+                "priority": 10,
+                "num_exes": 1
+            },
+            "dry_run_job": {},
+            "created": "2015-10-05T21:26:04.855Z",
+            "last_modified": "2015-10-05T21:26:04.855Z"
+        }
+    ]
+}

--- a/scale-ui/app/test/data/scans/scan1.json
+++ b/scale-ui/app/test/data/scans/scan1.json
@@ -1,0 +1,52 @@
+{
+    "id": 1,
+    "name": "scan1",
+    "title": "Scan 1",
+    "description": "First scan",
+    "file_count": 5,
+    "job": {
+        "id": 7,
+        "job_type": {
+            "id": 2,
+            "name": "scale-strike",
+            "version": "1.0",
+            "title": "Scale Strike",
+            "description": "Monitors a directory for incoming source files to ingest",
+            "category": "system",
+            "author_name": null,
+            "author_url": null,
+            "is_system": true,
+            "is_long_running": true,
+            "is_active": true,
+            "is_operational": true,
+            "is_paused": false,
+            "icon_code": "f0e7"
+        },
+        "job_type_rev": {
+            "id": 2
+        },
+        "event": {
+            "id": 1
+        },
+        "status": "RUNNING",
+        "priority": 10,
+        "num_exes": 1
+    },
+    "dry_run_job": {},
+    "created": "2015-10-05T21:26:04.876Z",
+    "last_modified": "2015-10-05T21:26:04.876Z",
+    "configuration": {
+        "version": "1.0",
+        "workspace": "rs",
+        "scanner": {
+            "type": "dir",
+            "transfer_suffix": "my-transfer-suffix"
+        },
+        "files_to_ingest": [{
+            "filename_regex": ".*txt",
+            "data_types": [],
+            "new_workspace": "",
+            "new_file_path": ""
+        }]
+    }
+}

--- a/scale-ui/app/test/data/scans/scan2.json
+++ b/scale-ui/app/test/data/scans/scan2.json
@@ -1,0 +1,51 @@
+{
+    "id": 2,
+    "name": "scan2",
+    "title": "Scan 2",
+    "description": "Second scan",
+    "file_count": 17,
+    "job": {
+        "id": 7,
+        "job_type": {
+            "id": 2,
+            "name": "scale-strike",
+            "version": "1.0",
+            "title": "Scale Strike",
+            "description": "Monitors a directory for incoming source files to ingest",
+            "category": "system",
+            "author_name": null,
+            "author_url": null,
+            "is_system": true,
+            "is_long_running": true,
+            "is_active": true,
+            "is_operational": true,
+            "is_paused": false,
+            "icon_code": "f0e7"
+        },
+        "job_type_rev": {
+            "id": 2
+        },
+        "event": {
+            "id": 1
+        },
+        "status": "RUNNING",
+        "priority": 10,
+        "num_exes": 1
+    },
+    "dry_run_job": {},
+    "created": "2015-10-05T21:26:04.855Z",
+    "last_modified": "2015-10-05T21:26:04.855Z",
+    "configuration": {
+        "version": "1.0",
+        "workspace": "products",
+        "scanner": {
+            "type": "s3"
+        },
+        "files_to_ingest": [{
+            "filename_regex": ".*txt",
+            "data_types": [],
+            "new_workspace": "",
+            "new_file_path": ""
+        }]
+    }
+}

--- a/scale-ui/app/test/scripts/backendStubs.js
+++ b/scale-ui/app/test/scripts/backendStubs.js
@@ -694,6 +694,60 @@
             return [200, JSON.stringify(returnStrike), {}];
         });
 
+        // Scan Details
+        var scanDetailsOverrideUrl = 'test/data/scans/scan1.json';
+        var scanDetailsRegex = new RegExp('^' + scaleConfig.urls.apiPrefix + 'scans/.*/', 'i');
+        $httpBackend.whenGET(scanDetailsRegex).respond(function (method, url) {
+            // get the scan.id from the url
+            url = url.toString();
+            var id = url.substring(url.substring(0,url.lastIndexOf('/')).lastIndexOf('/')+1,url.length-1);
+            scanDetailsOverrideUrl = 'test/data/scans/scan' + id + '.json';
+            var returnValue = getSync(scanDetailsOverrideUrl);
+            if (returnValue[0] !== 200) {
+                returnValue = localStorage.getItem('scan' + id);
+                return [200, JSON.parse(returnValue), {}];
+            } else {
+                return returnValue;
+            }
+        });
+
+        // Scans
+        var scansOverrideUrl = 'test/data/scans.json';
+        var scansRegex = new RegExp('^' + scaleConfig.urls.apiPrefix + 'scans/', 'i');
+        $httpBackend.whenGET(scansRegex).respond(function () {
+            return getSync(scansOverrideUrl);
+        });
+
+        // Save Scan
+        var getScanReturn = function (data, id) {
+            var scan = JSON.parse(data);
+
+            return {
+                id: id || Math.floor(Math.random() * (10000 - 5 + 1)) + 5,
+                name: scan.name,
+                title: scan.title,
+                description: scan.description,
+                file_count: Math.floor(Math.random() * (100 - 1 + 1)) + 1,
+                job: null,
+                dry_run_job: null,
+                created: new Date().toISOString(),
+                last_modified: new Date().toISOString(),
+                configuration: scan.configuration
+            };
+        };
+        var scanCreateRegex = new RegExp('^' + scaleConfig.urls.apiPrefix + 'scans/', 'i');
+        $httpBackend.whenPOST(scanCreateRegex).respond(function (method, url, data) {
+            var returnScan = getScanReturn(data);
+            return [200, JSON.stringify(returnScan), {}];
+        });
+        $httpBackend.whenPATCH(scanDetailsRegex).respond(function (method, url, data) {
+            // get the scan.id from the url
+            url = url.toString();
+            var id = url.substring(url.substring(0,url.lastIndexOf('/')).lastIndexOf('/')+1,url.length-1);
+            var returnScan = getScanReturn(data, id);
+            return [200, JSON.stringify(returnScan), {}];
+        });
+
         // Batch
         var batchesOverrideUrl = 'test/data/batch/batches.json';
         var batchesRegex = new RegExp('^' + scaleConfig.urls.apiPrefix + 'batches/', 'i');

--- a/scale-ui/config/scaleConfig.json
+++ b/scale-ui/config/scaleConfig.json
@@ -238,7 +238,8 @@
             "feed": [
                 { "path": "feed", "label": "Status" },
                 { "path": "feed/ingests", "label": "Ingest Records" },
-                { "path": "feed/strikes", "label": "Strikes" }
+                { "path": "feed/strikes", "label": "Strikes" },
+                { "path": "feed/scans", "label": "Scans" }
             ],
             "batch": [
                 { "path": "batch", "label": "Batches" },

--- a/scale-ui/config/scaleConfig.json
+++ b/scale-ui/config/scaleConfig.json
@@ -172,6 +172,7 @@
             }
         ],
         "strikeConfigurationVersion": "2.0",
+        "scanConfigurationVersion": "1.0",
         "nfsBrokerDescription": "The NFS broker mounts a remote network file system volume into the job’s container.",
         "hostBrokerDescription": "The host broker mounts a local directory from the host into the job’s container. This local directory should be a shared file system that has been mounted onto all hosts in the cluster. All hosts must have the same shared file system mounted at the same location for this broker to work properly.",
         "s3BrokerDescription": "The S3 broker mounts a remote Amazon S3 bucket or compatible object store.",


### PR DESCRIPTION
Closes #815.

There may yet be some changes that need to be made, since I wasn't entirely sure which fields were of interest to users both in the grid and detail views.  The "File Count" and "Job" values are null in the grid screenshots below because that's what's being returned by the API - probably because our Scale instance over here is pretty bare.  But that might be good to verify.

I also pulled in the reordering changes from #688 so this has the same functionality as strikes.

![image](https://cloud.githubusercontent.com/assets/15909071/25283887/4dcadcd2-2683-11e7-81a8-0b76425b4987.png)
![image](https://cloud.githubusercontent.com/assets/15909071/25283892/5272ee78-2683-11e7-985d-c6d7e1f8d8dc.png)
![image](https://cloud.githubusercontent.com/assets/15909071/25283894/56c2d7b8-2683-11e7-91cb-2129654ab244.png)
![image](https://cloud.githubusercontent.com/assets/15909071/25283903/5a83e220-2683-11e7-8708-14e6fd0d791e.png)
