### PR TITLE
#810 - Update dcos-vault to include proper health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ Scale runs across a cluster of networked machines (called nodes) that process th
 Apache Mesos, a free and open source project, for managing the available resources on the nodes. Mesos
 informs Scale of available computing resources and Scale schedules jobs to run on those resources.
 
-Ingest 
+Ingest
 ------
 Scale ingests source files using a Scale component called Strike. Strike is a process that monitors an
 ingest directory into which source data files are being copied. After a new source data file has been
 ingested, Scale produces and places jobs on the queue depending on the type of the ingested file.
 Many Strike processes can be run simultaneously, allowing Scale to monitor many different ingest directories.
 
-Jobs 
+Jobs
 ----
 Scale creates jobs based on its known job types. A job type defines key characteristics about an algorithm
 that Scale needs to know in order to run it (what command to run, the algorithm.s inputs and outputs, etc.)
@@ -32,7 +32,7 @@ they may be created manually by a user. Jobs that need to be executed are placed
 a queue before being scheduled onto an available node. When multiple jobs need to be run in a serial or parallel
 sequence, a recipe can be created that defines the job workflow.
 
-Products 
+Products
 --------
 Jobs can produce products as a result of their successful execution. Products may be disseminated to users
 or used to analyze and improve the algorithms that produced them. Scale allows the creation of different
@@ -71,8 +71,8 @@ Alternatively, your own local_settings.py can be volume mounted into `/opt/scale
 | SCALE_WEBSERVER_CPU         | 1                               | UI/API CPU allocation during bootstrap     |
 | SCALE_WEBSERVER_MEMORY      | 2048                            | UI/API memory allocation during bootstrap  |
 | SCALE_ZK_URL                | None                            | Scale master location                      |
-| SECRETS_TOKEN               | None                            | API endpoint for a secrets service         |
-| SECRETS_URL                 | None                            | Authentication token for secrets service   |
+| SECRETS_TOKEN               | None                            | Authentication token for secrets service   |
+| SECRETS_URL                 | None                            | API endpoint for a secrets service         |
 
 Quick Start
 ===========
@@ -132,4 +132,3 @@ All pull request contributions to this project will be released under the Apache
 source code previously released under an open source license and then modified by NGA staff is considered a "joint work"
 (see 17 USC § 101); it is partially copyrighted, partially public domain, and as a whole is protected by the copyrights
 of the non-government authors and must be released according to the terms of the original open source license.
-

--- a/dockerfiles/vault-dcos/Dockerfile
+++ b/dockerfiles/vault-dcos/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine
 ENV VAULT_VERSION 0.6.2
 
 ADD https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip vault.zip
-RUN apk add --update unzip openssl ca-certificates curl && \
+RUN apk add --update unzip openssl ca-certificates curl jq && \
     unzip vault.zip && \
     rm vault.zip && \
     cp vault /usr/bin && \

--- a/dockerfiles/vault-dcos/Dockerfile
+++ b/dockerfiles/vault-dcos/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine
 ENV VAULT_VERSION 0.6.2
 
 ADD https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip vault.zip
-RUN apk add --update unzip openssl ca-certificates && \
+RUN apk add --update unzip openssl ca-certificates curl && \
     unzip vault.zip && \
     rm vault.zip && \
     cp vault /usr/bin && \

--- a/dockerfiles/vault-dcos/Dockerfile
+++ b/dockerfiles/vault-dcos/Dockerfile
@@ -14,6 +14,7 @@ COPY run-vault /usr/bin/run-vault
 COPY config.hcl config.hcl
 
 RUN chmod +x /usr/bin/run-vault
+RUN sed -i 's/\r$//g' /usr/bin/run-vault
 
 ENTRYPOINT ["run-vault"]
 CMD ["server", "-config=config.hcl"]

--- a/dockerfiles/vault-dcos/Dockerfile
+++ b/dockerfiles/vault-dcos/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-ENV VAULT_VERSION 0.6.2
+ENV VAULT_VERSION 0.7.0
 
 ADD https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip vault.zip
 RUN apk add --update unzip openssl ca-certificates curl jq && \

--- a/dockerfiles/vault-dcos/Dockerfile
+++ b/dockerfiles/vault-dcos/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine
 ENV VAULT_VERSION 0.7.0
 
 ADD https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip vault.zip
-RUN apk add --update unzip openssl ca-certificates curl jq && \
+RUN apk add --update unzip openssl ca-certificates curl && \
     unzip vault.zip && \
     rm vault.zip && \
     cp vault /usr/bin && \

--- a/dockerfiles/vault-dcos/Readme.md
+++ b/dockerfiles/vault-dcos/Readme.md
@@ -8,7 +8,7 @@ This is an example of how to run [HashiCorp's Vault](https://github.com/hashicor
 Save the following JSON as `vault.json`:
 ```json
 {
-  "id": "vault",
+  "id": "scale-vault",
   "cpus": 1,
   "mem": 1000,
   "requirePorts":true,

--- a/dockerfiles/vault-dcos/Readme.md
+++ b/dockerfiles/vault-dcos/Readme.md
@@ -115,7 +115,18 @@ Key           	Value
 lease_duration	2592000
 value         	world
 ```
+
 For more examples, take a look at the [Vault getting started guide](https://vaultproject.io/intro/getting-started/install.html).
+
+### Reinitializing your Vault Server
+If you misplaced your unseal keys or you want to start with a fresh service you need to delete the `vault` tree in ZooKeeper. To interact with Zookeeper:
+-   Browse to `http://[DCOS_URL]/exhibitor`.
+-   Under the *Explorer* tab highlight `vault`.
+-   Select the *Modify* button at bottom of the page.
+-   Choose the *Delete* operation type, ensure the path is `/vault`, and fill out the tacking info.
+-   Select `Next...` and verify the operation.
+
+You will have to restart the Vault service in DC/OS to see the change with the client.  
 
 ## Next steps
 After you get Vault up and running, you may want to consider running multiple instances, and enabling discovery via [marathon-lb](https://github.com/mesosphere/marathon-lb).

--- a/dockerfiles/vault-dcos/Readme.md
+++ b/dockerfiles/vault-dcos/Readme.md
@@ -53,7 +53,7 @@ $ dcos marathon app add vault.json
 ### Step 2: Initialize the vault
 SSH into one of the DC/OS cluster nodes, and initialize the vault with the following:
 ```
-$ docker run -e "VAULT_SKIP_VERIFY=true" -e "VAULT_ADDR=https://vault.marathon.l4lb.thisdcos.directory:8200" --entrypoint=vault -t geoint/scale-vault init
+$ docker run -e "VAULT_SKIP_VERIFY=true" -e "VAULT_ADDR=https://scale-vault.marathon.l4lb.thisdcos.directory:8200" --entrypoint=vault -t geoint/scale-vault init
 Key 1: 62b6e5c157446c05c067bb41fadf931fd8f422f4af2a4c0ee056acbd5a89d3ed01
 Key 2: a065dbfd663c5a619bfdc74ebce68051f9e7004d19c67bc6726daf49e209d4ea02
 Key 3: 91e97d22436508a67905e535f636bb3e4550a8ad77b9f69da43717baa4012b5b03
@@ -71,7 +71,7 @@ your Vault will remain permanently sealed.
 ```
 After, check to make sure it was properly initialized:
 ```
-$ docker run -e "VAULT_SKIP_VERIFY=true" -e "VAULT_ADDR=https://vault.marathon.l4lb.thisdcos.directory:8200" --entrypoint=vault -t geoint/scale-vault status
+$ docker run -e "VAULT_SKIP_VERIFY=true" -e "VAULT_ADDR=https://scale-vault.marathon.l4lb.thisdcos.directory:8200" --entrypoint=vault -t geoint/scale-vault status
 Sealed: true
 Key Shares: 5
 Key Threshold: 3
@@ -83,7 +83,7 @@ High-Availability Enabled: true
 ### Step 3: Unseal your vault
 Repeat the following command 3 times, pasting a separate key each time:
 ```
-$ docker run -i -e "VAULT_SKIP_VERIFY=true" -e "VAULT_ADDR=https://vault.marathon.l4lb.thisdcos.directory:8200" --entrypoint=vault -t geoint/scale-vault unseal
+$ docker run -i -e "VAULT_SKIP_VERIFY=true" -e "VAULT_ADDR=https://scale-vault.marathon.l4lb.thisdcos.directory:8200" --entrypoint=vault -t geoint/scale-vault unseal
 Key (will be hidden):
 Sealed: true
 Key Shares: 5
@@ -96,7 +96,7 @@ Once it says `Sealed: false`, your vault is unsealed.
 ### Step 4: Start using your vault!
 Run an interactive shell to test your vault:
 ```
-$ docker run -i -e "VAULT_SKIP_VERIFY=true" -e "VAULT_ADDR=https://vault.marathon.l4lb.thisdcos.directory:8200" --entrypoint=/bin/sh -t geoint/scale-vault
+$ docker run -i -e "VAULT_SKIP_VERIFY=true" -e "VAULT_ADDR=https://scale-vault.marathon.l4lb.thisdcos.directory:8200" --entrypoint=/bin/sh -t geoint/scale-vault
 $ vault auth 11aaf733-f280-fbaf-251d-69b9606bf4fa # use root token from init
 Successfully authenticated!
 token: 11aaf733-f280-fbaf-251d-69b9606bf4fa

--- a/dockerfiles/vault-dcos/Readme.md
+++ b/dockerfiles/vault-dcos/Readme.md
@@ -30,13 +30,16 @@ Save the following JSON as `vault.json`:
     }
   },
   "healthChecks": [{
-      "protocol": "TCP",
-      "portIndex": 0,
+      "protocol": "COMMAND",
+      "command": {
+        "value": "curl -X GET -s -k https://localhost:8200/v1/sys/health/dev/null"
+      },
+      "gracePeriodSeconds": 20,
+      "intervalSeconds": 30,
       "timeoutSeconds": 10,
-      "gracePeriodSeconds": 10,
-      "intervalSeconds": 2,
-      "maxConsecutiveFailures": 10
-  }]
+      "maxConsecutiveFailures": 6,
+      "ignoreHttp1xx": false
+    }]
 }
 ```
 Now launch on Marathon:

--- a/dockerfiles/vault-dcos/Readme.md
+++ b/dockerfiles/vault-dcos/Readme.md
@@ -5,7 +5,7 @@ This is an example of how to run [HashiCorp's Vault](https://github.com/hashicor
 ## Running on DC/OS
 
 ### Step 1: Launch Vault server
-Save the following JSON as `vault.json`:
+Copy the following JSON:
 ```json
 {
   "id": "scale-vault",
@@ -32,7 +32,7 @@ Save the following JSON as `vault.json`:
   "healthChecks": [{
       "protocol": "COMMAND",
       "command": {
-        "value": "curl -X GET -s -k https://localhost:8200/v1/sys/health/dev/null"
+        "value": "curl -X GET -s -o /dev/null -k https://localhost:8200/v1/sys/health"
       },
       "gracePeriodSeconds": 20,
       "intervalSeconds": 30,
@@ -42,10 +42,7 @@ Save the following JSON as `vault.json`:
     }]
 }
 ```
-Now launch on Marathon:
-```
-$ dcos marathon app add vault.json
-```
+In the DC/OS interface go to **Services** > **Deploy Service** > *Check the JSON Mode toggle* > Paste in the configuration.
 
 **Note**: you may configure some parameters via environment variables, from the wrapper script [`run-vault`](run-vault). You may set the following environment variables:
  * VAULT_TLS_KEY: TLS key file contents
@@ -72,6 +69,7 @@ to unseal it again.
 Vault does not store the master key. Without at least 3 keys,
 your Vault will remain permanently sealed.
 ```
+
 After, check to make sure it was properly initialized:
 ```
 $ docker run -e "VAULT_SKIP_VERIFY=true" -e "VAULT_ADDR=https://scale-vault.marathon.l4lb.thisdcos.directory:8200" --entrypoint=vault -t geoint/scale-vault status

--- a/dockerfiles/vault-dcos/config.hcl
+++ b/dockerfiles/vault-dcos/config.hcl
@@ -7,7 +7,7 @@ listener "tcp" {
 backend "zookeeper" {
   address = "master.mesos:2181"
   path = "vault"
-  advertise_addr = "https://vault.marathon.l4lb.thisdcos.directory:8200"
+  advertise_addr = "https://scale-vault.marathon.l4lb.thisdcos.directory:8200"
 }
 
 disable_mlock = true


### PR DESCRIPTION
*  Corrected mistake in scale README.md in docker env_vars table
* Updated Vault version to recent stable release
* Updated vault-dcos README.md with:
    * Updated workflow to match DC/OS 1.8.8
    * Unified service name (scale-vaule) and references throughout
    * Transitioned heath check to COMMAND, using cURL
    * Added section about vault back end management with ZooKeeper. 
