### PR TITLE
Issue 825 - General health check failure

### DIFF
--- a/scale/scheduler/scale_scheduler.py
+++ b/scale/scheduler/scale_scheduler.py
@@ -340,9 +340,9 @@ class ScaleScheduler(MesosScheduler):
         node = node_mgr.get_node(agent_id)
 
         if node:
-            logger.error('Node lost on host %s', node.hostname)
+            logger.warning('Node lost on host %s', node.hostname)
         else:
-            logger.error('Node lost on agent %s', agent_id)
+            logger.warning('Node lost on agent %s', agent_id)
 
         node_mgr.lost_node(agent_id)
         offer_mgr.lost_node(agent_id)
@@ -380,9 +380,9 @@ class ScaleScheduler(MesosScheduler):
         node = node_mgr.get_node(agent_id)
 
         if node:
-            logger.error('Executor %s lost on host: %s', executorId.value, node.hostname)
+            logger.warning('Executor %s lost on host: %s', executorId.value, node.hostname)
         else:
-            logger.error('Executor %s lost on agent: %s', executorId.value, agent_id)
+            logger.warning('Executor %s lost on agent: %s', executorId.value, agent_id)
 
         duration = now() - started
         msg = 'Scheduler executorLost() took %.3f seconds'

--- a/scale/scheduler/test/node/test_node_class.py
+++ b/scale/scheduler/test/node/test_node_class.py
@@ -249,6 +249,10 @@ class TestNode(TestCase):
         self.task_mgr.handle_task_update(update)
         node.handle_task_update(update)
 
+        # Check node state
+        self.assertEqual(node._state, Node.DEGRADED)
+        self.assertTrue(NodeConditions.HEALTH_FAIL_ERR.name in node._conditions._active_errors)
+
         # No new health task right away
         tasks = node.get_next_tasks(when + datetime.timedelta(seconds=5))
         self.assertListEqual([], tasks)


### PR DESCRIPTION
Created a node error for a general health check error. Right now a node error is only applied if the exit code is parsed and matches a known exit code error condition.