### PR TITLE
RabbitMQ deploy

### DIFF
--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -74,7 +74,7 @@ def run(client):
         print("DB_PORT=%s" % db_port)
 
     if not len(SCALE_LOGGING_ADDRESS):
-        log_port = get_host_port_from_healthy_app(client, log_app_name, es_urls)
+        log_port = get_host_port_from_healthy_app(client, log_app_name, 0)
         print("LOGGING_ADDRESS=tcp://%s.marathon.mesos:%s" % (log_app_name, log_port))
         print("LOGGING_HEALTH_ADDRESS=%s.marathon.l4lb.thisdcos.directory:80" % log_app_name)
 
@@ -130,10 +130,10 @@ def check_app_exists(client, app_name):
         return False
 
 
-def get_host_port_from_healthy_app(client, app_name, port_idex):
+def get_host_port_from_healthy_app(client, app_name, port_index):
     wait_app_healthy(client, app_name)
 
-    return get_marathon_app_single_task_host_port(client, app_name, port_idex)
+    return get_marathon_app_single_task_host_port(client, app_name, port_index)
 
 
 def get_marathon_app_single_task_host_port(client, app_name, port_index):
@@ -291,11 +291,6 @@ def deploy_database(client, app_name):
         if CONFIG_URI:
             marathon['uris'].append(CONFIG_URI)
         deploy_marathon_app(client, marathon)
-        wait_app_healthy(client, app_name)
-
-    db_port = get_marathon_app_single_task_host_port(client, app_name, 0)
-
-    return db_port
 
 
 def get_elasticsearch_urls():
@@ -311,8 +306,8 @@ def deploy_rabbitmq(client, app_name):
         
         marathon = {
             "id": app_name,
-            "cpus": 0.1,
-            "mem": 128,
+            "cpus": 1,
+            "mem": 512,
             "disk": 0,
             "instances": 1,
             "container": {
@@ -439,11 +434,6 @@ def deploy_logstash(client, app_name, es_urls):
         marathon['uris'].append(CONFIG_URI)
 
     deploy_marathon_app(client, marathon)
-    wait_app_healthy(client, app_name)
-
-    logstash_port = get_marathon_app_single_task_host_port(client, app_name, 0)
-
-    return logstash_port
 
 
 if __name__ == '__main__':

--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -59,12 +59,10 @@ def run(client):
     if not len(SCALE_LOGGING_ADDRESS):
         deploy_logstash(client, log_app_name, es_urls)
 
-    ##########################################
-    # Wait for all needed apps to be healthy #
-    ##########################################
+    # Wait for all needed apps to be healthy
     if not len(broker_url):
         rabbitmq_port = get_host_port_from_healthy_app(client, rabbitmq_app_name, 0)
-        broker_url = 'amqp://guest:guest@%s:%s//' % (rabbitmq_app_name, rabbitmq_port)
+        broker_url = 'amqp://guest:guest@%s.marathon.mesos:%s//' % (rabbitmq_app_name, rabbitmq_port)
         print("BROKER_URL=%s" % broker_url)
 
     if not len(db_host):
@@ -318,8 +316,8 @@ def deploy_rabbitmq(client, app_name):
                     "portMappings": [
                         {
                             "containerPort": 5672,
+                            "hostPort": 5672,
                             "protocol": "tcp",
-                            "servicePort": 0,
                             "labels": {
                                 "VIP_0": "/%s:5672" % app_name
                             }

--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -40,23 +40,43 @@ def run(client):
         es_urls = get_elasticsearch_urls()
 
     print("ELASTICSEARCH_URLS=" + es_urls)
+    rabbitmq_app_name = '%s-rabbitmq' % FRAMEWORK_NAME
+    log_app_name = '%s-logstash' % FRAMEWORK_NAME
+    db_app_name = '%s-db' % FRAMEWORK_NAME
+
+    # Determine if rabbitmq should be deployed. If SCALE_BROKER_URL is unset we need to deploy it
+    broker_url = os.getenv('SCALE_BROKER_URL', '')
+    if not len(broker_url):
+        deploy_rabbitmq(client, rabbitmq_app_name)
 
     # Determine if db should be deployed.
     db_host = os.getenv('SCALE_DB_HOST', '')
     db_port = os.getenv('SCALE_DB_PORT', '')
     if not len(db_host):
-        app_name = '%s-db' % FRAMEWORK_NAME
-        db_port = deploy_database(client, app_name)
-        db_host = "%s.marathon.mesos" % app_name
-        print("DB_HOST=%s" % db_host)
-        print("DB_PORT=%s" % db_port)
+        deploy_database(client, db_app_name)
 
     # Determine if logstash should be deployed.
     if not len(SCALE_LOGGING_ADDRESS):
-        app_name = '%s-logstash' % FRAMEWORK_NAME
-        log_port = deploy_logstash(client, app_name, es_urls)
-        print("LOGGING_ADDRESS=tcp://%s.marathon.mesos:%s" % (app_name, log_port))
-        print("LOGGING_HEALTH_ADDRESS=%s.marathon.l4lb.thisdcos.directory:80" % app_name)
+        deploy_logstash(client, log_app_name, es_urls)
+
+    ##########################################
+    # Wait for all needed apps to be healthy #
+    ##########################################
+    if not len(broker_url):
+        rabbitmq_port = get_host_port_from_healthy_app(client, rabbitmq_app_name, 0)
+        broker_url = 'amqp://guest:guest@%s:%s//' % (rabbitmq_app_name, rabbitmq_port)
+        print("BROKER_URL=%s" % broker_url)
+
+    if not len(db_host):
+        db_port = get_host_port_from_healthy_app(client,db_app_name, 0)
+        db_host = "%s.marathon.mesos" % db_app_name
+        print("DB_HOST=%s" % db_host)
+        print("DB_PORT=%s" % db_port)
+
+    if not len(SCALE_LOGGING_ADDRESS):
+        log_port = get_host_port_from_healthy_app(client, log_app_name, es_urls)
+        print("LOGGING_ADDRESS=tcp://%s.marathon.mesos:%s" % (log_app_name, log_port))
+        print("LOGGING_HEALTH_ADDRESS=%s.marathon.l4lb.thisdcos.directory:80" % log_app_name)
 
     # Determine if Web Server should be deployed.
     if DEPLOY_WEBSERVER.lower() == 'true':
@@ -108,6 +128,12 @@ def check_app_exists(client, app_name):
         return True
     except NotFoundError:
         return False
+
+
+def get_host_port_from_healthy_app(client, app_name, port_idex):
+    wait_app_healthy(client, app_name)
+
+    return get_marathon_app_single_task_host_port(client, app_name, port_idex)
 
 
 def get_marathon_app_single_task_host_port(client, app_name, port_index):
@@ -260,6 +286,7 @@ def deploy_database(client, app_name):
             ],
             'uris': []
         }
+
         CONFIG_URI = os.getenv('CONFIG_URI')
         if CONFIG_URI:
             marathon['uris'].append(CONFIG_URI)
@@ -277,6 +304,71 @@ def get_elasticsearch_urls():
     es_urls = ','.join(endpoints)
     return es_urls
 
+def deploy_rabbitmq(client, app_name):
+    # Check if scale-db is already running
+    if not check_app_exists(client, app_name):
+        rabbitmq_image = os.getenv('RABBITMQ_DOCKER_IMAGE', 'rabbitmq:3.6-management')
+        
+        marathon = {
+            "id": app_name,
+            "cpus": 0.1,
+            "mem": 128,
+            "disk": 0,
+            "instances": 1,
+            "container": {
+                "docker": {
+                    "image": rabbitmq_image,
+                    "forcePullImage": True,
+                    "privileged": False,
+                    "portMappings": [
+                        {
+                            "containerPort": 5672,
+                            "protocol": "tcp",
+                            "servicePort": 0,
+                            "labels": {
+                                "VIP_0": "/%s:5672" % app_name
+                            }
+                        },
+                        {
+                            "containerPort": 15672,
+                            "protocol": "tcp",
+                            "servicePort": 0,
+                            "labels": {
+                                "VIP_1": "/%s:15672" % app_name
+                            }
+                        }
+                    ],
+                    "network": "BRIDGE"
+                }
+            },
+            "healthChecks": [
+                {
+                    "protocol": "TCP",
+                    "gracePeriodSeconds": 300,
+                    "intervalSeconds": 60,
+                    "timeoutSeconds": 20,
+                    "maxConsecutiveFailures": 3,
+                    "portIndex": 0
+                },
+                {
+                    "protocol": "TCP",
+                    "gracePeriodSeconds": 300,
+                    "intervalSeconds": 60,
+                    "timeoutSeconds": 20,
+                    "maxConsecutiveFailures": 3,
+                    "portIndex": 1
+                }
+            ],
+            'uris': []
+        }
+
+
+        # Support uri passing for protected Docker Registries
+        CONFIG_URI = os.getenv('CONFIG_URI')
+        if CONFIG_URI:
+            marathon['uris'].append(CONFIG_URI)
+
+        deploy_marathon_app(client, marathon)
 
 def deploy_logstash(client, app_name, es_urls):
     # attempt to delete an old instance..if it doesn't exists it will error but we don't care so we ignore it


### PR DESCRIPTION
Deployment of the RabbitMQ service into Marathon via the Scale bootstrap. This will only be deployed when the `SCALE_BROKER_URL` environment variable is _unset_. This behavior mirrors that of the database and logstash deploys. The RabbitMQ Marathon app is also treated exactly like the Postgres app as it is a persistent store of data.

I also reworked how the apps are launched to parallelize the deployment of all apps that are independent of each other (scale-db, scale-rabbitmq, scale-logstash). The only app blocking during the deployment process is the webserver as it needs to know the ports / addresses of the other running services. This should reduce the start up time to roughly 1/3rd of that previously experienced.