### PR TITLE
Broker URL passthrough and developer bootstrap

### DIFF
--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -191,7 +191,6 @@ def deploy_webserver(client, app_name, es_urls, db_host, db_port):
             "SCALE_ELASTICSEARCH_URLS": es_urls
         },
         'labels': {
-            "DCOS_PACKAGE_FRAMEWORK_NAME": FRAMEWORK_NAME,
             "HAPROXY_GROUP": "internal,external",
             "DCOS_SERVICE_SCHEME": "http",
             "DCOS_SERVICE_NAME": FRAMEWORK_NAME,

--- a/scale/environment/cent7-init.sh
+++ b/scale/environment/cent7-init.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export SCALE_DB_PORT=55432
+export SCALE_MESSAGE_PORT=55672
 export SCALE_DB_PASS=scale-postgres
 
 # Launch a database for Scale testing
@@ -10,6 +11,9 @@ docker run -d --restart=always -p ${SCALE_DB_PORT}:5432 --name scale-postgis \
     -e POSTGRES_PASSWORD=${SCALE_DB_PASS} mdillon/postgis:9.4-alpine
 echo Giving Postgres a moment to start up before initializing...
 sleep 10
+
+docker run -d --restart=always -p ${SCALE_MESSAGE_PORT}:5672 --name scale-rabbitmq \
+    rabbitmq:3.6-management
 
 # Configure database
 cat << EOF > database-commands.sql
@@ -30,6 +34,8 @@ pip install -U virtualenv pip
 
 cp scale/local_settings_dev.py scale/local_settings.py
 cat << EOF >> scale/local_settings.py
+BROKER_URL = 'amqp://guest:guest@localhost:${SCALE_MESSAGE_PORT}//'
+
 POSTGIS_TEMPLATE = 'template_postgis'
 
 # Example settings for using PostgreSQL database with PostGIS.

--- a/scale/environment/cloud-init.sh
+++ b/scale/environment/cloud-init.sh
@@ -9,6 +9,12 @@ wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key a
 apt-get install -y --force-yes  postgresql-9.4 postgresql-contrib-9.4 postgresql-9.4-postgis-2.3
 sed 's^local   all             all                                     peer^local   all             all                                     trust^g' -i /etc/postgresql/9.4/main/pg_hba.conf
 service postgresql start
+update-rc.d postgresql enable
+
+# Install RabbitMQ as broker for messaging
+apt-get install -y rabbitmq-server
+service rabbitmq-server start
+update-rc.d rabbitmq-server enable
 
 # Install all python dependencies (gotta pin setuptools due to errors during pycparser install)
 apt-get install -y build-essential libssl-dev libffi-dev python-dev

--- a/scale/environment/mac-init.sh
+++ b/scale/environment/mac-init.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export SCALE_DB_PORT=55432
+export SCALE_MESSAGE_PORT=55672
 export SCALE_DB_PASS=scale-postgres
 
 # Launch a database for Scale testing
@@ -8,6 +9,9 @@ docker run -d --restart=always -p ${SCALE_DB_PORT}:5432 --name scale-postgis \
     -e POSTGRES_PASSWORD=${SCALE_DB_PASS} mdillon/postgis:9.4-alpine
 echo Giving Postgres a moment to start up before initializing...
 sleep 10
+
+docker run -d --restart=always -p ${SCALE_MESSAGE_PORT}:5672 --name scale-rabbitmq \
+    rabbitmq:3.6-management
 
 # Configure database
 cat << EOF > database-commands.sql
@@ -25,6 +29,8 @@ brew install libgeoip
 
 cp scale/local_settings_dev.py scale/local_settings.py
 cat << EOF >> scale/local_settings.py
+BROKER_URL = 'amqp://guest:guest@localhost:${SCALE_MESSAGE_PORT}//'
+
 POSTGIS_TEMPLATE = 'template_postgis'
 
 # Example settings for using PostgreSQL database with PostGIS.

--- a/scale/environment/win-init.bat
+++ b/scale/environment/win-init.bat
@@ -1,8 +1,12 @@
 set SCALE_DB_PORT=55432
+set SCALE_MESSAGE_PORT=55672
 set SCALE_DB_PASS=scale-postgres
 
 REM Launch a database for Scale testing
 docker run -d --restart=always -p %SCALE_DB_PORT%:5432 --name scale-postgis -e POSTGRES_PASSWORD=%SCALE_DB_PASS% mdillon/postgis:9.4-alpine
+
+REM Launch a message broker for Scale testing
+docker run -d --restart=always -p %SCALE_MESSAGE_PORT%:5672 --name scale-rabbitmq rabbitmq:3.6-management
 
 REM Configure database
 echo "Giving Postgres a moment to start up before initializing..."
@@ -16,6 +20,7 @@ docker exec -it scale-postgis psql -U scale -c "CREATE EXTENSION postgis;" scale
 
 copy scale\local_settings_dev.py scale\local_settings.py
 REM Set default connection string for database
+echo BROKER_URL = 'amqp://guest:guest@localhost:%SCALE_MESSAGE_PORT%//' >> scale\local_settings.py
 echo POSTGIS_TEMPLATE = 'template_postgis' >> scale\local_settings.py
 echo. >> scale\local_settings.py
 echo DATABASES = { >> scale\local_settings.py

--- a/scale/scale/local_settings_dev.py
+++ b/scale/scale/local_settings_dev.py
@@ -27,6 +27,9 @@ TIME_ZONE = 'UTC'
 # you can avoid needing to run the unit tests as a PostgreSQL superuser.
 POSTGIS_TEMPLATE = 'template1'
 
+# Broker URL for connection to messaging backend
+BROKER_URL = 'amqp://guest:guest@localhost:5672//'
+
 # Example settings for using PostgreSQL database with PostGIS.
 DATABASES = {
     'default': {

--- a/scale/scale/local_settings_docker.py
+++ b/scale/scale/local_settings_docker.py
@@ -38,6 +38,9 @@ if ELASTICSEARCH_URLS:
         sniffer_timeout=60
     )
 
+# Broker URL for connection to messaging backend. Bootstrap must populate.
+BROKER_URL = os.environ.get('SCALE_BROKER_URL', '')
+
 DB_HOST = os.environ.get('SCALE_DB_HOST', '')
 if DB_HOST == '':
         DB_HOST = os.environ.get('DB_PORT_5432_TCP_ADDR', '')

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -46,6 +46,9 @@ ELASTICSEARCH_URLS = None
 # Placeholder for Elasticsearch object. Needed for unit tests.
 ELASTICSEARCH = None
 
+# Broker URL for connection to messaging backend
+BROKER_URL = None
+
 # Base URL of vault or DCOS secrets store, or None to disable secrets
 SECRETS_URL = None
 # Public token if DCOS secrets store, or privleged token for vault


### PR DESCRIPTION
Added passthrough of SCALE_BROKER_URL from bootstrap into the Scale application. This is used internally to the messaging components. 

Also updated the developer bootsrap scripts for all environments to configure RabbitMQ for local and cloud IDE development.