### PR TITLE
Issue 880 - Pull task for job executions

### DIFF
--- a/scale/job/execution/job_exe.py
+++ b/scale/job/execution/job_exe.py
@@ -11,6 +11,7 @@ from error.models import Error
 from job.execution.tasks.job_task import JobTask
 from job.execution.tasks.post_task import PostTask
 from job.execution.tasks.pre_task import PreTask
+from job.execution.tasks.pull_task import PullTask
 from job.models import JobExecution
 from job.tasks.update import TaskStatusUpdate
 from util.retry import retry_database_query
@@ -50,6 +51,7 @@ class RunningJobExecution(object):
 
         # Create tasks
         if not job_exe.is_system:
+            self._all_tasks.append(PullTask(job_exe))
             self._all_tasks.append(PreTask(job_exe))
         self._all_tasks.append(JobTask(job_exe))
         if not job_exe.is_system:

--- a/scale/job/execution/tasks/cleanup_task.py
+++ b/scale/job/execution/tasks/cleanup_task.py
@@ -35,7 +35,6 @@ class CleanupTask(Task):
 
         self._uses_docker = False
         self._docker_image = None
-        self._force_docker_pull = False
         self._docker_params = []
         self._is_docker_privileged = False
         self._running_timeout_threshold = datetime.timedelta(minutes=10)

--- a/scale/job/execution/tasks/exe_task.py
+++ b/scale/job/execution/tasks/exe_task.py
@@ -86,7 +86,6 @@ class JobExecutionTask(Task):
 
         raise NotImplementedError()
 
-    @abstractmethod
     def populate_job_exe_model(self, job_exe):
         """Populates the job execution model with the relevant information from this task
 
@@ -94,7 +93,7 @@ class JobExecutionTask(Task):
         :type job_exe: :class:`job.models.JobExecution`
         """
 
-        raise NotImplementedError()
+        pass
 
     def refresh_cached_values(self, job_exe):
         """Refreshes the task's cached job execution values with the given model

--- a/scale/job/execution/tasks/job_task.py
+++ b/scale/job/execution/tasks/job_task.py
@@ -32,7 +32,6 @@ class JobTask(JobExecutionTask):
                 self._docker_image = self._create_scale_image_name()
             else:
                 self._docker_image = job_exe.get_docker_image()
-            self._force_docker_pull = not self._is_system  # Force pull non-system jobs
             self._docker_params = job_exe.get_execution_configuration().get_job_task_docker_params()
             self._is_docker_privileged = job_exe.is_docker_privileged()
         self._command = job_exe.get_job_interface().get_command()

--- a/scale/job/execution/tasks/post_task.py
+++ b/scale/job/execution/tasks/post_task.py
@@ -23,7 +23,6 @@ class PostTask(JobExecutionTask):
 
         self._uses_docker = True
         self._docker_image = self._create_scale_image_name()
-        self._force_docker_pull = False
         self._docker_params = job_exe.get_execution_configuration().get_post_task_docker_params()
         self._is_docker_privileged = False
         self._command_arguments = 'scale_post_steps -i %i' % job_exe.id

--- a/scale/job/execution/tasks/pre_task.py
+++ b/scale/job/execution/tasks/pre_task.py
@@ -23,7 +23,6 @@ class PreTask(JobExecutionTask):
 
         self._uses_docker = True
         self._docker_image = self._create_scale_image_name()
-        self._force_docker_pull = False
         self._docker_params = job_exe.get_execution_configuration().get_pre_task_docker_params()
         self._is_docker_privileged = False
         self._command_arguments = 'scale_pre_steps -i %i' % job_exe.id

--- a/scale/job/execution/tasks/pull_task.py
+++ b/scale/job/execution/tasks/pull_task.py
@@ -24,7 +24,6 @@ class PullTask(JobExecutionTask):
 
         self._uses_docker = False
         self._docker_image = None
-        self._force_docker_pull = False
         self._docker_params = []
         self._is_docker_privileged = False
         self._running_timeout_threshold = datetime.timedelta(minutes=15)

--- a/scale/job/execution/tasks/pull_task.py
+++ b/scale/job/execution/tasks/pull_task.py
@@ -1,0 +1,52 @@
+"""Defines the class for a job execution pull-task"""
+from __future__ import unicode_literals
+
+import datetime
+
+from error.models import Error
+from job.execution.tasks.exe_task import JobExecutionTask
+from job.tasks.pull_task import create_pull_command
+from node.resources.node_resources import NodeResources
+from node.resources.resource import Cpus, Mem
+
+
+class PullTask(JobExecutionTask):
+    """Represents a job execution pull-task. This class is thread-safe.
+    """
+
+    def __init__(self, job_exe):
+        """Constructor
+
+        :param job_exe: The job execution, which must be in RUNNING status and have its related node, job, and job_type
+        models populated
+        :type job_exe: :class:`job.models.JobExecution`
+        """
+
+        super(PullTask, self).__init__(job_exe.get_pre_task_id(), job_exe)
+
+        self._uses_docker = False
+        self._docker_image = None
+        self._force_docker_pull = False
+        self._docker_params = []
+        self._is_docker_privileged = False
+        self._running_timeout_threshold = datetime.timedelta(minutes=15)
+        self._staging_timeout_threshold = datetime.timedelta(minutes=2)
+
+        self.timeout_error_name = 'pull-timeout'
+        self._command = create_pull_command(job_exe.get_docker_image())
+
+    def determine_error(self, task_update):
+        """See :meth:`job.execution.tasks.exe_task.JobExecutionTask.determine_error`
+        """
+
+        with self._lock:
+            if self._task_id != task_update.task_id:
+                return None
+
+            return Error.objects.get_builtin_error('pull')
+
+    def get_resources(self):
+        """See :meth:`job.tasks.base_task.Task.get_resources`
+        """
+
+        return NodeResources([Cpus(0.1), Mem(32.0)])

--- a/scale/job/execution/tasks/pull_task.py
+++ b/scale/job/execution/tasks/pull_task.py
@@ -20,7 +20,7 @@ class PullTask(JobExecutionTask):
         :type job_exe: :class:`job.models.JobExecution`
         """
 
-        super(PullTask, self).__init__(job_exe.get_pre_task_id(), job_exe)
+        super(PullTask, self).__init__(job_exe.get_pull_task_id(), job_exe)
 
         self._uses_docker = False
         self._docker_image = None

--- a/scale/job/execution/tasks/pull_task.py
+++ b/scale/job/execution/tasks/pull_task.py
@@ -6,8 +6,6 @@ import datetime
 from error.models import Error
 from job.execution.tasks.exe_task import JobExecutionTask
 from job.tasks.pull_task import create_pull_command
-from node.resources.node_resources import NodeResources
-from node.resources.resource import Cpus, Mem
 
 
 class PullTask(JobExecutionTask):
@@ -49,4 +47,4 @@ class PullTask(JobExecutionTask):
         """See :meth:`job.tasks.base_task.Task.get_resources`
         """
 
-        return NodeResources([Cpus(0.1), Mem(32.0)])
+        return self._resources

--- a/scale/job/fixtures/basic_job_errors.json
+++ b/scale/job/fixtures/basic_job_errors.json
@@ -73,6 +73,20 @@
         "model": "error.Error",
         "pk": null,
         "fields": {
+            "name": "pull-timeout",
+            "title": "Pull-task Timeout",
+            "description": "The pull-task did not finish within a reasonable amount of time. This is likely due to excessive time downloading the algorithm's Docker image.",
+            "category": "SYSTEM",
+            "is_builtin": true,
+            "should_be_retried": false,
+            "created": "2017-06-19T00:00:00.0Z",
+            "last_modified": "2017-06-19T00:00:00.0Z"
+        }
+    },
+    {
+        "model": "error.Error",
+        "pk": null,
+        "fields": {
             "name": "pre-timeout",
             "title": "Pre-task Timeout",
             "description": "The pre-task did not finish within a reasonable amount of time. This is likely due to excessive time downloading the algorithm's input data from their workspace(s).",
@@ -123,6 +137,20 @@
             "should_be_retried": false,
             "created": "2015-03-11T00:00:00.0Z",
             "last_modified": "2015-03-11T00:00:00.0Z"
+        }
+    },
+    {
+        "model": "error.Error",
+        "pk": null,
+        "fields": {
+            "name": "pull",
+            "title": "Docker Pull Failed",
+            "description": "Scale was unable to pull the algorithm's Docker image. Please ensure the image name is correct and the Docker registry is available.",
+            "category": "SYSTEM",
+            "is_builtin": true,
+            "should_be_retried": false,
+            "created": "2017-06-19T00:00:00.0Z",
+            "last_modified": "2017-06-19T00:00:00.0Z"
         }
     },
     {

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1647,6 +1647,21 @@ class JobExecution(models.Model):
 
         return '%s_pre' % self.get_cluster_id()
 
+    def get_pull_task_id(self):
+        """Gets the pull-task ID for this job execution. This call is only valid after the job execution has been
+        scheduled (is no longer queued) and if this is not a system job type.
+
+        :returns: The pull-task ID for the job execution
+        :rtype: string
+
+        :raises :class:`util.exceptions.ScaleLogicBug`: If the job execution is still queued or is a system job type
+        """
+
+        if self.is_system:
+            raise ScaleLogicBug('System jobs do not have a pull-task')
+
+        return '%s_pull' % self.get_cluster_id()
+
     def get_resources(self):
         """Returns the resources allocated to this job execution
 

--- a/scale/job/tasks/base_task.py
+++ b/scale/job/tasks/base_task.py
@@ -85,7 +85,6 @@ class Task(object):
         # These values will vary by different task subclasses
         self._uses_docker = False
         self._docker_image = None
-        self._force_docker_pull = False
         self._docker_params = []
         self._is_docker_privileged = False
         self._command = 'echo "Hello Scale"'
@@ -152,16 +151,6 @@ class Task(object):
         """
 
         return self._docker_params
-
-    @property
-    def force_docker_pull(self):
-        """Indicates if a force pull of the Docker image should be done
-
-        :returns: True if force pull should be used, False otherwise
-        :rtype: bool
-        """
-
-        return self._force_docker_pull
 
     @property
     def has_been_launched(self):

--- a/scale/job/tasks/health_task.py
+++ b/scale/job/tasks/health_task.py
@@ -36,7 +36,6 @@ class HealthTask(Task):
 
         self._uses_docker = False
         self._docker_image = None
-        self._force_docker_pull = False
         self._docker_params = []
         self._is_docker_privileged = False
         self._running_timeout_threshold = datetime.timedelta(minutes=15)

--- a/scale/job/tasks/manager.py
+++ b/scale/job/tasks/manager.py
@@ -30,6 +30,18 @@ class TaskManager(object):
         with self._lock:
             return list(self._tasks.values())
 
+    def get_task(self, task_id):
+        """Returns the task with the given ID, possibly None
+
+        :param task_id: The task ID
+        :type task_id: int
+        :returns: The task with the given ID
+        :rtype: :class:`job.tasks.base_task.Task`
+        """
+
+        with self._lock:
+            return self._tasks[task_id] if task_id in self._tasks else None
+
     def get_tasks_to_reconcile(self, when):
         """Returns all of the tasks that need to be reconciled
 

--- a/scale/job/tasks/pull_task.py
+++ b/scale/job/tasks/pull_task.py
@@ -54,7 +54,6 @@ class PullTask(Task):
 
         self._uses_docker = False
         self._docker_image = None
-        self._force_docker_pull = False
         self._docker_params = []
         self._is_docker_privileged = False
         self._running_timeout_threshold = datetime.timedelta(minutes=15)

--- a/scale/job/tasks/pull_task.py
+++ b/scale/job/tasks/pull_task.py
@@ -42,7 +42,7 @@ def create_pull_command(image_name, check_exists=False):
     if check_exists and not image_name.endswith(':latest'):
         exists_echo_cmd = 'echo \'Checking if image is already pulled...\''
         image_search_cmd = 'docker images --format \'{{.Repository}}:{{.Tag}}\' | grep %s' % image_name
-        exists_cmd = '%s; if [[ $? = 0 ]]; then echo \'Image already pulled\'; exit 0; fi;' % image_search_cmd
+        exists_cmd = '`%s; if [[ $? = 0 ]]; then echo \'Image already pulled\'; exit 0; fi;`' % image_search_cmd
         command = '%s && %s && %s' % (exists_echo_cmd, exists_cmd, command)
 
     return command

--- a/scale/job/tasks/pull_task.py
+++ b/scale/job/tasks/pull_task.py
@@ -42,7 +42,7 @@ def create_pull_command(image_name, check_exists=False):
     if check_exists and not image_name.endswith(':latest'):
         exists_echo_cmd = 'echo \'Checking if image is already pulled...\''
         image_search_cmd = 'docker images --format \'{{.Repository}}:{{.Tag}}\' | grep %s' % image_name
-        exists_cmd = '`%s; if [[ $? = 0 ]]; then echo \'Image already pulled\'; exit 0; fi;`' % image_search_cmd
+        exists_cmd = '(%s; if [[ $? = 0 ]]; then echo \'Image already pulled\'; exit 0; fi;)' % image_search_cmd
         command = '%s && %s && %s' % (exists_echo_cmd, exists_cmd, command)
 
     return command

--- a/scale/job/tasks/pull_task.py
+++ b/scale/job/tasks/pull_task.py
@@ -42,8 +42,8 @@ def create_pull_command(image_name, check_exists=False):
     if check_exists and not image_name.endswith(':latest'):
         exists_echo_cmd = 'echo \'Checking if image is already pulled...\''
         image_search_cmd = 'docker images --format \'{{.Repository}}:{{.Tag}}\' | grep %s' % image_name
-        exists_cmd = '(%s; if [[ $? = 0 ]]; then echo \'Image already pulled\'; exit 1; fi;)' % image_search_cmd
-        command = '%s && %s && %s' % (exists_echo_cmd, exists_cmd, command)
+        exists_cmd = '(%s; if [[ $? = 0 ]]; then echo \'Image already pulled\'; else exit 1; fi;)' % image_search_cmd
+        command = '%s && %s || %s' % (exists_echo_cmd, exists_cmd, command)
 
     return command
 

--- a/scale/job/tasks/pull_task.py
+++ b/scale/job/tasks/pull_task.py
@@ -42,7 +42,7 @@ def create_pull_command(image_name, check_exists=False):
     if check_exists and not image_name.endswith(':latest'):
         exists_echo_cmd = 'echo \'Checking if image is already pulled...\''
         image_search_cmd = 'docker images --format \'{{.Repository}}:{{.Tag}}\' | grep %s' % image_name
-        exists_cmd = '(%s; if [[ $? = 0 ]]; then echo \'Image already pulled\'; exit 0; fi;)' % image_search_cmd
+        exists_cmd = '(%s; if [[ $? = 0 ]]; then echo \'Image already pulled\'; exit 1; fi;)' % image_search_cmd
         command = '%s && %s && %s' % (exists_echo_cmd, exists_cmd, command)
 
     return command

--- a/scale/job/tasks/pull_task.py
+++ b/scale/job/tasks/pull_task.py
@@ -14,24 +14,36 @@ PULL_TASK_ID_PREFIX = 'scale_pull'
 COUNTER = AtomicCounter()
 
 
-def create_pull_command(image_name):
+def create_pull_command(image_name, check_exists=False):
     """Creates the Docker pull command to pull the given image name
 
     :param image_name: The name of the Docker image to pull
     :type image_name: string
+    :param check_exists: If True, skips pull if image already exists, False pulls image regardless
+    :type check_exists: bool
     :returns: The Docker pull command
     :rtype: string
     """
 
     # Create command that pulls image and deletes any dangling images
+    pull_echo_cmd = 'echo \'Pulling image...\''
     pull_cmd = 'docker pull %s' % image_name
+    delete_echo_cmd = 'echo \'Cleaning up dangling images...\''
     delete_cmd = 'for img in `docker images -q -f dangling=true`; do docker rmi $img; done'
-    command = '%s && %s' % (pull_cmd, delete_cmd)
+    command = '%s && %s && %s && %s' % (pull_echo_cmd, pull_cmd, delete_echo_cmd, delete_cmd)
 
     # Setting DOCKER_CONFIG env var is needed if CONFIG_URI is set for custom Docker configuration
     if settings.CONFIG_URI:
+        export_echo_cmd = 'echo \'Setting Docker configuration\''
         export_cmd = 'export DOCKER_CONFIG=`pwd`/.docker'
-        command = '%s && %s' % (export_cmd, command)
+        command = '%s && %s && %s' % (export_echo_cmd, export_cmd, command)
+
+    # If check_exists and the image does not have a "latest" tag, check for image locally before pulling
+    if check_exists and not image_name.endswith(':latest'):
+        exists_echo_cmd = 'echo \'Checking if image is already pulled...\''
+        image_search_cmd = 'docker images --format \'{{.Repository}}:{{.Tag}}\' | grep %s' % image_name
+        exists_cmd = '%s; if [[ $? = 0 ]]; then echo \'Image already pulled\'; exit 0; fi;' % image_search_cmd
+        command = '%s && %s && %s' % (exists_echo_cmd, exists_cmd, command)
 
     return command
 
@@ -58,7 +70,7 @@ class PullTask(Task):
         self._is_docker_privileged = False
         self._running_timeout_threshold = datetime.timedelta(minutes=15)
 
-        self._command = create_pull_command(self._create_scale_image_name())
+        self._command = create_pull_command(self._create_scale_image_name(), check_exists=True)
 
     def get_resources(self):
         """See :meth:`job.tasks.base_task.Task.get_resources`

--- a/scale/job/tasks/pull_task.py
+++ b/scale/job/tasks/pull_task.py
@@ -14,28 +14,43 @@ PULL_TASK_ID_PREFIX = 'scale_pull'
 COUNTER = AtomicCounter()
 
 
+def create_pull_command(image_name):
+    """Creates the Docker pull command to pull the given image name
+
+    :param image_name: The name of the Docker image to pull
+    :type image_name: string
+    :returns: The Docker pull command
+    :rtype: string
+    """
+
+    # Create command that pulls image and deletes any dangling images
+    pull_cmd = 'docker pull %s' % image_name
+    delete_cmd = 'for img in `docker images -q -f dangling=true`; do docker rmi $img; done'
+    command = '%s && %s' % (pull_cmd, delete_cmd)
+
+    # Setting DOCKER_CONFIG env var is needed if CONFIG_URI is set for custom Docker configuration
+    if settings.CONFIG_URI:
+        export_cmd = 'export DOCKER_CONFIG=`pwd`/.docker'
+        command = '%s && %s' % (export_cmd, command)
+
+    return command
+
+
 class PullTask(Task):
     """Represents a task that pulls Docker images from the registry. This class is thread-safe.
     """
 
-    def __init__(self, framework_id, agent_id, image_name=None):
+    def __init__(self, framework_id, agent_id):
         """Constructor
 
         :param framework_id: The framework ID
         :type framework_id: string
         :param agent_id: The agent ID
         :type agent_id: string
-        :param image_name: The name of the Docker image to pull. If None, pulls the Scale Docker image
-        :type image_name: string
         """
 
         task_id = '%s_%s_%d' % (PULL_TASK_ID_PREFIX, framework_id, COUNTER.get_next())
         super(PullTask, self).__init__(task_id, 'Scale Docker Pull', agent_id)
-
-        if image_name:
-            self.image_name = image_name
-        else:
-            self.image_name = self._create_scale_image_name()
 
         self._uses_docker = False
         self._docker_image = None
@@ -45,15 +60,7 @@ class PullTask(Task):
         self._running_timeout_threshold = datetime.timedelta(minutes=15)
         self._staging_timeout_threshold = datetime.timedelta(minutes=2)
 
-        # Create command that pulls image and deletes any dangling images
-        pull_cmd = 'docker pull %s' % self.image_name
-        delete_cmd = 'for img in `docker images -q -f dangling=true`; do docker rmi $img; done'
-        self._command = '%s && %s' % (pull_cmd, delete_cmd)
-
-        # Setting DOCKER_CONFIG env var is needed if CONFIG_URI is set for custom Docker configuration
-        if settings.CONFIG_URI:
-            export_cmd = 'export DOCKER_CONFIG=`pwd`/.docker'
-            self._command = '%s && %s' % (export_cmd, self._command)
+        self._command = create_pull_command(self._create_scale_image_name())
 
     def get_resources(self):
         """See :meth:`job.tasks.base_task.Task.get_resources`

--- a/scale/mesos_api/tasks.py
+++ b/scale/mesos_api/tasks.py
@@ -100,6 +100,6 @@ def _create_docker_task(task):
         mesos_task.command.arguments.append(argument)
 
     mesos_task.container.docker.network = mesos_pb2.ContainerInfo.DockerInfo.Network.Value('BRIDGE')
-    mesos_task.container.docker.force_pull_image = task.force_docker_pull
+    mesos_task.container.docker.force_pull_image = False
 
     return mesos_task

--- a/scale/mesos_api/tasks.py
+++ b/scale/mesos_api/tasks.py
@@ -87,14 +87,9 @@ def _create_docker_task(task):
     if task.is_docker_privileged:
         mesos_task.container.docker.privileged = True
 
-    # TODO: Determine whether or not there is an entry point within
-    # the docker image in order to pass in the docker container
-    # command arguments correctly.
-    # Right now we assume an entry point
+    # Use Docker image entrypoint
     mesos_task.command.shell = False
 
-    # parse through the docker arguments and add them
-    # to the CommandInfo 'arguments' list
     arguments = task.command_arguments.split(" ")
     for argument in arguments:
         mesos_task.command.arguments.append(argument)

--- a/scale/scheduler/recon/manager.py
+++ b/scale/scheduler/recon/manager.py
@@ -1,26 +1,34 @@
-"""Defines the class that manages pushing task status updates to the database"""
+"""Defines the class that manages reconciling tasks"""
 from __future__ import unicode_literals
 
+import datetime
 import logging
 import threading
 
+from django.utils.timezone import now
 from mesos.interface import mesos_pb2
 
+COUNT_WARNING_THRESHOLD = 1000  # If the total list count hits this threshold, log a warning
+FULL_RECON_THRESHOLD = datetime.timedelta(minutes=2)
 
 logger = logging.getLogger(__name__)
 
 
 class ReconciliationManager(object):
-    """This class manages tasks that needs to be reconciled with Mesos. This class is thread-safe."""
-
-    COUNT_WARNING_THRESHOLD = 1000  # If the total list count hits this threshold, log a warning
+    """This class manages tasks that need to be reconciled. This class is thread-safe."""
 
     def __init__(self):
         """Constructor
         """
 
+        self._driver = None
         self._lock = threading.Lock()
-        self._task_ids_to_reconcile = set()
+
+        # Rookie tasks have just been added and have not sent a reconciliation request yet
+        # After their first reconciliation request, they will move to self._tasks
+        self._rookie_tasks = {}  # {Task ID: Task}
+        self._tasks = {}  # {Task ID: Task}
+        self._last_full_reconciliation = now()  # Last time all tasks were reconciled
 
     @property
     def driver(self):
@@ -42,37 +50,48 @@ class ReconciliationManager(object):
 
         self._driver = value
 
-    def add_task_ids(self, task_ids):
-        """Adds a list of task IDs that need to be reconciled
+    def add_tasks(self, tasks):
+        """Adds a list of tasks that need to be reconciled
 
-        :param task_ids: The list of task IDs to reconcile
-        :type task_ids: [string]
+        :param tasks: The list of tasks to reconcile
+        :type tasks: list
         """
 
         with self._lock:
-            for task_id in task_ids:
-                self._task_ids_to_reconcile.add(task_id)
+            for task in tasks:
+                if task.id not in self._tasks:
+                    self._rookie_tasks[task.id] = task
 
     def perform_reconciliation(self):
         """Performs task reconciliation with the Mesos master
         """
 
-        task_ids_to_reconcile = []
+        tasks_to_reconcile = {}
         with self._lock:
-            for task_id in self._task_ids_to_reconcile:
-                task_ids_to_reconcile.append(task_id)
+            when = now()
+            # Reconcile all tasks if time threshold has been reached
+            if when > self._last_full_reconciliation + FULL_RECON_THRESHOLD:
+                self._last_full_reconciliation = when
+                for task in self._tasks.values():
+                    tasks_to_reconcile[task.id] = task
+            # Always reconcile rookie tasks and move them to self._tasks
+            # This enables tasks to be quickly reconciled the first time
+            for task in self._rookie_tasks.values():
+                tasks_to_reconcile[task.id] = task
+                self._tasks[task.id] = task
+            self._rookie_tasks = {}
 
-        if not task_ids_to_reconcile:
+        if not tasks_to_reconcile:
             return
 
-        logger.info('Asking Mesos to reconcile %i task(s)', len(task_ids_to_reconcile))
-        tasks = []
-        for task_id in task_ids_to_reconcile:
-            task = mesos_pb2.TaskStatus()
-            task.task_id.value = task_id
-            task.state = mesos_pb2.TASK_LOST
-            tasks.append(task)
-        self._driver.reconcileTasks(tasks)
+        logger.info('Reconciling %d task(s)', len(tasks_to_reconcile))
+        task_statuses = []
+        for task in tasks_to_reconcile.values():
+            task_status = mesos_pb2.TaskStatus()
+            task_status.task_id.value = task.id
+            task_status.state = mesos_pb2.TASK_LOST
+            task_statuses.append(task_status)
+        self._driver.reconcileTasks(task_statuses)
 
     def remove_task_id(self, task_id):
         """Removes the task ID from the reconciliation set
@@ -82,7 +101,10 @@ class ReconciliationManager(object):
         """
 
         with self._lock:
-            self._task_ids_to_reconcile.discard(task_id)
+            if task_id in self._rookie_tasks:
+                del self._rookie_tasks[task_id]
+            if task_id in self._tasks:
+                del self._tasks[task_id]
 
 
 recon_mgr = ReconciliationManager()

--- a/scale/scheduler/sync/job_type_manager.py
+++ b/scale/scheduler/sync/job_type_manager.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 import threading
 
 from job.models import JobType
-from node.resources.node_resources import NodeResources
-from node.resources.resource import Cpus, Disk, Mem
 
 
 # TODO: when we calculate duration averages for job types, create a new job type class that contains model, resources,
@@ -79,9 +77,7 @@ class JobTypeManager(object):
         updated_job_types = {}
         for job_type in JobType.objects.all().iterator():
             updated_job_types[job_type.id] = job_type
-            resources = NodeResources([Cpus(job_type.cpus_required), Mem(job_type.mem_required),
-                                       Disk(job_type.disk_out_const_required)])
-            update_job_type_resources.append(resources)
+            update_job_type_resources.append(job_type.get_resources())
 
         with self._lock:
             self._job_type_resources = update_job_type_resources

--- a/scale/scheduler/threads/recon.py
+++ b/scale/scheduler/threads/recon.py
@@ -7,8 +7,8 @@ from scheduler.recon.manager import recon_mgr
 from scheduler.threads.base_thread import BaseSchedulerThread
 
 
-THROTTLE = datetime.timedelta(seconds=60)
-WARN_THRESHOLD = datetime.timedelta(seconds=1)
+THROTTLE = datetime.timedelta(seconds=1)
+WARN_THRESHOLD = datetime.timedelta(milliseconds=500)
 
 
 class ReconciliationThread(BaseSchedulerThread):

--- a/scale/scheduler/threads/task_handling.py
+++ b/scale/scheduler/threads/task_handling.py
@@ -71,10 +71,7 @@ class TaskHandlingThread(BaseSchedulerThread):
         :type when: :class:`datetime.datetime`
         """
 
-        task_ids = []
-        for task in task_mgr.get_tasks_to_reconcile(when):
-            task_ids.append(task.id)
-        recon_mgr.add_task_ids(task_ids)
+        recon_mgr.add_tasks(task_mgr.get_tasks_to_reconcile(when))
 
     def _timeout_tasks(self, when):
         """Handles any tasks that have exceeded their time out thresholds


### PR DESCRIPTION
Added an initial pull task to job executions so that image pulling does not occur during task staging. Turned off forcePull and tightened the limits of staging reconciliation/timeouts. Also added a check for pulling the Scale image where the registry is not hit if the image has already been pulled.