### PR TITLE
Issue 894 - Recipe detail bug

### DIFF
--- a/scale-ui/app/modules/recipes/controllers/recipeDetailsController.js
+++ b/scale-ui/app/modules/recipes/controllers/recipeDetailsController.js
@@ -18,6 +18,8 @@
             recipeService.getRecipeDetails(recipeId).then(function (data) {
                 vm.recipe = data;
                 recipeService.getRecipeTypeDetail(data.recipe_type_rev.recipe_type.id).then(function(recipeType){
+                    // use definition from recipe type revision
+                    recipeType.definition = vm.recipe.recipe_type_rev.definition;
                     vm.recipeType = recipeType;
                 }).catch(function(error){
                    console.log(error);

--- a/scale-ui/app/modules/recipes/controllers/recipeDetailsController.js
+++ b/scale-ui/app/modules/recipes/controllers/recipeDetailsController.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
 
-    angular.module('scaleApp').controller('recipeDetailsController', function ($rootScope, $scope, $location, $routeParams, navService, recipeService, scaleConfig, subnavService, userService) {
+    angular.module('scaleApp').controller('recipeDetailsController', function ($rootScope, $scope, $location, $routeParams, navService, recipeService, scaleConfig, subnavService, userService, RecipeTypeDetail) {
 
         var vm = this;
 
@@ -17,13 +17,29 @@
             vm.loadingRecipeDetail = true;
             recipeService.getRecipeDetails(recipeId).then(function (data) {
                 vm.recipe = data;
-                recipeService.getRecipeTypeDetail(data.recipe_type_rev.recipe_type.id).then(function(recipeType){
-                    // use definition from recipe type revision
-                    recipeType.definition = vm.recipe.recipe_type_rev.definition;
-                    vm.recipeType = recipeType;
-                }).catch(function(error){
-                   console.log(error);
+                // attach revision interface to each job type
+                var jobTypes = [];
+                _.forEach(data.jobs, function (jobData) {
+                    var jobType = jobData.job.job_type;
+                    jobType.interface = jobData.job.job_type_rev.interface;
+                    jobTypes.push(jobType);
                 });
+                // build recipe type details with revision definition and adjusted job types
+                vm.recipeType = new RecipeTypeDetail(
+                    data.recipe_type.id,
+                    data.recipe_type.name,
+                    data.recipe_type.version,
+                    data.recipe_type.title,
+                    data.recipe_type.description,
+                    data.recipe_type.is_active,
+                    data.recipe_type_rev.definition,
+                    data.recipe_type.created,
+                    data.recipe_type.last_modified,
+                    data.recipe_type.archived,
+                    data.recipe_type.trigger_rule,
+                    jobTypes,
+                    data.recipe_type
+                );
             }).catch(function (error) {
                 console.log(error);
             }).finally(function () {

--- a/scale-ui/app/modules/recipes/models/RecipeDetails.js
+++ b/scale-ui/app/modules/recipes/models/RecipeDetails.js
@@ -2,23 +2,23 @@
     'use strict';
 
     angular.module('scaleApp').factory('RecipeDetails', function (RecipeData, RecipeTypeDefinition, RecipeType, RecipeTypeDetail, RecipeJobContainer, scaleConfig) {
-        var RecipeDetails = function (id, created, completed, last_modified, data, recipe_type, recipe_type_rev, jobs,
-                                      is_superseded, root_superseded_recipe, superseded_recipe,
-                                      superseded_by_recipe, superseded) {
+        var RecipeDetails = function (id, recipe_type, recipe_type_rev, event, is_superseded, root_superseded_recipe, superseded_recipe, superseded_by_recipe, created, completed, superseded, last_modified, data, inputs, jobs) {
             this.id = id;
-            this.created = created;
-            this.completed = completed;
-            this.completed_formatted = this.completed ? moment.utc(this.completed).format(scaleConfig.dateFormats.day_second_utc) : this.completed;
-            this.last_modified = last_modified;
-            this.data = RecipeData.transformer(data);
             this.recipe_type = RecipeType.transformer(recipe_type);
             this.recipe_type_rev = RecipeTypeDetail.transformer(recipe_type_rev);
-            this.jobs = RecipeJobContainer.transformer(jobs);
+            this.event = event;
             this.is_superseded = is_superseded;
             this.root_superseded_recipe = root_superseded_recipe;
             this.superseded_recipe = superseded_recipe;
             this.superseded_by_recipe = superseded_by_recipe;
+            this.created = created;
+            this.completed = completed;
+            this.completed_formatted = this.completed ? moment.utc(this.completed).format(scaleConfig.dateFormats.day_second_utc) : this.completed;
             this.superseded = superseded;
+            this.last_modified = last_modified;
+            this.data = RecipeData.transformer(data);
+            this.inputs = inputs;
+            this.jobs = jobs;
         };
 
         // static methods, assigned to class
@@ -26,18 +26,20 @@
             if (data) {
                 return new RecipeDetails(
                   data.id,
-                  data.created,
-                  data.completed,
-                  data.last_modified,
-                  data.data,
                   data.recipe_type,
                   data.recipe_type_rev,
-                  data.jobs,
+                  data.event,
                   data.is_superseded,
                   data.root_superseded_recipe,
                   data.superseded_recipe,
                   data.superseded_by_recipe,
-                  data.superseded
+                  data.created,
+                  data.completed,
+                  data.superseded,
+                  data.last_modified,
+                  data.data,
+                  data.inputs,
+                  data.jobs
                 );
             }
             return new RecipeDetails();

--- a/scale-ui/app/test/data/recipe-details/recipeDetail1.json
+++ b/scale-ui/app/test/data/recipe-details/recipeDetail1.json
@@ -252,6 +252,38 @@
           "is_paused": false,
           "icon_code": "f248"
         },
+        "job_type_rev": {
+            "id": 1,
+            "job_type": {
+                "id": 1
+            },
+            "revision_num": 1,
+            "interface": {
+                "output_data": [
+                    {
+                        "media_type": "image/tiff",
+                        "required": true,
+                        "type": "file",
+                        "name": "geotiff"
+                    }
+                ],
+                "shared_resources": [],
+                "command_arguments": "",
+                "input_data": [
+                    {
+                        "media_types": [
+                            "image/tiff"
+                        ],
+                        "required": true,
+                        "type": "file",
+                        "name": "input_file"
+                    }
+                ],
+                "version": "1.0",
+                "command": ""
+            },
+            "created": "2016-01-01T00:00:00.000Z"
+        },
         "event": {
           "id": 7,
           "type": "INGEST",
@@ -294,6 +326,38 @@
           "is_operational": true,
           "is_paused": false,
           "icon_code": "f00c"
+        },
+        "job_type_rev": {
+            "id": 1,
+            "job_type": {
+                "id": 1
+            },
+            "revision_num": 1,
+            "interface": {
+                "output_data": [
+                    {
+                        "media_type": "image/tiff",
+                        "required": true,
+                        "type": "file",
+                        "name": "geotiff"
+                    }
+                ],
+                "shared_resources": [],
+                "command_arguments": "",
+                "input_data": [
+                    {
+                        "media_types": [
+                            "image/tiff"
+                        ],
+                        "required": true,
+                        "type": "file",
+                        "name": "input_file"
+                    }
+                ],
+                "version": "1.0",
+                "command": ""
+            },
+            "created": "2016-01-01T00:00:00.000Z"
         },
         "event": {
           "id": 7,
@@ -338,6 +402,38 @@
           "is_paused": false,
           "icon_code": "f1c0"
         },
+        "job_type_rev": {
+            "id": 1,
+            "job_type": {
+                "id": 1
+            },
+            "revision_num": 1,
+            "interface": {
+                "output_data": [
+                    {
+                        "media_type": "image/tiff",
+                        "required": true,
+                        "type": "file",
+                        "name": "geotiff"
+                    }
+                ],
+                "shared_resources": [],
+                "command_arguments": "",
+                "input_data": [
+                    {
+                        "media_types": [
+                            "image/tiff"
+                        ],
+                        "required": true,
+                        "type": "file",
+                        "name": "input_file"
+                    }
+                ],
+                "version": "1.0",
+                "command": ""
+            },
+            "created": "2016-01-01T00:00:00.000Z"
+        },
         "event": {
           "id": 7,
           "type": "INGEST",
@@ -380,6 +476,38 @@
           "is_operational": true,
           "is_paused": false,
           "icon_code": "f06e"
+        },
+        "job_type_rev": {
+            "id": 1,
+            "job_type": {
+                "id": 1
+            },
+            "revision_num": 1,
+            "interface": {
+                "output_data": [
+                    {
+                        "media_type": "image/tiff",
+                        "required": true,
+                        "type": "file",
+                        "name": "geotiff"
+                    }
+                ],
+                "shared_resources": [],
+                "command_arguments": "",
+                "input_data": [
+                    {
+                        "media_types": [
+                            "image/tiff"
+                        ],
+                        "required": true,
+                        "type": "file",
+                        "name": "input_file"
+                    }
+                ],
+                "version": "1.0",
+                "command": ""
+            },
+            "created": "2016-01-01T00:00:00.000Z"
         },
         "event": {
           "id": 7,

--- a/scale-ui/app/test/data/recipe-details/recipeDetail2.json
+++ b/scale-ui/app/test/data/recipe-details/recipeDetail2.json
@@ -231,6 +231,38 @@
           "is_paused": false,
           "icon_code": "f0e7"
         },
+        "job_type_rev": {
+            "id": 1,
+            "job_type": {
+                "id": 1
+            },
+            "revision_num": 1,
+            "interface": {
+                "output_data": [
+                    {
+                        "media_type": "image/tiff",
+                        "required": true,
+                        "type": "file",
+                        "name": "geotiff"
+                    }
+                ],
+                "shared_resources": [],
+                "command_arguments": "",
+                "input_data": [
+                    {
+                        "media_types": [
+                            "image/tiff"
+                        ],
+                        "required": true,
+                        "type": "file",
+                        "name": "input_file"
+                    }
+                ],
+                "version": "1.0",
+                "command": ""
+            },
+            "created": "2016-01-01T00:00:00.000Z"
+        },
         "event": {
           "id": 7,
           "type": "INGEST",
@@ -273,6 +305,38 @@
           "is_operational": true,
           "is_paused": false,
           "icon_code": "f140"
+        },
+        "job_type_rev": {
+            "id": 1,
+            "job_type": {
+                "id": 1
+            },
+            "revision_num": 1,
+            "interface": {
+                "output_data": [
+                    {
+                        "media_type": "image/tiff",
+                        "required": true,
+                        "type": "file",
+                        "name": "geotiff"
+                    }
+                ],
+                "shared_resources": [],
+                "command_arguments": "",
+                "input_data": [
+                    {
+                        "media_types": [
+                            "image/tiff"
+                        ],
+                        "required": true,
+                        "type": "file",
+                        "name": "input_file"
+                    }
+                ],
+                "version": "1.0",
+                "command": ""
+            },
+            "created": "2016-01-01T00:00:00.000Z"
         },
         "event": {
           "id": 7,
@@ -317,6 +381,38 @@
           "is_paused": false,
           "icon_code": "f185"
         },
+        "job_type_rev": {
+            "id": 1,
+            "job_type": {
+                "id": 1
+            },
+            "revision_num": 1,
+            "interface": {
+                "output_data": [
+                    {
+                        "media_type": "image/tiff",
+                        "required": true,
+                        "type": "file",
+                        "name": "geotiff"
+                    }
+                ],
+                "shared_resources": [],
+                "command_arguments": "",
+                "input_data": [
+                    {
+                        "media_types": [
+                            "image/tiff"
+                        ],
+                        "required": true,
+                        "type": "file",
+                        "name": "input_file"
+                    }
+                ],
+                "version": "1.0",
+                "command": ""
+            },
+            "created": "2016-01-01T00:00:00.000Z"
+        },
         "event": {
           "id": 7,
           "type": "INGEST",
@@ -359,6 +455,38 @@
           "is_operational": true,
           "is_paused": false,
           "icon_code": "f06e"
+        },
+        "job_type_rev": {
+            "id": 1,
+            "job_type": {
+                "id": 1
+            },
+            "revision_num": 1,
+            "interface": {
+                "output_data": [
+                    {
+                        "media_type": "image/tiff",
+                        "required": true,
+                        "type": "file",
+                        "name": "geotiff"
+                    }
+                ],
+                "shared_resources": [],
+                "command_arguments": "",
+                "input_data": [
+                    {
+                        "media_types": [
+                            "image/tiff"
+                        ],
+                        "required": true,
+                        "type": "file",
+                        "name": "input_file"
+                    }
+                ],
+                "version": "1.0",
+                "command": ""
+            },
+            "created": "2016-01-01T00:00:00.000Z"
         },
         "event": {
           "id": 7,

--- a/scale-ui/app/test/data/recipe-details/recipeDetail3.json
+++ b/scale-ui/app/test/data/recipe-details/recipeDetail3.json
@@ -243,6 +243,38 @@
                     "is_paused": false,
                     "icon_code": "f0c2"
                 },
+                "job_type_rev": {
+                    "id": 1,
+                    "job_type": {
+                        "id": 1
+                    },
+                    "revision_num": 1,
+                    "interface": {
+                        "output_data": [
+                            {
+                                "media_type": "image/tiff",
+                                "required": true,
+                                "type": "file",
+                                "name": "geotiff"
+                            }
+                        ],
+                        "shared_resources": [],
+                        "command_arguments": "",
+                        "input_data": [
+                            {
+                                "media_types": [
+                                    "image/tiff"
+                                ],
+                                "required": true,
+                                "type": "file",
+                                "name": "input_file"
+                            }
+                        ],
+                        "version": "1.0",
+                        "command": ""
+                    },
+                    "created": "2016-01-01T00:00:00.000Z"
+                },
                 "event": {
                     "id": 7,
                     "type": "INGEST",
@@ -285,6 +317,38 @@
                     "is_operational": true,
                     "is_paused": false,
                     "icon_code": "f14e"
+                },
+                "job_type_rev": {
+                    "id": 1,
+                    "job_type": {
+                        "id": 1
+                    },
+                    "revision_num": 1,
+                    "interface": {
+                        "output_data": [
+                            {
+                                "media_type": "image/tiff",
+                                "required": true,
+                                "type": "file",
+                                "name": "geotiff"
+                            }
+                        ],
+                        "shared_resources": [],
+                        "command_arguments": "",
+                        "input_data": [
+                            {
+                                "media_types": [
+                                    "image/tiff"
+                                ],
+                                "required": true,
+                                "type": "file",
+                                "name": "input_file"
+                            }
+                        ],
+                        "version": "1.0",
+                        "command": ""
+                    },
+                    "created": "2016-01-01T00:00:00.000Z"
                 },
                 "event": {
                     "id": 7,
@@ -329,6 +393,38 @@
                     "is_paused": false,
                     "icon_code": "f219"
                 },
+                "job_type_rev": {
+                    "id": 1,
+                    "job_type": {
+                        "id": 1
+                    },
+                    "revision_num": 1,
+                    "interface": {
+                        "output_data": [
+                            {
+                                "media_type": "image/tiff",
+                                "required": true,
+                                "type": "file",
+                                "name": "geotiff"
+                            }
+                        ],
+                        "shared_resources": [],
+                        "command_arguments": "",
+                        "input_data": [
+                            {
+                                "media_types": [
+                                    "image/tiff"
+                                ],
+                                "required": true,
+                                "type": "file",
+                                "name": "input_file"
+                            }
+                        ],
+                        "version": "1.0",
+                        "command": ""
+                    },
+                    "created": "2016-01-01T00:00:00.000Z"
+                },
                 "event": {
                     "id": 7,
                     "type": "INGEST",
@@ -371,6 +467,38 @@
                     "is_operational": true,
                     "is_paused": false,
                     "icon_code": "f06e"
+                },
+                "job_type_rev": {
+                    "id": 1,
+                    "job_type": {
+                        "id": 1
+                    },
+                    "revision_num": 1,
+                    "interface": {
+                        "output_data": [
+                            {
+                                "media_type": "image/tiff",
+                                "required": true,
+                                "type": "file",
+                                "name": "geotiff"
+                            }
+                        ],
+                        "shared_resources": [],
+                        "command_arguments": "",
+                        "input_data": [
+                            {
+                                "media_types": [
+                                    "image/tiff"
+                                ],
+                                "required": true,
+                                "type": "file",
+                                "name": "input_file"
+                            }
+                        ],
+                        "version": "1.0",
+                        "command": ""
+                    },
+                    "created": "2016-01-01T00:00:00.000Z"
                 },
                 "event": {
                     "id": 7,

--- a/scale-ui/app/test/data/recipe-details/recipeDetail4.json
+++ b/scale-ui/app/test/data/recipe-details/recipeDetail4.json
@@ -184,6 +184,38 @@
                     "is_paused": false,
                     "icon_code": "f0e7"
                 },
+                "job_type_rev": {
+                    "id": 1,
+                    "job_type": {
+                        "id": 1
+                    },
+                    "revision_num": 1,
+                    "interface": {
+                        "output_data": [
+                            {
+                                "media_type": "image/tiff",
+                                "required": true,
+                                "type": "file",
+                                "name": "geotiff"
+                            }
+                        ],
+                        "shared_resources": [],
+                        "command_arguments": "",
+                        "input_data": [
+                            {
+                                "media_types": [
+                                    "image/tiff"
+                                ],
+                                "required": true,
+                                "type": "file",
+                                "name": "input_file"
+                            }
+                        ],
+                        "version": "1.0",
+                        "command": ""
+                    },
+                    "created": "2016-01-01T00:00:00.000Z"
+                },
                 "event": {
                     "id": 7,
                     "type": "INGEST",
@@ -226,6 +258,38 @@
                     "is_operational": true,
                     "is_paused": false,
                     "icon_code": "f0ac"
+                },
+                "job_type_rev": {
+                    "id": 1,
+                    "job_type": {
+                        "id": 1
+                    },
+                    "revision_num": 1,
+                    "interface": {
+                        "output_data": [
+                            {
+                                "media_type": "image/tiff",
+                                "required": true,
+                                "type": "file",
+                                "name": "geotiff"
+                            }
+                        ],
+                        "shared_resources": [],
+                        "command_arguments": "",
+                        "input_data": [
+                            {
+                                "media_types": [
+                                    "image/tiff"
+                                ],
+                                "required": true,
+                                "type": "file",
+                                "name": "input_file"
+                            }
+                        ],
+                        "version": "1.0",
+                        "command": ""
+                    },
+                    "created": "2016-01-01T00:00:00.000Z"
                 },
                 "event": {
                     "id": 7,

--- a/scale-ui/app/test/data/recipe-details/recipeDetail5.json
+++ b/scale-ui/app/test/data/recipe-details/recipeDetail5.json
@@ -153,6 +153,38 @@
                     "is_paused": false,
                     "icon_code": "f072"
                 },
+                "job_type_rev": {
+                    "id": 1,
+                    "job_type": {
+                        "id": 1
+                    },
+                    "revision_num": 1,
+                    "interface": {
+                        "output_data": [
+                            {
+                                "media_type": "image/tiff",
+                                "required": true,
+                                "type": "file",
+                                "name": "geotiff"
+                            }
+                        ],
+                        "shared_resources": [],
+                        "command_arguments": "",
+                        "input_data": [
+                            {
+                                "media_types": [
+                                    "image/tiff"
+                                ],
+                                "required": true,
+                                "type": "file",
+                                "name": "input_file"
+                            }
+                        ],
+                        "version": "1.0",
+                        "command": ""
+                    },
+                    "created": "2016-01-01T00:00:00.000Z"
+                },
                 "event": {
                     "id": 7,
                     "type": "INGEST",

--- a/scale-ui/app/test/data/recipe-details/recipeDetail6.json
+++ b/scale-ui/app/test/data/recipe-details/recipeDetail6.json
@@ -251,6 +251,38 @@
           "is_paused": false,
           "icon_code": "f248"
         },
+        "job_type_rev": {
+            "id": 1,
+            "job_type": {
+                "id": 1
+            },
+            "revision_num": 1,
+            "interface": {
+                "output_data": [
+                    {
+                        "media_type": "image/tiff",
+                        "required": true,
+                        "type": "file",
+                        "name": "geotiff"
+                    }
+                ],
+                "shared_resources": [],
+                "command_arguments": "",
+                "input_data": [
+                    {
+                        "media_types": [
+                            "image/tiff"
+                        ],
+                        "required": true,
+                        "type": "file",
+                        "name": "input_file"
+                    }
+                ],
+                "version": "1.0",
+                "command": ""
+            },
+            "created": "2016-01-01T00:00:00.000Z"
+        },
         "event": {
           "id": 7,
           "type": "INGEST",
@@ -293,6 +325,38 @@
           "is_operational": true,
           "is_paused": false,
           "icon_code": "f00c"
+        },
+        "job_type_rev": {
+            "id": 1,
+            "job_type": {
+                "id": 1
+            },
+            "revision_num": 1,
+            "interface": {
+                "output_data": [
+                    {
+                        "media_type": "image/tiff",
+                        "required": true,
+                        "type": "file",
+                        "name": "geotiff"
+                    }
+                ],
+                "shared_resources": [],
+                "command_arguments": "",
+                "input_data": [
+                    {
+                        "media_types": [
+                            "image/tiff"
+                        ],
+                        "required": true,
+                        "type": "file",
+                        "name": "input_file"
+                    }
+                ],
+                "version": "1.0",
+                "command": ""
+            },
+            "created": "2016-01-01T00:00:00.000Z"
         },
         "event": {
           "id": 7,
@@ -337,6 +401,38 @@
           "is_paused": false,
           "icon_code": "f1c0"
         },
+        "job_type_rev": {
+            "id": 1,
+            "job_type": {
+                "id": 1
+            },
+            "revision_num": 1,
+            "interface": {
+                "output_data": [
+                    {
+                        "media_type": "image/tiff",
+                        "required": true,
+                        "type": "file",
+                        "name": "geotiff"
+                    }
+                ],
+                "shared_resources": [],
+                "command_arguments": "",
+                "input_data": [
+                    {
+                        "media_types": [
+                            "image/tiff"
+                        ],
+                        "required": true,
+                        "type": "file",
+                        "name": "input_file"
+                    }
+                ],
+                "version": "1.0",
+                "command": ""
+            },
+            "created": "2016-01-01T00:00:00.000Z"
+        },
         "event": {
           "id": 7,
           "type": "INGEST",
@@ -379,6 +475,38 @@
           "is_operational": true,
           "is_paused": false,
           "icon_code": "f06e"
+        },
+        "job_type_rev": {
+            "id": 1,
+            "job_type": {
+                "id": 1
+            },
+            "revision_num": 1,
+            "interface": {
+                "output_data": [
+                    {
+                        "media_type": "image/tiff",
+                        "required": true,
+                        "type": "file",
+                        "name": "geotiff"
+                    }
+                ],
+                "shared_resources": [],
+                "command_arguments": "",
+                "input_data": [
+                    {
+                        "media_types": [
+                            "image/tiff"
+                        ],
+                        "required": true,
+                        "type": "file",
+                        "name": "input_file"
+                    }
+                ],
+                "version": "1.0",
+                "command": ""
+            },
+            "created": "2016-01-01T00:00:00.000Z"
         },
         "event": {
           "id": 7,


### PR DESCRIPTION
Fixes #894 

The call to get the recipe type detail has been left in, and the resulting definition is being replaced with the revision definition. This was necessary due to the fact that job type data essential for the recipe viewer is not included in the recipe details response. So if the recipe type details call was not made, additional calls (potentially multiple) would have needed to be made further down the line to get the appropriate job type data. 