### PR TITLE
Issue 893

### DIFF
--- a/scale/docs/rest/product.rst
+++ b/scale/docs/rest/product.rst
@@ -254,6 +254,12 @@ These services provide access to information about products that Scale has produ
 +=========================================================================================================================+
 | Returns a specific product file and all its related model information including sources and derived products.           |
 +-------------------------------------------------------------------------------------------------------------------------+
+| **DEPRECATED**                                                                                                          |
+|                This table describes the current v5 version of the product file details API, which is now deprecated.    |
+|                The new v6 version of this API does not include the *sources*, *ancestors*, and *descendants* arrays     |
+|                in the response. The new v6 version also does not support the use of *file_name* in the URL (only        |
+|                product ID supported).                                                                                   |
++-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /products/{id}/                                                                                                 |
 |         Where {id} is the unique identifier of an existing model.                                                       |
 +-------------------------------------------------------------------------------------------------------------------------+
@@ -317,6 +323,10 @@ These services provide access to information about products that Scale has produ
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | unpublished        | ISO-8601 Datetime | When the product file was unpublished by Scale.                                |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
+| source_started     | ISO-8601 Datetime | When collection of the underlying source file started.                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| source_ended       | ISO-8601 Datetime | When collection of the underlying source file ended.                           |
++--------------------+-------------------+--------------------------------------------------------------------------------+
 | job_type           | JSON Object       | The type of job that created the product.                                      |
 |                    |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -326,6 +336,15 @@ These services provide access to information about products that Scale has produ
 | job_exe            | JSON Object       | The job execution that created the product.                                    |
 |                    |                   | (See :ref:`Job Execution Details <rest_job_execution_details>`)                |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
+| .recipe_type       | JSON Object       | The type of recipe that generated the product.                                 |
+|                    |                   | (See :ref:`Recipe Type Details <rest_recipe_type_details>`)                    |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .recipe            | JSON Object       | The recipe instance that generated the product.                                |
+|                    |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                              |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .batch             | JSON Object       | The batch instance that generated the product.                                 |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+|                    |                   | (See :ref:`Batch Details <rest_batch_details>`)                                |
 | sources            | Array             | A list of source files used to derive this product file during jobs.           |
 |                    |                   | (See :ref:`Source File Details <rest_source_file_details>`)                    |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -364,6 +383,8 @@ These services provide access to information about products that Scale has produ
 |        "has_been_published": true,                                                                                      |
 |        "published": "1970-01-01T00:00:00Z",                                                                             |
 |        "unpublished": null,                                                                                             |
+|        "source_started": "1970-01-01T00:00:00Z",                                                                        |
+|        "source_ended": "1970-01-02T00:00:00Z",                                                                          |
 |        "job_type": {                                                                                                    |
 |            "id": 4,                                                                                                     |
 |            "name": "png-filter",                                                                                        |
@@ -385,7 +406,26 @@ These services provide access to information about products that Scale has produ
 |        },                                                                                                               |
 |        "job_exe": {                                                                                                     |
 |            "id": 4                                                                                                      |
-|        }                                                                                                                |
+|        },                                                                                                               |
+|        "recipe_type": {                                                                                                 |
+|            "id": 6,                                                                                                     |
+|            "name": "my-recipe",                                                                                         |
+|            "version": "1.0.0",                                                                                          |
+|            "title": "My Recipe",                                                                                        |
+|            "description": "Processes some data",                                                                        |
+|        },                                                                                                               |
+|        "recipe": {                                                                                                      |
+|            "id": 60                                                                                                     |
+|        },                                                                                                               |
+|        "batch": {                                                                                                       |
+|            "id": 15,                                                                                                    |
+|            "title": "My Batch",                                                                                         |
+|            "description": "My batch of recipes",                                                                        |
+|            "status": "SUBMITTED",                                                                                       |
+|            "recipe_type": 6,                                                                                            |
+|            "event": 19,                                                                                                 |
+|            "creator_job": 62,                                                                                           |
+|        },                                                                                                               |
 |        "sources": [                                                                                                     |
 |            {                                                                                                            |
 |                "id": 1,                                                                                                 |

--- a/scale/docs/rest/product.rst
+++ b/scale/docs/rest/product.rst
@@ -336,13 +336,13 @@ These services provide access to information about products that Scale has produ
 | job_exe            | JSON Object       | The job execution that created the product.                                    |
 |                    |                   | (See :ref:`Job Execution Details <rest_job_execution_details>`)                |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| .recipe_type       | JSON Object       | The type of recipe that generated the product.                                 |
+| recipe_type        | JSON Object       | The type of recipe that generated the product.                                 |
 |                    |                   | (See :ref:`Recipe Type Details <rest_recipe_type_details>`)                    |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| .recipe            | JSON Object       | The recipe instance that generated the product.                                |
+| recipe             | JSON Object       | The recipe instance that generated the product.                                |
 |                    |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                              |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| .batch             | JSON Object       | The batch instance that generated the product.                                 |
+| batch              | JSON Object       | The batch instance that generated the product.                                 |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 |                    |                   | (See :ref:`Batch Details <rest_batch_details>`)                                |
 | sources            | Array             | A list of source files used to derive this product file during jobs.           |

--- a/scale/product/models.py
+++ b/scale/product/models.py
@@ -377,6 +377,20 @@ class ProductFileManager(models.GeoManager):
         return sources
 
     def get_details(self, product_id):
+        """Gets additional details for the given product model
+
+        :param product_id: The unique identifier of the product.
+        :type product_id: int
+        :returns: The product with extra related attributes: sources, ancestor/descendant products.
+        :rtype: :class:`storage.models.ScaleFile`
+
+        :raises :class:`storage.models.ScaleFile.DoesNotExist`: If the file does not exist
+        """
+
+        return ScaleFile.objects.all().select_related('workspace').get(pk=product_id, file_type='PRODUCT')
+
+    # TODO: remove when REST API v5 is removed
+    def get_details_v5(self, product_id):
         """Gets additional details for the given product model based on related model attributes.
 
         :param product_id: The unique identifier of the product.

--- a/scale/product/models.py
+++ b/scale/product/models.py
@@ -381,7 +381,7 @@ class ProductFileManager(models.GeoManager):
 
         :param product_id: The unique identifier of the product.
         :type product_id: int
-        :returns: The product with extra related attributes: sources, ancestor/descendant products.
+        :returns: The product file model with related workspace
         :rtype: :class:`storage.models.ScaleFile`
 
         :raises :class:`storage.models.ScaleFile.DoesNotExist`: If the file does not exist

--- a/scale/product/serializers.py
+++ b/scale/product/serializers.py
@@ -21,7 +21,7 @@ class ProductFileBaseSerializer(ScaleFileBaseSerializer):
     unpublished = serializers.DateTimeField()
     superseded = serializers.DateTimeField()
 
-    source_started =  serializers.DateTimeField()
+    source_started = serializers.DateTimeField()
     source_ended = serializers.DateTimeField()
 
     job_type = ModelIdSerializer()
@@ -43,6 +43,12 @@ class ProductFileSerializer(ProductFileBaseSerializer):
 
 
 class ProductFileDetailsSerializer(ProductFileSerializer):
+    """Converts product file model fields to REST output"""
+    pass
+
+
+# TODO: remove when REST API v5 is removed
+class ProductFileDetailsSerializerV5(ProductFileSerializer):
     """Converts product file model fields to REST output"""
     from source.serializers import SourceFileSerializer
 

--- a/scale/product/test/test_views.py
+++ b/scale/product/test/test_views.py
@@ -171,6 +171,44 @@ class TestProductDetailsView(TestCase):
     def setUp(self):
         django.setup()
 
+        self.country = storage_test_utils.create_country()
+        self.job_type1 = job_test_utils.create_job_type(name='test1', category='test-1', is_operational=True)
+        self.job1 = job_test_utils.create_job(job_type=self.job_type1)
+        self.job_exe1 = job_test_utils.create_job_exe(job=self.job1)
+        self.product = product_test_utils.create_product(job_exe=self.job_exe1, has_been_published=True,
+                                                          is_published=True, file_name='test.txt',
+                                                          countries=[self.country])
+
+    def test_id(self):
+        """Tests successfully calling the product files detail view by id"""
+        
+        # TODO: this can change to rest_util.get_url() once v6 is default instead of v5
+        url = '/v6/products/%i/' % self.product.id
+        #  url = rest_util.get_url('/products/%i/' % self.product.id)
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(result['id'], self.product.id)
+        self.assertEqual(result['file_name'], self.product.file_name)
+        self.assertFalse('ancestors' in result)
+        self.assertFalse('descendants' in result)
+        self.assertFalse('sources' in result)
+    def test_missing(self):
+        """Tests calling the product files view with an invalid id"""
+
+        # TODO: this can change to rest_util.get_url() once v6 is default instead of v5
+        url = '/v6/products/12345/'
+        #  url = rest_util.get_url('/products/12345/')
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
+
+# TODO: remove when REST API v5 is removed
+class TestProductDetailsViewV5(TestCase):
+
+    def setUp(self):
+        django.setup()
+
         self.source = source_test_utils.create_source()
         self.ancestor = product_test_utils.create_product(file_name='test_ancestor.txt')
         self.descendant = product_test_utils.create_product(file_name='test_descendant.txt')

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -155,7 +155,7 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer',
         'rest_framework.renderers.AdminRenderer',
     ),
-    'ALLOWED_VERSIONS': ('v4', 'v5'),
+    'ALLOWED_VERSIONS': ('v4', 'v5', 'v6'),
     'DEFAULT_VERSION': 'v5',
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
 }


### PR DESCRIPTION
* Added `v6` to allowed API versions
* Deprecated `sources`, `ancestors`, `descendants` from `/product/{id}/`
