### PR TITLE
#816 - Update REST API for settings secrets

### DIFF
--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -207,6 +207,12 @@ def deploy_webserver(client, app_name, es_urls, es_lb, db_host, db_port, broker_
     marathon['cpus'] = int(cpu)
     marathon['mem'] = int(memory)
 
+    # Set attributes for secrets
+    marathon['DCOS_SERVICE_ACCOUNT'] = os.environ.get('DCOS_SERVICE_ACCOUNT', None)
+    marathon['SECRETS_SSL_WARNINGS'] = os.environ.get('SECRETS_SSL_WARNINGS').lower() not in ['false', '0', 'f']
+    marathon['SECRETS_TOKEN'] = os.environ.get('SECRETS_TOKEN', None)
+    marathon['SECRETS_URL'] = os.environ.get('SECRETS_URL', None)
+
     env_map = {
         'SCALE_ALLOWED_HOSTS': 'SCALE_ALLOWED_HOSTS',
         'SCALE_SECRET_KEY': 'SCALE_SECRET_KEY',

--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -207,12 +207,6 @@ def deploy_webserver(client, app_name, es_urls, es_lb, db_host, db_port, broker_
     marathon['cpus'] = int(cpu)
     marathon['mem'] = int(memory)
 
-    # Set attributes for secrets
-    marathon['DCOS_SERVICE_ACCOUNT'] = os.environ.get('DCOS_SERVICE_ACCOUNT', None)
-    marathon['SECRETS_SSL_WARNINGS'] = os.environ.get('SECRETS_SSL_WARNINGS').lower() not in ['false', '0', 'f']
-    marathon['SECRETS_TOKEN'] = os.environ.get('SECRETS_TOKEN', None)
-    marathon['SECRETS_URL'] = os.environ.get('SECRETS_URL', None)
-
     env_map = {
         'SCALE_ALLOWED_HOSTS': 'SCALE_ALLOWED_HOSTS',
         'SCALE_SECRET_KEY': 'SCALE_SECRET_KEY',
@@ -225,6 +219,7 @@ def deploy_webserver(client, app_name, es_urls, es_lb, db_host, db_port, broker_
 
     arbitrary_env = {
         'DCOS_PACKAGE_FRAMEWORK_NAME': FRAMEWORK_NAME,
+        'DCOS_SERVICE_ACCOUNT': os.environ.get('DCOS_SERVICE_ACCOUNT', None),
         'ENABLE_WEBSERVER': 'true',
         'SCALE_BROKER_URL': broker_url,
         'SCALE_DB_HOST': db_host,
@@ -233,7 +228,10 @@ def deploy_webserver(client, app_name, es_urls, es_lb, db_host, db_port, broker_
         'SCALE_WEBSERVER_CPU': str(cpu),
         'SCALE_WEBSERVER_MEMORY': str(memory),
         'SCALE_ELASTICSEARCH_URLS': es_urls,
-        'SCALE_ELASTICSEARCH_LB': es_lb
+        'SCALE_ELASTICSEARCH_LB': es_lb,
+        'SECRETS_SSL_WARNINGS': os.environ.get('SECRETS_SSL_WARNINGS').lower() not in ['false', '0', 'f'],
+        'SECRETS_TOKEN': os.environ.get('SECRETS_TOKEN', None),
+        'SECRETS_URL': os.environ.get('SECRETS_URL', None)
     }
     # For all environment variable that are set add to marathon json.
     for env in arbitrary_env:

--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -207,6 +207,13 @@ def deploy_webserver(client, app_name, es_urls, es_lb, db_host, db_port, broker_
     marathon['cpus'] = int(cpu)
     marathon['mem'] = int(memory)
 
+    # Set attributes for secrets
+    secrets_dcos_sa = os.environ.get('DCOS_SERVICE_ACCOUNT', '')
+    secrets_ssl_warn = os.environ.get('SECRETS_SSL_WARNINGS', '')
+    secrets_token = os.environ.get('SECRETS_TOKEN', '')
+    secrets_url = os.environ.get('SECRETS_URL', '')
+
+
     env_map = {
         'SCALE_ALLOWED_HOSTS': 'SCALE_ALLOWED_HOSTS',
         'SCALE_SECRET_KEY': 'SCALE_SECRET_KEY',
@@ -219,7 +226,7 @@ def deploy_webserver(client, app_name, es_urls, es_lb, db_host, db_port, broker_
 
     arbitrary_env = {
         'DCOS_PACKAGE_FRAMEWORK_NAME': FRAMEWORK_NAME,
-        'DCOS_SERVICE_ACCOUNT': os.environ.get('DCOS_SERVICE_ACCOUNT', None),
+        'DCOS_SERVICE_ACCOUNT': str(secrets_dcos_sa),
         'ENABLE_WEBSERVER': 'true',
         'SCALE_BROKER_URL': broker_url,
         'SCALE_DB_HOST': db_host,
@@ -229,9 +236,9 @@ def deploy_webserver(client, app_name, es_urls, es_lb, db_host, db_port, broker_
         'SCALE_WEBSERVER_MEMORY': str(memory),
         'SCALE_ELASTICSEARCH_URLS': es_urls,
         'SCALE_ELASTICSEARCH_LB': es_lb,
-        'SECRETS_SSL_WARNINGS': os.environ.get('SECRETS_SSL_WARNINGS').lower() not in ['false', '0', 'f'],
-        'SECRETS_TOKEN': os.environ.get('SECRETS_TOKEN', None),
-        'SECRETS_URL': os.environ.get('SECRETS_URL', None)
+        'SECRETS_SSL_WARNINGS': str(secrets_ssl_warn),
+        'SECRETS_TOKEN': str(secrets_token),
+        'SECRETS_URL': str(secrets_url)
     }
     # For all environment variable that are set add to marathon json.
     for env in arbitrary_env:

--- a/scale/docs/rest/job_type.rst
+++ b/scale/docs/rest/job_type.rst
@@ -255,6 +255,9 @@ These services provide access to information about job types.
 | interface               | JSON Object       | Required | JSON description of the interface for running the job.         |
 |                         |                   |          | (See :ref:`architecture_jobs_interface_spec`)                  |
 +-------------------------+-------------------+----------+----------------------------------------------------------------+
+| configuration           | JSON Object       | Optional | JSON description of the configuration for running the job      |
+|                         |                   |          | (See :ref:`architecture_jobs_job_configuration_spec`)          |
++--------------------------+-------------------+--------------------------------------------------------------------------+
 | custom_resources        | JSON Object       | Optional | JSON description for any custom resources needed for running a |
 |                         |                   |          | job of this type. (See :ref:`architecture_jobs_resources`)     |
 +-------------------------+-------------------+----------+----------------------------------------------------------------+
@@ -294,7 +297,7 @@ These services provide access to information about job types.
 |        "interface": {                                                                                                   |
 |            "version": "1.0",                                                                                            |
 |            "command": "test_cmd",                                                                                       |
-|            "command_arguments": "test_arg",                                                                             |
+|            "command_arguments": "test_arg ${dted_path}",                                                                |
 |            "input_data": [                                                                                              |
 |                {                                                                                                        |
 |                    "media_types": ["image/png"],                                                                        |
@@ -302,8 +305,32 @@ These services provide access to information about job types.
 |                    "name": "input_file"                                                                                 |
 |                }                                                                                                        |
 |            ],                                                                                                           |
+|            "settings": [                                                                                                |
+|                {                                                                                                        |
+|                    "name": "dted_path",                                                                                 |
+|                    "required": true,                                                                                    |
+|                    "secret": false                                                                                      |
+|                }                                                                                                        |
+|            ],                                                                                                           |
+|            "mounts": [                                                                                                  |
+|                {                                                                                                        |
+|                    "name": "ref_data",                                                                                  |
+|                    "path": "/container/path/to/ref_data",                                                               |
+|                    "required": true,                                                                                    |
+|                    "mode": "ro"                                                                                         |
+|                }                                                                                                        |
+|            ],                                                                                                           |
 |            "output_data": [],                                                                                           |
 |            "shared_resources": []                                                                                       |
+|        },                                                                                                               |
+|        "configuration": {                                                                                               |
+|            "version": "2.0",                                                                                            |
+|            "mounts": {                                                                                                  |
+|                "ref_data": {"type": "host", "host_path": "/path/to/ref_data"}                                           |
+|            },                                                                                                           |
+|            "settings": {                                                                                                |
+|                "dted_path": "/path/to/dted"                                                                             |
+|            }                                                                                                            |
 |        },                                                                                                               |
 |        "custom_resources": {                                                                                            |
 |            "version": "1.0",                                                                                            |
@@ -465,6 +492,9 @@ These services provide access to information about job types.
 | interface               | JSON Object       | Required | JSON description of the interface for running the job.         |
 |                         |                   |          | (See :ref:`architecture_jobs_interface_spec`)                  |
 +-------------------------+-------------------+----------+----------------------------------------------------------------+
+| configuration           | JSON Object       | Optional | JSON description of the configuration for running the job      |
+|                         |                   |          | (See :ref:`architecture_jobs_job_configuration_spec`)          |
++--------------------------+-------------------+--------------------------------------------------------------------------+
 | custom_resources        | JSON Object       | Optional | JSON description for any custom resources needed for running a |
 |                         |                   |          | job of this type. (See :ref:`architecture_jobs_resources`)     |
 +-------------------------+-------------------+----------+----------------------------------------------------------------+
@@ -504,7 +534,7 @@ These services provide access to information about job types.
 |        "interface": {                                                                                                   |
 |            "version": "1.0",                                                                                            |
 |            "command": "test_cmd",                                                                                       |
-|            "command_arguments": "test_arg",                                                                             |
+|            "command_arguments": "test_arg ${dted_path}",                                                                |
 |            "input_data": [                                                                                              |
 |                {                                                                                                        |
 |                    "media_types": ["image/png"],                                                                        |
@@ -512,8 +542,32 @@ These services provide access to information about job types.
 |                    "name": "input_file"                                                                                 |
 |                }                                                                                                        |
 |            ],                                                                                                           |
+|            "settings": [                                                                                                |
+|                {                                                                                                        |
+|                    "name": "dted_path",                                                                                 |
+|                    "required": true,                                                                                    |
+|                    "secret": false                                                                                      |
+|                }                                                                                                        |
+|            ],                                                                                                           |
+|            "mounts": [                                                                                                  |
+|                {                                                                                                        |
+|                    "name": "ref_data",                                                                                  |
+|                    "path": "/container/path/to/ref_data",                                                               |
+|                    "required": true,                                                                                    |
+|                    "mode": "ro"                                                                                         |
+|                }                                                                                                        |
+|            ],                                                                                                           |
 |            "output_data": [],                                                                                           |
 |            "shared_resources": []                                                                                       |
+|        },                                                                                                               |
+|        "configuration": {                                                                                               |
+|            "version": "2.0",                                                                                            |
+|            "mounts": {                                                                                                  |
+|                "ref_data": {"type": "host", "host_path": "/path/to/ref_data"}                                           |
+|            },                                                                                                           |
+|            "settings": {                                                                                                |
+|                "dted_path": "/path/to/dted"                                                                             |
+|            }                                                                                                            |
 |        },                                                                                                               |
 |        "custom_resources": {                                                                                            |
 |            "version": "1.0",                                                                                            |
@@ -662,6 +716,9 @@ These services provide access to information about job types.
 | interface                | JSON Object       | JSON description defining the interface for running a job of this type.  |
 |                          |                   | (See :ref:`architecture_jobs_interface_spec`)                            |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
+| configuration            | JSON Object       | JSON description defining the configuration for running a job of this    |
+|                          |                   | type. (See :ref:`architecture_jobs_job_configuration_spec`)              |
++--------------------------+-------------------+--------------------------------------------------------------------------+
 | custom_resources         | JSON Object       | JSON description for any custom resources needed for running a job of    |
 |                          |                   | this type. (See :ref:`architecture_jobs_resources`)                      |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
@@ -742,6 +799,7 @@ These services provide access to information about job types.
 |        "paused": null,                                                                                                  |
 |        "last_modified": "2015-03-11T00:00:00Z"                                                                          |
 |        "interface": {...},                                                                                              |
+|        "configuration": {...},                                                                                          |
 |        "custom_resources": {...},                                                                                       |
 |        "error_mapping": {...},                                                                                          |
 |        "trigger_rule": {...},                                                                                           |
@@ -861,6 +919,9 @@ These services provide access to information about job types.
 | interface               | JSON Object       | Optional | JSON description of the interface for running the job.         |
 |                         |                   |          | (See :ref:`architecture_jobs_interface_spec`)                  |
 +-------------------------+-------------------+----------+----------------------------------------------------------------+
+| configuration           | JSON Object       | Optional | JSON description of the configuration for running the job      |
+|                         |                   |          | (See :ref:`architecture_jobs_job_configuration_spec`)          |
++--------------------------+-------------------+--------------------------------------------------------------------------+
 | custom_resources        | JSON Object       | Optional | JSON description for any custom resources needed for running a |
 |                         |                   |          | job of this type. (See :ref:`architecture_jobs_resources`)     |
 +-------------------------+-------------------+----------+----------------------------------------------------------------+
@@ -899,7 +960,7 @@ These services provide access to information about job types.
 |        "interface": {                                                                                                   |
 |            "version": "1.0",                                                                                            |
 |            "command": "test_cmd",                                                                                       |
-|            "command_arguments": "test_arg",                                                                             |
+|            "command_arguments": "test_arg ${dted_path}",                                                                |
 |            "input_data": [                                                                                              |
 |                {                                                                                                        |
 |                    "media_types": ["image/png"],                                                                        |
@@ -907,8 +968,24 @@ These services provide access to information about job types.
 |                    "name": "input_file"                                                                                 |
 |                }                                                                                                        |
 |            ],                                                                                                           |
+|            "settings": [                                                                                                |
+|                {                                                                                                        |
+|                    "name": "dted_path",                                                                                 |
+|                    "required": true,                                                                                    |
+|                    "secret": false                                                                                      |
+|                }                                                                                                        |
+|            ],                                                                                                           |
 |            "output_data": [],                                                                                           |
 |            "shared_resources": []                                                                                       |
+|        },                                                                                                               |
+|        "configuration": {                                                                                               |
+|            "version": "2.0",                                                                                            |
+|            "mounts": {                                                                                                  |
+|                "ref_data": {"type": "host", "host_path": "/path/to/ref_data"}                                           |
+|            },                                                                                                           |
+|            "settings": {                                                                                                |
+|                "dted_path": "/path/to/dted"                                                                             |
+|            }                                                                                                            |
 |        },                                                                                                               |
 |        "custom_resources": {                                                                                            |
 |            "version": "1.0",                                                                                            |
@@ -987,6 +1064,7 @@ These services provide access to information about job types.
 |        "paused": null,                                                                                                  |
 |        "last_modified": "2015-03-11T00:00:00Z",                                                                         |
 |        "interface": {...},                                                                                              |
+|        "configuration": {...},                                                                                          |
 |        "error_mapping": {...},                                                                                          |
 |        "errors": [...],                                                                                                 |
 |        "job_counts_6h": [...],                                                                                          |
@@ -1055,7 +1133,7 @@ These services provide access to information about job types.
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .. code-block:: javascript                                                                                              |
 |                                                                                                                         |
-|   "count": 2,                                                                                                           | 
+|   "count": 2,                                                                                                           |
 |   "next": null,                                                                                                         |
 |   "previous": null,                                                                                                     |
 |   "results": [                                                                                                          |
@@ -1319,7 +1397,7 @@ These services provide access to information about job types.
 |                    "last_modified": "2015-03-11T00:00:00Z"                                                              |
 |                },                                                                                                       |
 |                "count": 38,                                                                                             |
-|                "first_error": "2015-08-28T23:29:28.719Z",                                                               | 
+|                "first_error": "2015-08-28T23:29:28.719Z",                                                               |
 |                "last_error": "2015-09-08T16:27:42.243Z"                                                                 |
 |            },                                                                                                           |
 |            ...                                                                                                          |

--- a/scale/docs/rest/port.rst
+++ b/scale/docs/rest/port.rst
@@ -104,6 +104,7 @@ These services allow administrators to export recipe, job, and error records and
 |                "disk_out_const_required": 64.0,                                                                         |
 |                "disk_out_mult_required": 0.0,                                                                           |
 |                "interface": {...},                                                                                      |
+|                "configuration": {...},                                                                                  |
 |                "error_mapping": {...},                                                                                  |
 |                "trigger_rule": {...}                                                                                    |
 |            },                                                                                                           |

--- a/scale/job/configuration/interface/job_interface.py
+++ b/scale/job/configuration/interface/job_interface.py
@@ -789,7 +789,7 @@ class JobInterface(object):
             if setting_is_secret:
                 job_type_name = job_type.get_job_type_name()
                 job_type_ver = job_type.get_job_type_version()
-                job_index = '-'.join([job_type_name, job_type_ver])
+                job_index = '-'.join([job_type_name, job_type_ver]).replace('.', '_')
 
                 if not secret_settings:
                     secret_settings = secrets_mgr.retrieve_job_type_secrets(job_index)

--- a/scale/job/configuration/json/job/job_config.py
+++ b/scale/job/configuration/json/job/job_config.py
@@ -203,8 +203,7 @@ class JobConfiguration(object):
         warnings = []
 
         settings_to_delete = []
-        if 'settings' in self._configuration and 'settings' in interface and \
-           self._configuration['settings'] is not None and interface['settings'] is not None:
+        if 'settings' in self._configuration and 'settings' in interface:
             interface_settings = interface['settings']
 
             # Remove settings not used in the interface
@@ -221,7 +220,7 @@ class JobConfiguration(object):
                     if setting_name not in settings_to_delete:
                         settings_to_delete.append({'name': setting_name, 'warning': None})
 
-        elif 'settings' in self._configuration and self._configuration['settings'] is not None:
+        elif 'settings' in self._configuration:
             # Remove all settings
             for setting_name in self._configuration['settings']:
                 warning_str = 'Setting %s will be ignored due to no matching interface designation.' % setting_name
@@ -233,8 +232,7 @@ class JobConfiguration(object):
                 warnings.append(ValidationWarning('settings', setting['warning']))
 
         mounts_to_delete = []
-        if 'mounts' in interface and 'mounts' in self._configuration and \
-           self._configuration['mounts'] is not None and interface['mounts'] is not None:
+        if 'mounts' in interface and 'mounts' in self._configuration:
             interface_mounts = interface['mounts']
 
             # Remove mounts not used in the interface
@@ -244,7 +242,7 @@ class JobConfiguration(object):
                     warning_str = 'Mount %s will be ignored due to no matching interface designation.' % mount_name
                     mounts_to_delete.append({'name': mount_name, 'warning': warning_str})
 
-        elif 'mounts' in self._configuration and self._configuration['mounts'] is not None:
+        elif 'mounts' in self._configuration:
             # Remove all mounts
             for mount_name, _mount_value in self._configuration['mounts'].items():
                 warning_str = 'Mount %s will be ignored due to no matching interface designation.' % mount_name

--- a/scale/job/configuration/json/job/job_config.py
+++ b/scale/job/configuration/json/job/job_config.py
@@ -67,6 +67,21 @@ JOB_CONFIG_SCHEMA = {
 }
 
 
+class ValidationWarning(object):
+    """Tracks job configuration warnings during validation that may not prevent the job from working."""
+
+    def __init__(self, key, details):
+        """Constructor sets basic attributes.
+
+        :param key: A unique identifier clients can use to recognize the warning.
+        :type key: string
+        :param details: A user-friendly description of the problem, including field names and/or associated values.
+        :type details: string
+        """
+        self.key = key
+        self.details = details
+
+
 class JobConfiguration(object):
     """Represents the schema for a job configuration"""
 
@@ -140,6 +155,29 @@ class JobConfiguration(object):
 
         return volume
 
+    def get_secret_settings(self, interface):
+        """Returns a dict of configuration settings that are secret based off the job interface
+        setting designations.
+
+        :param interface: The interface for the job type
+        :type interface: :class:`job.configuration.interface.job_interface.JobInterface`
+        :returns: name:value pairs of secret settings, possibly None
+        :rtype: dict
+        """
+
+        secrets = {}
+        interface_dict = interface.get_dict()
+
+        if 'settings' in self._configuration and 'settings' in interface_dict:
+            interface_settings = interface_dict['settings']
+            secret_settings = [setting['name'] for setting in interface_settings if setting['secret']]
+
+            for setting_name in secret_settings:
+                if setting_name in self._configuration['settings']:
+                    secrets[setting_name] = self._configuration['settings'][setting_name]
+
+        return secrets
+
     def get_setting_value(self, name):
         """Returns the value of the given setting if defined in this configuration, otherwise returns None
 
@@ -153,6 +191,63 @@ class JobConfiguration(object):
             return self._configuration['settings'][name]
 
         return None
+
+    def validate(self, interface):
+        """Validates the configuration against the interface to find setting and mount usages
+
+        :param interface: The interface for the job type
+        :type interface: :class:`job.configuration.interface.job_interface.JobInterface`
+        :returns: A list of warnings discovered during validation.
+        :rtype: [:class:`job.configuration.data.job_data.ValidationWarning`]
+        """
+
+        warnings = []
+        interface_dict = interface.get_dict()
+
+        if 'settings' in self._configuration and 'settings' in interface_dict:
+            interface_settings = interface_dict['settings']
+
+            # Detect any secrets and remove them as settings in configuration
+            interface_secret_names = [setting['name'] for setting in interface_settings if setting['secret']]
+            for setting_name in interface_secret_names:
+                if setting_name in self._configuration['settings']:
+                    del self._configuration['settings'][setting_name]
+                    warning_str = 'Setting %s will be handled as a secret based off interface designation.'
+                    warnings.extend(ValidationWarning('settings', warning_str % setting_name))
+
+            # Remove settings not used in the interface
+            interface_setting_names = [setting['name'] for setting in interface_settings]
+            for setting_name in self._configuration['settings']:
+                if setting_name not in interface_setting_names:
+                    del self._configuration['settings'][setting_name]
+                    warning_str = 'Setting %s will be ignored due to no corresponding interface designation.'
+                    warnings.extend(ValidationWarning('settings', warning_str & setting_name))
+
+        elif 'settings' in self._configuration:
+            # Remove all settings
+            for setting_name in self._configuration['settings']:
+                del self._configuration['settings'][setting_name]
+                warning_str = 'Setting %s will be ignored due to no corresponding interface designation.'
+                warnings.extend(ValidationWarning('settings', warning_str & setting_name))
+
+        if 'mounts' in interface_dict and 'mounts' in self._configuration:
+            interface_mounts = interface_dict['mounts']
+
+            # Remove mounts not used in the interface
+            interface_mount_names = [mount['name'] for mount in interface_mounts]
+            for mount in self._configuration['mounts']:
+                if mount['name'] not in interface_mount_names:
+                    del self._configuration['mounts'][mount['name']]
+                    warning_str = 'Mount %s will be ignored due to no corresponding interface designation.'
+                    warnings.extend(ValidationWarning('mounts', warning_str & mount['name']))
+
+        elif 'mounts' in self._configuration:
+            for mount in self._configuration['mounts']:
+                del self._configuration['mounts'][mount]
+                warning_str = 'Mount %s will be ignored due to no corresponding interface designation.'
+                warnings.extend(ValidationWarning('mounts', warning_str & mount['name']))
+
+        return warnings
 
     def _convert_configuration(self):
         """Converts the configuration from a previous schema version

--- a/scale/job/configuration/json/job/job_config.py
+++ b/scale/job/configuration/json/job/job_config.py
@@ -202,7 +202,10 @@ class JobConfiguration(object):
         """
 
         warnings = []
-        interface_dict = interface.get_dict()
+        try:
+            interface_dict = interface.get_dict()
+        except AttributeError:
+            interface_dict = interface
 
         if 'settings' in self._configuration and 'settings' in interface_dict:
             interface_settings = interface_dict['settings']

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1936,7 +1936,7 @@ class JobTypeManager(models.Manager):
 
         # Save any secrets to Vault
         if secrets:
-            job_type.objects.set_job_type_secrets(job_type.id, secrets)
+            self.set_job_type_secrets(job_type.id, secrets)
 
         # Create first revision of the job type
         JobTypeRevision.objects.create_job_type_revision(job_type)
@@ -2041,7 +2041,7 @@ class JobTypeManager(models.Manager):
 
         # Save any secrets to Vault
         if secrets:
-            job_type.objects.set_job_type_secrets(job_type.id, secrets)
+            self.set_job_type_secrets(job_type.id, secrets)
 
         if interface:
             # Create new revision of the job type for new interface
@@ -2323,8 +2323,8 @@ class JobTypeManager(models.Manager):
         """
 
         secrets_handler = SecretsHandler()
-        job_info = JobType.objects.values_list('name', 'version', flat=True).get(pk=job_type_id)
-        job_name = '-'.join([job_info])
+        job_info = JobType.objects.values_list('name', 'version').get(pk=job_type_id)
+        job_name = '-'.join(list(job_info))
 
         secrets_handler.set_job_type_secrets(job_name, secrets)
 

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1921,7 +1921,8 @@ class JobTypeManager(models.Manager):
         job_type.interface = interface.get_dict()
         job_type.trigger_rule = trigger_rule
         if configuration:
-            configuration.validate()
+            configuration = JobConfiguration(job_type.configuration)
+            configuration.validate(job_type.interface)
             job_type.configuration = configuration.get_dict()
         if error_mapping:
             error_mapping.validate()
@@ -2006,8 +2007,9 @@ class JobTypeManager(models.Manager):
                 recipe_type.get_recipe_definition().validate_job_interfaces()
 
         # New job configuration
-        if configuration:
-            configuration.validate()
+        if job_type.configuration:
+            configuration = JobConfiguration(job_type.configuration)
+            configuration.validate(job_type.interface)
             job_type.configuration = configuration.get_dict()
 
         if trigger_rule or remove_trigger_rule:
@@ -2135,8 +2137,10 @@ class JobTypeManager(models.Manager):
         job_type.errors = Error.objects.filter(name__in=error_names) if error_names else []
 
         # Scrub configuration for secrets
-        job_type.configuration.validate(job_type.interface)
-        job_type.configuration = job_type.configuration.get_dict()
+        if job_type.configuration:
+            configuration = JobConfiguration(job_type.configuration)
+            configuration.validate(job_type.interface)
+            job_type.configuration = configuration.get_dict()
 
         # Add recent performance statistics
         started = timezone.now()
@@ -2364,7 +2368,7 @@ class JobTypeManager(models.Manager):
             warnings.extend(trigger_config.validate_trigger_for_job(interface))
 
         if configuration:
-            warnings.extend(configuration.validate())
+            warnings.extend(configuration.validate(interface))
 
         if error_mapping:
             warnings.extend(error_mapping.validate())

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -2366,7 +2366,7 @@ class JobTypeManager(models.Manager):
             warnings.extend(trigger_config.validate_trigger_for_job(interface))
 
         if configuration:
-            warnings.extend(configuration.validate(interface))
+            warnings.extend(configuration.validate(interface.get_dict()))
 
         if error_mapping:
             warnings.extend(error_mapping.validate())

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1932,8 +1932,8 @@ class JobTypeManager(models.Manager):
         return job_type
 
     @transaction.atomic
-    def edit_job_type(self, job_type_id, interface=None, trigger_rule=None, remove_trigger_rule=False,
-                      error_mapping=None, custom_resources=None, **kwargs):
+    def edit_job_type(self, job_type_id, interface=None, configuration=None, trigger_rule=None, 
+                      remove_trigger_rule=False,error_mapping=None, custom_resources=None, **kwargs):
         """Edits the given job type and saves the changes in the database. The caller must provide the related
         trigger_rule model. All database changes occur in an atomic transaction. An argument of None for a field
         indicates that the field should not change. The remove_trigger_rule parameter indicates the difference between
@@ -1943,6 +1943,8 @@ class JobTypeManager(models.Manager):
         :type job_type_id: int
         :param interface: The interface for running a job of this type, possibly None
         :type interface: :class:`job.configuration.interface.job_interface.JobInterface`
+        :param configuration: The configuration for running a job of this type, possibly None
+        :type configuration: :class:`job.configuration.json.job.job_config.JobConfiguration`
         :param trigger_rule: The trigger rule that creates jobs of this type, possibly None
         :type trigger_rule: :class:`trigger.models.TriggerRule`
         :param remove_trigger_rule: Indicates whether the trigger rule should be unchanged (False) or removed (True)
@@ -1988,6 +1990,10 @@ class JobTypeManager(models.Manager):
             job_type.save()
             for recipe_type in recipe_types:
                 recipe_type.get_recipe_definition().validate_job_interfaces()
+
+        # New job configuration
+        if configuration:
+            job_type.configuration = configuration.get_dict()
 
         if trigger_rule or remove_trigger_rule:
             if job_type.trigger_rule:

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -2324,7 +2324,7 @@ class JobTypeManager(models.Manager):
 
         secrets_handler = SecretsHandler()
         job_info = JobType.objects.values_list('name', 'version').get(pk=job_type_id)
-        job_name = '-'.join(list(job_info))
+        job_name = '-'.join(list(job_info)).replace('.', '_')
 
         secrets_handler.set_job_type_secrets(job_name, secrets)
 

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1921,7 +1921,6 @@ class JobTypeManager(models.Manager):
         job_type.interface = interface.get_dict()
         job_type.trigger_rule = trigger_rule
         if configuration:
-            configuration = JobConfiguration(job_type.configuration)
             configuration.validate(job_type.interface)
             job_type.configuration = configuration.get_dict()
         if error_mapping:
@@ -2008,7 +2007,6 @@ class JobTypeManager(models.Manager):
 
         # New job configuration
         if job_type.configuration:
-            configuration = JobConfiguration(job_type.configuration)
             configuration.validate(job_type.interface)
             job_type.configuration = configuration.get_dict()
 

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1955,7 +1955,6 @@ class JobTypeManager(models.Manager):
         :type custom_resources: :class:`node.resources.json.resources.Resources`
         :param configuration: The configuration for running a job of this type, possibly None
         :type configuration: :class:`job.configuration.json.job.job_config.JobConfiguration`
-        
         :param secrets: Secret settings required by this job type
         :type secrets: dict
 

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -2006,7 +2006,7 @@ class JobTypeManager(models.Manager):
                 recipe_type.get_recipe_definition().validate_job_interfaces()
 
         # New job configuration
-        if job_type.configuration:
+        if configuration:
             configuration.validate(job_type.interface)
             job_type.configuration = configuration.get_dict()
 

--- a/scale/job/serializers.py
+++ b/scale/job/serializers.py
@@ -63,6 +63,7 @@ class JobTypeDetailsSerializer(JobTypeSerializer):
     from trigger.serializers import TriggerRuleDetailsSerializer
 
     interface = serializers.JSONField(default=dict)
+    configuration = serializers.JSONField(default=dict)
     custom_resources = serializers.JSONField(source='convert_custom_resources')
     error_mapping = serializers.JSONField(default=dict)
     errors = ErrorSerializer(many=True)

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -1369,8 +1369,8 @@ class TestJobTypeDetailsView(TestCase):
         }
 
         interface = self.interface.copy()
-        interface['settings'] = None
-        interface['mounts'] = None
+        interface['settings'] = []
+        interface['mounts'] = []
 
         new_job_type = job_test_utils.create_job_type(interface=interface, error_mapping=self.error_mapping,
                                                       trigger_rule=self.trigger_rule, max_scheduled=2,

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -805,7 +805,7 @@ class TestJobTypesView(TestCase):
         self.assertEqual(results['id'], job_type.id)
 
         # Secrets sent to Vault
-        secrets_name = '-'.join([json_data['name'], json_data['version']])
+        secrets_name = '-'.join([json_data['name'], json_data['version']]).replace('.', '_')
         secrets = json_data['configuration']['settings']
         mock_set_secret.assert_called_once_with(secrets_name, secrets)
 
@@ -1489,7 +1489,7 @@ class TestJobTypeDetailsView(TestCase):
         self.assertEqual(result['trigger_rule']['id'], self.trigger_rule.id)
 
         # Secrets sent to Vault
-        secrets_name = '-'.join([result['name'], result['version']])
+        secrets_name = '-'.join([result['name'], result['version']]).replace('.', '_')
         secrets = configuration['settings']
         mock_set_secret.assert_called_once_with(secrets_name, secrets)
 

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -18,6 +18,7 @@ import trigger.test.utils as trigger_test_utils
 import util.rest as rest_util
 from error.models import Error
 from job.models import JobType
+from vault.secrets_handler import SecretsHandler
 
 
 class TestJobsView(TestCase):
@@ -742,6 +743,75 @@ class TestJobTypesView(TestCase):
         self.assertIsNotNone(results['configuration']['mounts'])
         self.assertIsNotNone(results['configuration']['settings'])
 
+    def test_create_secrets(self):
+        """Tests creating a new job type with secrets."""
+        url = rest_util.get_url('/job-types/')
+        json_data = {
+            'name': 'job-type-post-test-secret',
+            'version': '1.0.0',
+            'title': 'Job Type Post Test',
+            'description': 'This is a test.',
+            'priority': '1',
+            'interface': {
+                'version': '1.4',
+                'command': 'test_cmd',
+                'command_arguments': 'test_arg ${DB_HOST}',
+                'mounts': [{
+                    'name': 'dted',
+                    'path': '/some/path',
+                    }],
+                'settings': [{
+                    'name': 'DB_HOST',
+                    'required': True,
+                    'secret': True,
+                }],
+                'input_data': [],
+                'output_data': [],
+                'shared_resources': [],
+            },
+            'configuration': {
+                'version': '2.0',
+                'mounts': {
+                    'dted': {'type': 'host',
+                             'host_path': '/path/to/dted'}
+                },
+                'settings': {
+                    'DB_HOST': 'scale'
+                }
+            },
+            'error_mapping': {
+                'version': '1.0',
+                'exit_codes': {
+                    '1': self.error.name,
+                },
+            },
+            'custom_resources': {
+                'version': '1.0',
+                'resources': {
+                    'foo': 10.0
+                }
+            }
+        }
+
+        with patch.object(SecretsHandler, '__init__', return_value=None), \
+          patch.object(SecretsHandler, 'set_job_type_secrets', return_value=None) as mock_set_secret:
+            response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+        job_type = JobType.objects.filter(name='job-type-post-test-secret').first()
+
+        results = json.loads(response.content)
+        self.assertEqual(results['id'], job_type.id)
+
+        # Secrets sent to Vault
+        secrets_name = '-'.join([json_data['name'], json_data['version']])
+        secrets = json_data['configuration']['settings']
+        mock_set_secret.assert_called_once_with(secrets_name, secrets)
+
+        #Secrets scrubbed from configuration on return
+        self.assertEqual(results['configuration']['settings'], {})
+
     def test_create_max_scheduled(self):
         """Tests creating a new job type."""
         url = rest_util.get_url('/job-types/')
@@ -1144,11 +1214,33 @@ class TestJobTypeDetailsView(TestCase):
             'command': 'test_cmd',
             'command_arguments': 'test_arg',
             'env_vars': [],
-            'mounts': [],
-            'settings': [],
+            'mounts': [{
+                'name': 'dted',
+                'path': '/some/path',
+                'required': True,
+                'mode': 'ro'
+            }],
+            'settings': [{
+                'name': 'DB_HOST',
+                'required': True,
+                'secret': False,
+            }],
             'input_data': [],
             'output_data': [],
             'shared_resources': [],
+        }
+
+        self.configuration = {
+            'version': '2.0',
+            'mounts': {
+                'dted': {
+                    'type': 'host',
+                    'host_path': '/path/to/dted',
+                    },
+            },
+            'settings': {
+                'DB_HOST': 'scale',
+            },
         }
 
         self.error = error_test_utils.create_error(category='ALGORITHM')
@@ -1174,7 +1266,8 @@ class TestJobTypeDetailsView(TestCase):
                                                                    configuration=self.trigger_config)
 
         self.job_type = job_test_utils.create_job_type(interface=self.interface, error_mapping=self.error_mapping,
-                                                       trigger_rule=self.trigger_rule, max_scheduled=2)
+                                                       trigger_rule=self.trigger_rule, max_scheduled=2,
+                                                       configuration=self.configuration)
         self.error1 = error_test_utils.create_error()
         self.error2 = error_test_utils.create_error()
 
@@ -1208,6 +1301,97 @@ class TestJobTypeDetailsView(TestCase):
         self.assertEqual(len(result['job_counts_6h']), 0)
         self.assertEqual(len(result['job_counts_12h']), 0)
         self.assertEqual(len(result['job_counts_24h']), 0)
+
+    def test_successful_get_secrets(self):
+        """Tests getting a job_type with associated secrets and extra mounts"""
+
+        configuration = self.configuration.copy()
+        configuration['mounts'] = {
+            'dted': {
+                'type': 'host',
+                'host_path': '/path/to/dted',
+            },
+            'ref_data': {
+                'type': 'host',
+                'host_path': '/path/to/ref_data',
+            }
+        }
+        configuration['settings'] = {
+            'DB_HOST': 'scale',
+            'OTHER_DB': 'other_scale'
+        }
+
+        interface = self.interface.copy()
+        interface['settings'] = [{
+            'name': 'DB_HOST',
+            'required': True,
+            'secret': True,
+        }]
+
+        new_job_type = job_test_utils.create_job_type(interface=interface, error_mapping=self.error_mapping,
+                                                      trigger_rule=self.trigger_rule, max_scheduled=2,
+                                                      configuration=configuration)
+
+        url = rest_util.get_url('/job-types/%d/' % new_job_type.id)
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+
+        self.assertEqual(result['id'], new_job_type.id)
+        self.assertEqual(result['name'], new_job_type.name)
+        self.assertEqual(result['version'], new_job_type.version)
+
+        # Check extra and secret settings removed
+        self.assertEqual(result['configuration']['settings'], {})
+
+        # Check extra mount removed
+        self.assertEqual(result['configuration']['mounts'], self.configuration['mounts'])
+
+    def test_successful_no_settings(self):
+        """Tests getting a job_type with no settings in interface (but defined in configuration)"""
+
+        configuration = self.configuration.copy()
+        configuration['mounts'] = {
+            'dted': {
+                'type': 'host',
+                'host_path': '/path/to/dted',
+            },
+            'ref_data': {
+                'type': 'host',
+                'host_path': '/path/to/ref_data',
+            }
+        }
+        configuration['settings'] = {
+            'DB_HOST': 'scale',
+            'OTHER_DB': 'other_scale'
+        }
+
+        interface = self.interface.copy()
+        interface['settings'] = None
+        interface['mounts'] = None
+
+        new_job_type = job_test_utils.create_job_type(interface=interface, error_mapping=self.error_mapping,
+                                                      trigger_rule=self.trigger_rule, max_scheduled=2,
+                                                      configuration=configuration)
+
+        url = rest_util.get_url('/job-types/%d/' % new_job_type.id)
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+
+        self.assertEqual(result['id'], new_job_type.id)
+        self.assertEqual(result['name'], new_job_type.name)
+        self.assertEqual(result['version'], new_job_type.version)
+
+        # Check extra settings removed
+        self.assertEqual(result['configuration']['settings'], {})
+
+        # Check extra mounts removed
+        self.assertEqual(result['configuration']['mounts'], {})
 
     def test_edit_simple(self):
         """Tests editing only the basic attributes of a job type"""
@@ -1248,6 +1432,69 @@ class TestJobTypeDetailsView(TestCase):
         self.assertEqual(result['revision_num'], 2)
         self.assertEqual(result['interface']['command'], 'test_cmd_edit')
         self.assertEqual(result['trigger_rule']['id'], self.trigger_rule.id)
+
+    def test_edit_configuration(self):
+        """Tests editing the configuration of a job type"""
+        configuration = self.configuration.copy()
+        configuration['settings'] = {'DB_HOST': 'other_scale_db'}
+        configuration['mounts'] = {
+            'dted': {
+                'type': 'host',
+                'host_path': '/some/new/path'
+                }
+            }
+
+        url = rest_util.get_url('/job-types/%d/' % self.job_type.id)
+        json_data = {
+            'configuration': configuration,
+        }
+        response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(result['id'], self.job_type.id)
+        self.assertEqual(result['title'], self.job_type.title)
+        self.assertEqual(result['revision_num'], 1)
+        self.assertEqual(result['configuration']['settings'], {'DB_HOST': 'other_scale_db'})
+        self.assertEqual(result['configuration']['mounts']['dted'], {'type': 'host', 'host_path': '/some/new/path'})
+        self.assertEqual(result['trigger_rule']['id'], self.trigger_rule.id)
+
+    def test_edit_configuration_secret(self):
+        """Tests editing the configuration of a job type with secrets"""
+        configuration = self.configuration.copy()
+
+        interface = self.interface.copy()
+        interface['settings'] = [{
+            'name': 'DB_HOST',
+            'required': True,
+            'secret': True,
+        }]
+
+        url = rest_util.get_url('/job-types/%d/' % self.job_type.id)
+        json_data = {
+            'configuration': configuration,
+            'interface': interface,
+        }
+
+        with patch.object(SecretsHandler, '__init__', return_value=None), \
+          patch.object(SecretsHandler, 'set_job_type_secrets', return_value=None) as mock_set_secret:
+            response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(result['id'], self.job_type.id)
+        self.assertEqual(result['title'], self.job_type.title)
+        self.assertEqual(result['revision_num'], 2)
+        self.assertEqual(result['trigger_rule']['id'], self.trigger_rule.id)
+
+        # Secrets sent to Vault
+        secrets_name = '-'.join([result['name'], result['version']])
+        secrets = configuration['settings']
+        mock_set_secret.assert_called_once_with(secrets_name, secrets)
+
+        #Secrets scrubbed from configuration on return
+        self.assertEqual(result['configuration']['settings'], {})
 
     def test_edit_error_mapping(self):
         """Tests editing the error mapping of a job type"""
@@ -2475,4 +2722,3 @@ class TestJobExecutionSpecificLogView(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         self.assertEqual(response.accepted_media_type, 'application/json')
-        

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -2058,8 +2058,7 @@ class TestJobTypesValidationView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         results = json.loads(response.content)
-        self.assertEqual(len(results['warnings']), 1)
-        self.assertEqual(results['warnings'][0]['id'], 'settings')
+        self.assertEqual(len(results['warnings']), 0)
 
     def test_bad_param(self):
         """Tests validating a new job type with missing fields."""

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -209,9 +209,11 @@ class JobTypeDetailsView(GenericAPIView):
             if configuration_dict:
                 configuration = JobConfiguration(configuration_dict)
                 if interface:
+                    secrets = configuration.get_secret_settings(interface)
                     configuration.validate(interface)
                 else:
                     stored_interface = JobType.objects.values_list('interface', flat=True).get(pk=job_type_id)
+                    secrets = configuration.get_secret_settings(stored_interface)
                     configuration.validate(JobInterface(stored_interface))
         except InvalidJobConfiguration as ex:
             raise BadParameter('Job type configuration invalid: %s' % unicode(ex))
@@ -292,7 +294,7 @@ class JobTypeDetailsView(GenericAPIView):
                 # Edit the job type
                 JobType.objects.edit_job_type(job_type_id, interface, configuration, trigger_rule,
                                               remove_trigger_rule, error_mapping, custom_resources,
-                                              **extra_fields)
+                                              secrets, **extra_fields)
         except (InvalidJobField, InvalidTriggerType, InvalidTriggerRule, InvalidConnection, InvalidDefinition,
                 ValueError) as ex:
             logger.exception('Unable to update job type: %i', job_type_id)

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -95,8 +95,8 @@ class JobTypesView(ListCreateAPIView):
         try:
             if configuration_dict:
                 configuration = JobConfiguration(configuration_dict)
-                secrets = configuration.get_secret_settings(interface)
-                configuration.validate(interface)
+                secrets = configuration.get_secret_settings(interface.get_dict())
+                configuration.validate(interface.get_dict())
         except InvalidJobConfiguration as ex:
             raise BadParameter('Job type configuration invalid: %s' % unicode(ex))
 
@@ -204,7 +204,7 @@ class JobTypeDetailsView(GenericAPIView):
     def patch(self, request, job_type_id):
         """Edits an existing job type and returns the updated details
 
-        :param request: the HTTP POST request
+        :param request: the HTTP PATCH request
         :type request: :class:`rest_framework.request.Request`
         :param job_type_id: The ID for the job type.
         :type job_type_id: int encoded as a str
@@ -229,12 +229,12 @@ class JobTypeDetailsView(GenericAPIView):
             if configuration_dict:
                 configuration = JobConfiguration(configuration_dict)
                 if interface:
-                    secrets = configuration.get_secret_settings(interface)
-                    configuration.validate(interface)
+                    secrets = configuration.get_secret_settings(interface.get_dict())
+                    configuration.validate(interface.get_dict())
                 else:
                     stored_interface = JobType.objects.values_list('interface', flat=True).get(pk=job_type_id)
                     secrets = configuration.get_secret_settings(stored_interface)
-                    configuration.validate(JobInterface(stored_interface))
+                    configuration.validate(stored_interface)
         except InvalidJobConfiguration as ex:
             raise BadParameter('Job type configuration invalid: %s' % unicode(ex))
 

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -94,13 +94,8 @@ class JobTypesView(ListCreateAPIView):
         try:
             if configuration_dict:
                 configuration = JobConfiguration(configuration_dict)
-                if interface:
-                    secrets = configuration.get_secret_settings(interface)
-                    configuration.validate(interface)
-                else:
-                    stored_interface = JobType.objects.values_list('interface', flat=True).get(pk=job_type_id)
-                    secrets = configuration.get_secret_settings(stored_interface)
-                    configuration.validate(JobInterface(stored_interface))
+                secrets = configuration.get_secret_settings(interface)
+                configuration.validate(interface)
         except InvalidJobConfiguration as ex:
             raise BadParameter('Job type configuration invalid: %s' % unicode(ex))
 

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -32,6 +32,7 @@ from queue.models import Queue
 from trigger.configuration.exceptions import InvalidTriggerRule, InvalidTriggerType
 import util.rest as rest_util
 from util.rest import BadParameter
+from vault.exceptions import InvalidSecretsConfiguration
 
 logger = logging.getLogger(__name__)
 
@@ -161,7 +162,8 @@ class JobTypesView(ListCreateAPIView):
                                                            configuration=configuration, secrets=secrets,
                                                            **extra_fields)
 
-        except (InvalidJobField, InvalidTriggerType, InvalidTriggerRule, InvalidConnection, ValueError) as ex:
+        except (InvalidJobField, InvalidTriggerType, InvalidTriggerRule, InvalidConnection, 
+                InvalidSecretsConfiguration, ValueError) as ex:
             logger.exception('Unable to create new job type: %s', name)
             raise BadParameter(unicode(ex))
 
@@ -316,7 +318,7 @@ class JobTypeDetailsView(GenericAPIView):
                                               custom_resources=custom_resources, configuration=configuration,
                                               secrets=secrets, **extra_fields)
         except (InvalidJobField, InvalidTriggerType, InvalidTriggerRule, InvalidConnection, InvalidDefinition,
-                ValueError) as ex:
+                InvalidSecretsConfiguration, ValueError) as ex:
             logger.exception('Unable to update job type: %i', job_type_id)
             raise BadParameter(unicode(ex))
 

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -202,9 +202,10 @@ class JobTypeDetailsView(GenericAPIView):
         except InvalidInterfaceDefinition as ex:
             raise BadParameter('Job type interface invalid: %s' % unicode(ex))
 
-        # Validate the job configuration
+        # Validate the job configuration and pull out secrets
         configuration_dict = rest_util.parse_dict(request, 'configuration', required=False)
         configuration = None
+        secrets = None
         try:
             if configuration_dict:
                 configuration = JobConfiguration(configuration_dict)

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -292,9 +292,10 @@ class JobTypeDetailsView(GenericAPIView):
                     job_type.trigger_rule.save()
 
                 # Edit the job type
-                JobType.objects.edit_job_type(job_type_id, interface, configuration, trigger_rule,
-                                              remove_trigger_rule, error_mapping, custom_resources,
-                                              secrets, **extra_fields)
+                JobType.objects.edit_job_type(job_type_id=job_type_id, interface=interface, trigger_rule=trigger_rule,
+                                              remove_trigger_rule=remove_trigger_rule, error_mapping=error_mapping,
+                                              custom_resources=custom_resources, configuration=configuration,
+                                              secrets=secrets, **extra_fields)
         except (InvalidJobField, InvalidTriggerType, InvalidTriggerRule, InvalidConnection, InvalidDefinition,
                 ValueError) as ex:
             logger.exception('Unable to update job type: %i', job_type_id)

--- a/scale/port/exporter.py
+++ b/scale/port/exporter.py
@@ -7,6 +7,7 @@ from django.db.models import Q
 
 import port.serializers as serializers
 from error.models import Error
+from job.configuration.json.job.job_config import JobConfiguration
 from job.models import JobType
 from port.schema import Configuration
 from recipe.models import RecipeType
@@ -75,6 +76,12 @@ def get_job_types(recipe_types=None, job_type_ids=None, job_type_names=None, job
         job_types = job_types.filter(name__in=job_type_names)
     if job_type_categories:
         job_types = job_types.filter(category__in=job_type_categories)
+
+    # Scrub configuration for secrets
+    for job_type in job_types:
+        if job_type.configuration:
+            job_type.configuration.validate(job_type.interface)
+            job_type.configuration = job_type.configuration.get_dict()
 
     return job_types
 

--- a/scale/port/exporter.py
+++ b/scale/port/exporter.py
@@ -80,8 +80,9 @@ def get_job_types(recipe_types=None, job_type_ids=None, job_type_names=None, job
     # Scrub configuration for secrets
     for job_type in job_types:
         if job_type.configuration:
-            job_type.configuration.validate(job_type.interface)
-            job_type.configuration = job_type.configuration.get_dict()
+            configuration = JobConfiguration(job_type.configuration)
+            configuration.validate(job_type.interface)
+            job_type.configuration = configuration.get_dict()
 
     return job_types
 

--- a/scale/port/importer.py
+++ b/scale/port/importer.py
@@ -408,7 +408,8 @@ def _import_job_type(job_type_dict, job_type=None):
     # Edit or create the associated job type model
     if job_type:
         try:
-            JobType.objects.edit_job_type(job_type.id, interface, trigger_rule, remove_trigger_rule, error_mapping,
+            JobType.objects.edit_job_type(job_type.id, interface=interface, trigger_rule=trigger_rule,
+                                          remove_trigger_rule=remove_trigger_rule, error_mapping=error_mapping,
                                           **extra_fields)
         except (InvalidJobField, InvalidTriggerType, InvalidTriggerRule, InvalidConnection, InvalidDefinition) as ex:
             logger.exception('Job type edit failed')

--- a/scale/port/importer.py
+++ b/scale/port/importer.py
@@ -355,7 +355,7 @@ def _import_job_type(job_type_dict, job_type=None):
     except InvalidInterfaceDefinition as ex:
         raise InvalidConfiguration('Job type interface invalid: %s -> %s' % (result.get('name'), unicode(ex)))
 
-    # Validate the job configuration 
+    # Validate the job configuration
     try:
         configuration_dict = None
         secrets = None
@@ -366,7 +366,7 @@ def _import_job_type(job_type_dict, job_type=None):
         if interface:
             configuration = JobConfiguration(configuration_dict)
             secrets = configuration.get_secret_settings(interface)
-            configuration.validate(interface)
+            warnings.extend(configuration.validate(interface))
     except InvalidJobConfiguration as ex:
         raise InvalidConfiguration('Job type configuration invalid: %s -> %s' % (result.get('name'), unicode(ex)))
 

--- a/scale/port/importer.py
+++ b/scale/port/importer.py
@@ -26,6 +26,7 @@ from recipe.models import RecipeType
 from recipe.triggers.configuration.trigger_rule import RecipeTriggerRuleConfiguration
 from trigger.models import TriggerRule
 from trigger.configuration.exceptions import InvalidTriggerType, InvalidTriggerRule
+from vault.exceptions import InvalidSecretsConfiguration
 
 logger = logging.getLogger(__name__)
 
@@ -433,7 +434,8 @@ def _import_job_type(job_type_dict, job_type=None, validating=False):
             JobType.objects.edit_job_type(job_type.id, interface=interface, trigger_rule=trigger_rule,
                                           remove_trigger_rule=remove_trigger_rule, error_mapping=error_mapping,
                                           configuration=configuration, secrets=secrets, **extra_fields)
-        except (InvalidJobField, InvalidTriggerType, InvalidTriggerRule, InvalidConnection, InvalidDefinition) as ex:
+        except (InvalidJobField, InvalidTriggerType, InvalidTriggerRule, InvalidConnection, InvalidDefinition,
+                InvalidSecretsConfiguration) as ex:
             logger.exception('Job type edit failed')
             raise InvalidConfiguration('Unable to edit existing job type: %s -> %s' % (result.get('name'), unicode(ex)))
     else:
@@ -442,7 +444,8 @@ def _import_job_type(job_type_dict, job_type=None, validating=False):
                                             interface=interface, trigger_rule=trigger_rule,
                                             error_mapping=error_mapping, configuration=configuration, secrets=secrets,
                                             **extra_fields)
-        except (InvalidJobField, InvalidTriggerType, InvalidTriggerRule, InvalidConnection, InvalidDefinition) as ex:
+        except (InvalidJobField, InvalidTriggerType, InvalidTriggerRule, InvalidConnection, InvalidDefinition,
+                InvalidSecretsConfiguration) as ex:
             logger.exception('Job type create failed')
             raise InvalidConfiguration('Unable to create new job type: %s -> %s' % (result.get('name'), unicode(ex)))
     return warnings

--- a/scale/port/importer.py
+++ b/scale/port/importer.py
@@ -371,8 +371,8 @@ def _import_job_type(job_type_dict, job_type=None, validating=False):
         if interface:
             configuration = JobConfiguration(configuration_dict)
             if not validating:
-                secrets = configuration.get_secret_settings(interface)
-            warnings.extend(configuration.validate(interface))
+                secrets = configuration.get_secret_settings(interface.get_dict())
+            warnings.extend(configuration.validate(interface.get_dict()))
     except InvalidJobConfiguration as ex:
         raise InvalidConfiguration('Job type configuration invalid: %s -> %s' % (result.get('name'), unicode(ex)))
 

--- a/scale/port/serializers.py
+++ b/scale/port/serializers.py
@@ -71,7 +71,7 @@ class ConfigurationJobTypeSerializer(serializers.ModelSerializer):
         fields = ('name', 'version', 'title', 'description', 'category', 'author_name', 'author_url', 'is_operational',
                   'icon_code', 'docker_privileged', 'docker_image', 'priority', 'timeout', 'max_scheduled', 'max_tries',
                   'cpus_required', 'mem_required', 'mem_const_required', 'mem_mult_required', 'disk_out_const_required',
-                  'disk_out_mult_required', 'interface', 'error_mapping', 'trigger_rule')
+                  'disk_out_mult_required', 'interface', 'error_mapping', 'trigger_rule', 'configuration')
 
 
 class ConfigurationRecipeTypeSerializer(serializers.ModelSerializer):

--- a/scale/port/serializers.py
+++ b/scale/port/serializers.py
@@ -62,6 +62,7 @@ class ConfigurationJobTypeSerializer(serializers.ModelSerializer):
     disk_out_mult_required = serializers.FloatField(required=False)
 
     interface = serializers.JSONField(required=False)
+    configuration = serializers.JSONField(required=False)
     error_mapping = serializers.JSONField(allow_null=True, required=False)
     trigger_rule = ConfigurationTriggerRuleSerializer(allow_null=True, required=False)
 

--- a/scale/port/test/test_views.py
+++ b/scale/port/test/test_views.py
@@ -2133,8 +2133,8 @@ class TestConfigurationValidationView(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         results = json.loads(response.content)
-        self.assertEqual(len(results['warnings']), 3)
-        self.assertEqual(len([warning for warning in results['warnings'] if warning['id'] == 'settings']), 2)
+        self.assertEqual(len(results['warnings']), 2)
+        self.assertEqual(len([warning for warning in results['warnings'] if warning['id'] == 'settings']), 1)
         self.assertEqual(len([warning for warning in results['warnings'] if warning['id'] == 'mounts']), 1)
 
     def test_errors(self):

--- a/scale/port/test/test_views.py
+++ b/scale/port/test/test_views.py
@@ -674,7 +674,7 @@ class TestConfigurationViewImport(TestCase):
 
         # Secrets sent to Vault
         secrets_name = '-'.join([json_data['import']['job_types'][0]['name'],
-                                 json_data['import']['job_types'][0]['version']])
+                                 json_data['import']['job_types'][0]['version']]).replace('.', '_')
         secrets = {'DB_PASS': 'elacs'}
         mock_set_secret.assert_called_once_with(secrets_name, secrets)
 

--- a/scale/port/test/test_views.py
+++ b/scale/port/test/test_views.py
@@ -4,6 +4,7 @@ import json
 
 import django
 from django.test.testcases import TestCase, TransactionTestCase
+from mock import patch
 from rest_framework import status
 
 import error.test.utils as error_test_utils
@@ -15,6 +16,7 @@ import util.rest as rest_util
 from error.models import Error
 from job.models import JobType
 from recipe.models import RecipeType
+from vault.secrets_handler import SecretsHandler
 
 
 class TestConfigurationViewExport(TransactionTestCase):
@@ -272,6 +274,69 @@ class TestConfigurationViewExport(TransactionTestCase):
         self.assertEqual(len(results['errors']), 1)
         self.assertEqual(results['errors'][0]['name'], error2.name)
 
+    def test_job_type_configuration(self):
+        """Tests effectiveness of configuration.validate() when exporting ."""
+
+        interface = {
+            'version': '1.4',
+            'command': 'test_cmd',
+            'command_arguments': 'test_arg, ${SECRET_SETTING} ${DB_HOST}',
+            'env_vars': [],
+            'mounts': [
+                {
+                    'name': 'dted',
+                    'path': '/some/path',
+                    'mode': 'ro',
+                    'required': True,
+                }
+            ],
+            'settings': [
+                {
+                    'name': 'SECRET_SETTING',
+                    'required': True,
+                    'secret': True,
+                },
+                {
+                    'name': 'DB_HOST',
+                    'required': True,
+                    'secret': False,
+                }
+            ],
+            'input_data': [],
+            'output_data': [],
+            'shared_resources': [],
+        }
+
+        configuration = {
+            'version': '2.0',
+            'mounts': {
+                'dted': {
+                    'type': 'host',
+                    'host_path': '/path/to/dted'
+                },
+                'UNUSED_MOUNT': {
+                    'type': 'host',
+                    'host_path': '/path/to/ref_data'
+                },
+            },
+            'settings': {
+                'SECRET_SETTING': 'elacs',
+                'DB_HOST': 'scale',
+                'UNUSED_SETTING': 'val',
+            },
+        }
+
+        job_type2 = job_test_utils.create_job_type(interface=interface, configuration=configuration)
+
+        url = rest_util.get_url('/configuration/?&job_type_name=%s' % (job_type2.name))
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+
+        self.assertTrue('UNUSED_SETTING' not in result['job_types'][0]['configuration']['settings'])
+        self.assertTrue('SECRET_SETTING' not in result['job_types'][0]['configuration']['settings'])
+        self.assertTrue('UNUSED_MOUNT' not in result['job_types'][0]['configuration']['mounts'])
 
 class TestConfigurationViewImport(TestCase):
     """Tests related to the configuration import endpoint"""
@@ -460,14 +525,52 @@ class TestConfigurationViewImport(TestCase):
         interface = {
             'version': '1.4',
             'command': 'test_cmd',
-            'command_arguments': 'test_arg',
+            'command_arguments': 'test_arg, ${DB_PASS} ${DB_HOST}',
             'env_vars': [],
-            'mounts': [],
-            'settings': [],
+            'mounts': [
+                {
+                    'name': 'dted',
+                    'path': '/some/path',
+                    'mode': 'ro',
+                    'required': True,
+                }
+            ],
+            'settings': [
+                {
+                    'name': 'DB_PASS',
+                    'required': True,
+                    'secret': True,
+                },
+                {
+                    'name': 'DB_HOST',
+                    'required': True,
+                    'secret': False,
+                }
+            ],
             'input_data': [],
             'output_data': [],
             'shared_resources': [],
         }
+
+        configuration = {
+            'version': '2.0',
+            'mounts': {
+                'dted': {
+                    'type': 'host',
+                    'host_path': '/path/to/dted'
+                },
+                'UNUSED_MOUNT': {
+                    'type': 'host',
+                    'host_path': '/path/to/ref_data'
+                },
+            },
+            'settings': {
+                'DB_PASS': 'elacs',
+                'DB_HOST': 'scale',
+                'UNUSED_SETTING': 'val',
+            },
+        }
+
         error_mapping = {
             'version': '1.0',
             'exit_codes': {
@@ -511,6 +614,7 @@ class TestConfigurationViewImport(TestCase):
                     'disk_out_const_required': 1024.0,
                     'disk_out_mult_required': 1.0,
                     'interface': interface,
+                    'configuration': configuration,
                     'error_mapping': error_mapping,
                     'trigger_rule': {
                         'type': 'PARSE',
@@ -523,7 +627,11 @@ class TestConfigurationViewImport(TestCase):
         }
 
         url = rest_util.get_url('/configuration/')
-        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+
+        with patch.object(SecretsHandler, '__init__', return_value=None), \
+          patch.object(SecretsHandler, 'set_job_type_secrets', return_value=None) as mock_set_secret:
+            response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         json.loads(response.content)
@@ -560,6 +668,15 @@ class TestConfigurationViewImport(TestCase):
         self.assertEqual(result.trigger_rule.name, 'test-name')
         self.assertFalse(result.trigger_rule.is_active)
         self.assertDictEqual(result.trigger_rule.configuration, trigger_rule_config)
+
+        self.assertTrue('UNUSED_SETTING' not in result.configuration['settings'])
+        self.assertTrue('UNUSED_MOUNT' not in result.configuration['mounts'])
+
+        # Secrets sent to Vault
+        secrets_name = '-'.join([json_data['import']['job_types'][0]['name'],
+                                 json_data['import']['job_types'][0]['version']])
+        secrets = {'DB_PASS': 'elacs'}
+        mock_set_secret.assert_called_once_with(secrets_name, secrets)
 
     def test_job_types_edit_simple(self):
         """Tests importing only job types that update basic models."""
@@ -1954,6 +2071,71 @@ class TestConfigurationValidationView(TestCase):
         recipe_types = RecipeType.objects.filter(name=recipe_type.name, version=recipe_type.version)
         self.assertEqual(len(recipe_types), 1)
         self.assertEqual(recipe_types[0].title, recipe_type.title)
+
+    def test_job_type_configuration(self):
+        """Tests validating with warnings in the configuration."""
+
+        error = error_test_utils.create_error(category='DATA')
+        job_type = job_test_utils.create_job_type()
+        recipe_type = recipe_test_utils.create_recipe_type()
+
+        configuration = {
+            'version': '2.0',
+            'mounts': {
+                'dted': {'type': 'host',
+                         'host_path': '/path/to/dted'}
+            },
+            'settings': {
+                'DB_HOST': 'scale',
+                'DB_USER': 'elacs'
+            }
+        }
+
+        interface = {
+            'version': '1.4',
+            'command': 'test_cmd',
+            'command_arguments': 'test_arg',
+            'mounts': [],
+            'settings': [{
+                'name': 'DB_HOST',
+                'required': True,
+                'secret': True,
+            }],
+            'input_data': [],
+            'output_data': [],
+            'shared_resources': [],
+        }
+
+        json_data = {
+            'import': {
+                'errors': [{
+                    'name': error.name,
+                    'title': 'test-error-title',
+                    'category': 'ALGORITHM',
+                }],
+                'job_types': [{
+                    'name': job_type.name,
+                    'version': job_type.version,
+                    'title': 'test-job-title',
+                    'interface': interface,
+                    'configuration': configuration
+                }],
+                'recipe_types': [{
+                    'name': recipe_type.name,
+                    'version': recipe_type.version,
+                    'title': 'test-recipe-title',
+                }],
+            },
+        }
+
+        url = rest_util.get_url('/configuration/validation/')
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        self.assertEqual(len(results['warnings']), 3)
+        self.assertEqual(len([warning for warning in results['warnings'] if warning['id'] == 'settings']), 2)
+        self.assertEqual(len([warning for warning in results['warnings'] if warning['id'] == 'mounts']), 1)
 
     def test_errors(self):
         """Tests validating an edit of all types with a critical error."""

--- a/scale/scale/local_settings_docker.py
+++ b/scale/scale/local_settings_docker.py
@@ -8,7 +8,7 @@ import elasticsearch
 SECRET_KEY = os.environ.get('SCALE_SECRET_KEY', INSECURE_DEFAULT_KEY)
 
 # Use the following lines to enable developer/debug mode.
-DEBUG = os.environ.get('SCALE_DEBUG') in ['True', 'TRUE', 'true', '1', 'yes']
+DEBUG = os.environ.get('SCALE_DEBUG').lower() in ['true', '1', 't']
 TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
 
 # Set the external URL context here, default to using SCRIPT_NAME passed by reverse proxy.
@@ -113,4 +113,4 @@ SECRETS_TOKEN = os.environ.get('SECRETS_TOKEN', None)
 # DCOS service account name, or None if not DCOS secrets store
 DCOS_SERVICE_ACCOUNT = os.environ.get('DCOS_SERVICE_ACCOUNT', None)
 # Flag for raising SSL warnings associated with secrets transactions.
-SECRETS_SSL_WARNINGS = os.environ.get('SECRETS_SSL_WARNINGS') not in ['False', 'FALSE', 'false', '0', 'no']
+SECRETS_SSL_WARNINGS = os.environ.get('SECRETS_SSL_WARNINGS').lower() not in ['false', '0', 'f']

--- a/scale/scale/local_settings_docker.py
+++ b/scale/scale/local_settings_docker.py
@@ -113,4 +113,4 @@ SECRETS_TOKEN = os.environ.get('SECRETS_TOKEN', None)
 # DCOS service account name, or None if not DCOS secrets store
 DCOS_SERVICE_ACCOUNT = os.environ.get('DCOS_SERVICE_ACCOUNT', None)
 # Flag for raising SSL warnings associated with secrets transactions.
-SECRETS_SSL_WARNINGS = os.environ.get('SECRETS_SSL_TRANSACTION_WARNINGS') not in ['False', 'FALSE', 'false', '0', 'no']
+SECRETS_SSL_WARNINGS = os.environ.get('SECRETS_SSL_WARNINGS') not in ['False', 'FALSE', 'false', '0', 'no']

--- a/scale/scale/local_settings_docker.py
+++ b/scale/scale/local_settings_docker.py
@@ -8,7 +8,7 @@ import elasticsearch
 SECRET_KEY = os.environ.get('SCALE_SECRET_KEY', INSECURE_DEFAULT_KEY)
 
 # Use the following lines to enable developer/debug mode.
-DEBUG = bool(os.environ.get('SCALE_DEBUG', False))
+DEBUG = os.environ.get('SCALE_DEBUG') in ['True', 'TRUE', 'true', '1', 'yes']
 TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
 
 # Set the external URL context here, default to using SCRIPT_NAME passed by reverse proxy.
@@ -113,4 +113,4 @@ SECRETS_TOKEN = os.environ.get('SECRETS_TOKEN', None)
 # DCOS service account name, or None if not DCOS secrets store
 DCOS_SERVICE_ACCOUNT = os.environ.get('DCOS_SERVICE_ACCOUNT', None)
 # Flag for raising SSL warnings associated with secrets transactions.
-SECRETS_SSL_WARNINGS = os.environ.get('SECRETS_SSL_TRANSACTION_WARNINGS', True)
+SECRETS_SSL_WARNINGS = os.environ.get('SECRETS_SSL_TRANSACTION_WARNINGS') not in ['False', 'FALSE', 'false', '0', 'no']

--- a/scale/scale/local_settings_docker.py
+++ b/scale/scale/local_settings_docker.py
@@ -8,7 +8,7 @@ import elasticsearch
 SECRET_KEY = os.environ.get('SCALE_SECRET_KEY', INSECURE_DEFAULT_KEY)
 
 # Use the following lines to enable developer/debug mode.
-DEBUG = os.environ.get('SCALE_DEBUG').lower() in ['true', '1', 't']
+DEBUG = os.environ.get('SCALE_DEBUG', 'false').lower in ('yes', 'true', 't', '1')
 TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
 
 # Set the external URL context here, default to using SCRIPT_NAME passed by reverse proxy.
@@ -113,4 +113,4 @@ SECRETS_TOKEN = os.environ.get('SECRETS_TOKEN', None)
 # DCOS service account name, or None if not DCOS secrets store
 DCOS_SERVICE_ACCOUNT = os.environ.get('DCOS_SERVICE_ACCOUNT', None)
 # Flag for raising SSL warnings associated with secrets transactions.
-SECRETS_SSL_WARNINGS = os.environ.get('SECRETS_SSL_WARNINGS').lower() not in ['false', '0', 'f']
+SECRETS_SSL_WARNINGS = os.environ.get('SECRETS_SSL_WARNINGS', 'true').lower() not in ('no', 'false', 'f', '0')

--- a/scale/scheduler/vault/manager.py
+++ b/scale/scheduler/vault/manager.py
@@ -16,23 +16,23 @@ class SecretsManager(object):
     def __init__(self):
         """Constructor
         """
-        
+
         self._all_secrets = {}
-    
-    def retrieve_job_type_secrets(self, job_name) :
+
+    def retrieve_job_type_secrets(self, job_name):
         """Get the secret values from the cache pertaining to the provided job
-        
-        :param job_name: the name of the job 
+
+        :param job_name: the name of the job
         :param type: string
         :return: job type secrets
         :rtype: dict
         """
-        
+
         if job_name in self._all_secrets:
             secret_values = self._all_secrets[job_name]
         else:
             secret_values = {}
-            
+
         return secret_values
 
     def sync_with_backend(self):
@@ -46,7 +46,7 @@ class SecretsManager(object):
         except (InvalidSecretsAuthorization, InvalidSecretsRequest, InvalidSecretsToken) as e:
             logger.exception('Secrets Error: %s', e.message)
             return
-        
+
         for job in jobs_with_secrets:
             try:
                 job_secrets = sh.get_job_type_secrets(job)

--- a/scale/vault/exceptions.py
+++ b/scale/vault/exceptions.py
@@ -7,6 +7,12 @@ class InvalidSecretsAuthorization(Exception):
     pass
 
 
+class InvalidSecretsConfiguration(Exception):
+    """Exception indicating that the secrets backend is not properly configured
+    """
+    pass
+
+
 class InvalidSecretsRequest(Exception):
     """Exception indicating that the secrets request was invalid
     """

--- a/scale/vault/secrets_handler.py
+++ b/scale/vault/secrets_handler.py
@@ -210,7 +210,7 @@ class SecretsHandler(object):
         try:
             token = jwt.encode({'uid': self.service_account}, self.secrets_token, algorithm='RS256')
         except ValueError:
-            raise InvalidSecretsToken('The provided token could not be encoded: ')
+            raise InvalidSecretsToken('The provided token could not be encoded')
 
         url = self.secrets_url + '/acs/api/v1/auth/login'
         data = json.dumps({

--- a/scale/vault/secrets_handler.py
+++ b/scale/vault/secrets_handler.py
@@ -134,6 +134,11 @@ class SecretsHandler(object):
         secret_values = json.dumps(secrets)
 
         if self.dcos_token:
+            if job_name in self.list_job_types():
+                method = 'PATCH'
+            else:
+                method = 'PUT'
+
             url = ''.join([url, '/secret/default/scale/job-type/', job_name])
             headers = {
                 'Content-Type': 'application/json',
@@ -144,7 +149,8 @@ class SecretsHandler(object):
                 'description': 'Secrets for Scale job ' + job_name,
                 'value': secret_values
             })
-            self._make_request('PUT', url, headers, data)
+
+            self._make_request(method, url, headers, data)
 
         else:
             url = ''.join([url, '/secret/scale/job-type/', job_name])

--- a/scale/vault/secrets_handler.py
+++ b/scale/vault/secrets_handler.py
@@ -117,18 +117,19 @@ class SecretsHandler(object):
 
         return all_job_types
 
-    def set_job_type_secrets(self, job_name, secret_json):
+    def set_job_type_secrets(self, job_name, secrets):
         """write job-type secrets to the secrets backend
 
-        :param job_name: name of the job that the screts belong to.
+        :param job_name: name of the job that the secrets belong to.
+                         Format: [job_name]-[job_version]
         :type job_name: str
-        :param secret_json: dict with name:value pairs for all secrets associated with the job
-        :type secret_json: dict
+        :param secrets: dict with name:value pairs for all secrets associated with the job
+        :type secrets: dict
         :return:
         """
 
         url = self.secrets_url
-        secret_values = json.dumps(secret_json)
+        secret_values = json.dumps(secrets)
 
         if self.dcos_token:
             url = ''.join([url, '/secret/default/scale/job-type/', job_name])

--- a/scale/vault/secrets_handler.py
+++ b/scale/vault/secrets_handler.py
@@ -7,8 +7,8 @@ import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 from django.conf import settings
-from vault.exceptions import InvalidSecretsAuthorization, InvalidSecretsRequest, InvalidSecretsToken, \
-    InvalidSecretsValue
+from vault.exceptions import InvalidSecretsAuthorization, InvalidSecretsConfiguration, InvalidSecretsRequest, \
+    InvalidSecretsToken, InvalidSecretsValue
 
 
 class SecretsHandler(object):
@@ -40,7 +40,9 @@ class SecretsHandler(object):
         if not self.raise_ssl_warnings:
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-        if self.service_account:
+        if not self.secrets_url:
+            raise InvalidSecretsConfiguration('A secrets backend is not properly configured with Scale.')
+        elif self.service_account:
             self.dcos_token = self._dcos_authenticate()
         else:
             self.dcos_token = None

--- a/scale/vault/test/test_secrets_handler.py
+++ b/scale/vault/test/test_secrets_handler.py
@@ -16,9 +16,9 @@ from vault.exceptions import InvalidSecretsAuthorization, InvalidSecretsRequest,
 
 class SecretsBackendValidation(TestCase):
     """Tests performing requests to the secrets backend"""
-    
+
     def setUp(self):
-        
+
         self.dcos_token = \
 """
 -----BEGIN RSA PRIVATE KEY-----
@@ -39,22 +39,22 @@ UB3V/SWf7Wqp9vDEbUtgzIn9y4l5cIjS/J2IKkYARg==
 """
 
         django.setup()
-        
+
     def mocked_validate(*args):
         class MockResponse:
             def __init__(self, json_data, status_code):
                 self.json_data = json_data
                 self.status_code = status_code
-    
+
             def json(self):
                 return self.json_data
-                
+
             def content(self):
                 return self.json_data
-    
-        if not args: 
+
+        if not args:
             return MockResponse({}, 403)
-        
+
         elif args[0] == 'vault':
             r_return = MagicMock()
             r_return.status_code = 200
@@ -68,53 +68,53 @@ UB3V/SWf7Wqp9vDEbUtgzIn9y4l5cIjS/J2IKkYARg==
                     "type": "generic",
                 }
             })
-            
+
             return r_return
-        
+
         elif args[0] == 'dcos':
             status_code = 200
             content = {
                 "token": "some_good_token"
             }
             return MockResponse(content, status_code)
-        
+
         return MockResponse({}, 404)
 
-    @patch('requests.request', return_value=mocked_validate('dcos'))    
+    @patch('requests.request', return_value=mocked_validate('dcos'))
     def test_dcos_authenticate_good_return(self, mock_request):
         with self.settings(SECRETS_TOKEN=self.dcos_token,
-                          DCOS_SERVICE_ACCOUNT='some_account_name',
-                          SECRETS_URL='HTTP://127.0.0.1:8200'):
-            auth_test = SecretsHandler()
+                           DCOS_SERVICE_ACCOUNT='some_account_name',
+                           SECRETS_URL='HTTP://127.0.0.1:8200'):
+            SecretsHandler()
 
-    @patch('requests.request', return_value=mocked_validate('dcos'))    
+    @patch('requests.request', return_value=mocked_validate('dcos'))
     def test_dcos_authenticate_bad_token(self, mock_request):
         with self.settings(SECRETS_TOKEN='some_bad_token',
-                          DCOS_SERVICE_ACCOUNT='some_account_name',
-                          SECRETS_URL='HTTP://127.0.0.1:8200'):
+                           DCOS_SERVICE_ACCOUNT='some_account_name',
+                           SECRETS_URL='HTTP://127.0.0.1:8200'):
             self.assertRaises(InvalidSecretsToken, SecretsHandler)
 
-    @patch('requests.request', return_value=mocked_validate('vault'))    
+    @patch('requests.request', return_value=mocked_validate('vault'))
     def test_vault_authenticate_good_return(self, mock_request):
         with self.settings(SECRETS_TOKEN='some_master_token',
-                          DCOS_SERVICE_ACCOUNT=None,
-                          SECRETS_URL='HTTP://127.0.0.1:8200'):
-            auth_test = SecretsHandler()
+                           DCOS_SERVICE_ACCOUNT=None,
+                           SECRETS_URL='HTTP://127.0.0.1:8200'):
+            SecretsHandler()
 
-    @patch('requests.request', return_value=mocked_validate())    
+    @patch('requests.request', return_value=mocked_validate())
     def test_vault_authenticate_bad_permission(self, mock_request):
         with self.settings(SECRETS_TOKEN='some_master_token',
-                          DCOS_SERVICE_ACCOUNT=None,
-                          SECRETS_URL='HTTP://127.0.0.1:8200'):
+                           DCOS_SERVICE_ACCOUNT=None,
+                           SECRETS_URL='HTTP://127.0.0.1:8200'):
             self.assertRaises(InvalidSecretsAuthorization, SecretsHandler)
-            
-            
+
+
 class VaultSecretsValueValidation(TestCase):
-    """Tests setting and recieving secrets"""
-    
+    """Tests setting and receiving secrets"""
+
     def setUp(self):
         self.secret_test_path = 'job_name-0.0.0'
-        
+
         self.vault_setup()
         django.setup()
 
@@ -123,16 +123,16 @@ class VaultSecretsValueValidation(TestCase):
             def __init__(self, json_data, status_code):
                 self.json_data = json_data
                 self.status_code = status_code
-    
+
             def json(self):
                 return self.json_data
-                
+
             def content(self):
                 return self.json_data
-    
-        if not args: 
+
+        if not args:
             return MockResponse({}, 403)
-        
+
         elif args[0] == 'secret':
             status_code = 200
             content = {
@@ -146,9 +146,9 @@ class VaultSecretsValueValidation(TestCase):
                 },
                 "warnings": "null"
             }
-            
+
             return MockResponse(content, status_code)
-        
+
         return MockResponse({}, 404)
 
     def mocked_request_setup():
@@ -164,34 +164,34 @@ class VaultSecretsValueValidation(TestCase):
                 "type": "generic",
             }
         })
-        
+
         return r_return
 
-    @patch('requests.request', return_value=mocked_request_setup())    
+    @patch('requests.request', return_value=mocked_request_setup())
     def vault_setup(self, mock_request):
         with self.settings(SECRETS_TOKEN='some_master_token',
-                          DCOS_SERVICE_ACCOUNT=None,
-                          SECRETS_URL='HTTP://127.0.0.1:8200'):
+                           DCOS_SERVICE_ACCOUNT=None,
+                           SECRETS_URL='HTTP://127.0.0.1:8200'):
 
             self.vault_backend = SecretsHandler()
 
-    @patch('requests.request', return_value=mocked_get_secret('secret'))    
+    @patch('requests.request', return_value=mocked_get_secret('secret'))
     def test_vault_get_secret(self, mock_request):
         test_secret = self.vault_backend.get_job_type_secrets(self.secret_test_path)
         self.assertEqual(test_secret, {"test_val_name": "vault_backend_secret", "foo": "bar"})
 
-    @patch('requests.request', return_value=mocked_get_secret())    
+    @patch('requests.request', return_value=mocked_get_secret())
     def test_vault_get_bad_secret(self, mock_request):
-        self.assertRaises(InvalidSecretsAuthorization, 
-                          self.vault_backend.get_job_type_secrets, 
+        self.assertRaises(InvalidSecretsAuthorization,
+                          self.vault_backend.get_job_type_secrets,
                           self.secret_test_path)
 
 
 class DCOSSecretsValueValidation(TestCase):
-    """Tests setting and recieving secrets"""
-    
+    """Tests setting and receiving secrets"""
+
     def setUp(self):
-        
+
         self.dcos_token = \
 """
 -----BEGIN RSA PRIVATE KEY-----
@@ -215,20 +215,20 @@ UB3V/SWf7Wqp9vDEbUtgzIn9y4l5cIjS/J2IKkYARg==
 
         self.dcos_setup()
         django.setup()
-        
+
     def mocked_get_secret(*args):
         class MockResponse:
             def __init__(self, json_data, status_code):
                 self.json_data = json_data
                 self.status_code = status_code
-    
+
             def json(self):
                 return self.json_data
-                
+
             def content(self):
                 return self.json_data
-    
-        if not args: 
+
+        if not args:
             return MockResponse({}, 403)
 
         elif args[0] == 'secret':
@@ -237,42 +237,39 @@ UB3V/SWf7Wqp9vDEbUtgzIn9y4l5cIjS/J2IKkYARg==
                 "value": "{'some_name': 'some_secret'}"
                 }
             return MockResponse(content, status_code)
-            
+
         elif args[0] == 'auth':
             status_code = 200
             content = {
                 "value": "dcos_token"
                 }
             return MockResponse(content, status_code)
-    
-        
+
         return MockResponse({}, 404)
-        
+
     def mocked_request_setup():
         r_return = MagicMock()
         r_return.status_code = 200
         r_return.content = {
             'dcos_token': 'foobar'
         }
-        
+
         return r_return
-            
-    @patch('requests.request', return_value=mocked_get_secret('auth'))    
+
+    @patch('requests.request', return_value=mocked_get_secret('auth'))
     def dcos_setup(self, mock_request):
         with self.settings(SECRETS_TOKEN=self.dcos_token,
-                          DCOS_SERVICE_ACCOUNT='some_account_name',
-                          SECRETS_URL='HTTP://127.0.0.1:8200'):
+                           DCOS_SERVICE_ACCOUNT='some_account_name',
+                           SECRETS_URL='HTTP://127.0.0.1:8200'):
             self.dcos_backend = SecretsHandler()
-        
-    @patch('requests.request', return_value=mocked_get_secret('secret'))    
+
+    @patch('requests.request', return_value=mocked_get_secret('secret'))
     def test_dcos_get_secret(self, mock_request):
-            test_secret = self.dcos_backend.get_job_type_secrets(self.secret_test_path)
-            self.assertEqual(test_secret, {'some_name': 'some_secret'})
-    
-    #@patch('vault.secrets_handler.SecretsHandler._make_request', return_value=mocked_get_secret())  
-    @patch('requests.request', return_value=mocked_get_secret())  
+        test_secret = self.dcos_backend.get_job_type_secrets(self.secret_test_path)
+        self.assertEqual(test_secret, {'some_name': 'some_secret'})
+
+    @patch('requests.request', return_value=mocked_get_secret())
     def test_dcos_get_bad_secret(self, mock_request):
-            secret_name = 'test_val_name'
-            self.assertRaises(InvalidSecretsAuthorization, 
-                              self.dcos_backend.get_job_type_secrets,
-                              self.secret_test_path)
+        self.assertRaises(InvalidSecretsAuthorization,
+                          self.dcos_backend.get_job_type_secrets,
+                          self.secret_test_path)


### PR DESCRIPTION
1. Add `configuration` support to the following API endpoints:
    - GET `/job-types/{id}/`
    - POST `/job-types/validation/`
    - PATCH `/job-types/{id}/`
    - POST `/configuration/`
    - GET `/configuration/`
    - POST `/configuration/validation/` 
    - POST `/configuration/`

2. Updated `Vault` app - Added error to for when no secrets backend is configured but someone submits a secret to Scale.
3. Added two functions to job_config: `get_secret_settings` and `validate` - The first gathers the secrets before sending to `Vault` and the last checks for secrets and unused settings, as well as unused mounts, and discards them. 
4. Added function to JobType that will send secrets off to `Vault` 


**I will deploy this in our test_env to ensure it works with Vault.**