### PR TITLE
#938 - Error when generating job_type pointer to a secret setting

### DIFF
--- a/scale/job/configuration/interface/job_interface.py
+++ b/scale/job/configuration/interface/job_interface.py
@@ -499,7 +499,7 @@ class JobInterface(object):
         :type command_arguments: string
         :param exe_configuration: The execution configuration
         :type exe_configuration: :class:`job.configuration.json.execution.exe_config.ExecutionConfiguration`
-        :param job_type: The job type definition 
+        :param job_type: The job type definition
         :type job_type: :class:`job.models.JobType`
         :return: command arguments with the settings populated
         :rtype: str
@@ -520,7 +520,7 @@ class JobInterface(object):
 
         :param exe_configuration: The execution configuration
         :type exe_configuration: :class:`job.configuration.json.execution.exe_config.ExecutionConfiguration`
-        :param job_type: The job type definition 
+        :param job_type: The job type definition
         :type job_type: :class:`job.models.JobType`
 
         :return: env_vars populated with values
@@ -770,6 +770,8 @@ class JobInterface(object):
         :type settings: JSON
         :param exe_configuration: The execution configuration
         :type exe_configuration: :class:`job.configuration.json.execution.exe_config.ExecutionConfiguration`
+        :param job_type: The job type definition
+        :type job_type: :class:`job.models.JobType`
         :return: settings name and the value to replace it with
         :rtype: dict
         """
@@ -787,9 +789,7 @@ class JobInterface(object):
             setting_is_secret = setting['secret']
 
             if setting_is_secret:
-                job_type_name = job_type.get_job_type_name()
-                job_type_ver = job_type.get_job_type_version()
-                job_index = '-'.join([job_type_name, job_type_ver]).replace('.', '_')
+                job_index = job_type.get_secrets_key()
 
                 if not secret_settings:
                     secret_settings = secrets_mgr.retrieve_job_type_secrets(job_index)

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1938,7 +1938,7 @@ class JobTypeManager(models.Manager):
 
         # Save any secrets to Vault
         if secrets:
-            self.set_job_type_secrets(job_type.id, secrets)
+            self.set_job_type_secrets(job_type.get_secrets_key(), secrets)
 
         # Create first revision of the job type
         JobTypeRevision.objects.create_job_type_revision(job_type)
@@ -2043,7 +2043,7 @@ class JobTypeManager(models.Manager):
 
         # Save any secrets to Vault
         if secrets:
-            self.set_job_type_secrets(job_type.id, secrets)
+            self.set_job_type_secrets(job_type.get_secrets_key(), secrets)
 
         if interface:
             # Create new revision of the job type for new interface
@@ -2315,20 +2315,17 @@ class JobTypeManager(models.Manager):
             results.append(status)
         return results
 
-    def set_job_type_secrets(self, job_type_id, secrets):
+    def set_job_type_secrets(self, secrets_key, secrets):
         """Sends request to SecretsHandler to write secrets for a job type.
 
-        :param job_type_id: The ID of the job type
-        :type job_type_id: int
+        :param secrets_key: Reference pointer for job_type settings stored in secrets backend
+        :type secrets_key: str
         :param secrets: Secret settings required by this job type.
         :type secrets: dict
         """
 
         secrets_handler = SecretsHandler()
-        job_info = JobType.objects.values_list('name', 'version').get(pk=job_type_id)
-        job_name = '-'.join(list(job_info)).replace('.', '_')
-
-        secrets_handler.set_job_type_secrets(job_name, secrets)
+        secrets_handler.set_job_type_secrets(secrets_key, secrets)
 
     def validate_job_type(self, name, version, interface, error_mapping=None, trigger_config=None, configuration=None):
         """Validates a new job type prior to attempting a save
@@ -2610,6 +2607,15 @@ class JobType(models.Model):
         cpus = max(self.cpus_required, MIN_CPUS)
         resources.add(NodeResources([Cpus(cpus)]))
         return resources
+
+    def get_secrets_key(self):
+        """Returns the reference key for job type secrets stored in the secrets backend.
+
+        :returns: The job_type name and version concatenated
+        :rtype: str
+        """
+
+        return '-'.join([self.name, self.version]).replace('.', '_')
 
     def natural_key(self):
         """Django method to define the natural key for a job type as the

--- a/scale/job/test/configuration/interface/test_job_interface.py
+++ b/scale/job/test/configuration/interface/test_job_interface.py
@@ -914,7 +914,7 @@ class TestJobInterfacePreSteps(TestCase):
         mock_secrets_mgr.return_value = {
             'setting1': 'secret_val'
         }
-        
+
         job_interface_dict, job_data_dict, job_environment_dict = self._get_simple_interface_data_env()
 
         job_interface_dict['version'] = '1.3'
@@ -934,9 +934,9 @@ class TestJobInterfacePreSteps(TestCase):
         job_config = ExecutionConfiguration(job_config_json)
 
         job_interface = JobInterface(job_interface_dict)
-        job_exe = job_test_utils.create_job_exe(status='QUEUED', configuration=job_config.get_dict())
+        job_type = job_test_utils.create_job_type(interface=job_interface_dict)
 
-        job_command_arguments = job_interface.populate_command_argument_settings(command_arguments, job_config, job_exe)
+        job_command_arguments = job_interface.populate_command_argument_settings(command_arguments, job_config, job_type)
         self.assertEqual(job_command_arguments,
                          ' '.join(config_key_values),
                          'expected a different command from pre_steps')
@@ -1049,7 +1049,7 @@ class TestJobInterfacePreSteps(TestCase):
         mock_secrets_mgr.return_value = {
             'setting1': 'secret_val'
         }
-        
+
         job_interface_dict, job_data_dict, job_environment_dict = self._get_simple_interface_data_env()
 
         job_interface_dict['command_arguments'] = '${setting1}'
@@ -1073,10 +1073,10 @@ class TestJobInterfacePreSteps(TestCase):
         job_interface = JobInterface(job_interface_dict)
         job_config = ExecutionConfiguration(job_config_json)
 
-        job_type = MagicMock()
+        job_type = job_test_utils.create_job_type(interface=job_interface_dict)
         job_exe = job_test_utils.create_job_exe(status='QUEUED', configuration=job_config.get_dict())
 
-        job_interface.populate_command_argument_settings(job_interface_dict['command_arguments'], job_config, job_exe)
+        job_interface.populate_command_argument_settings(job_interface_dict['command_arguments'], job_config, job_type)
 
         try:
             # Validate acceptable job_interface and job_configuration


### PR DESCRIPTION
* Centralized the generation of the job_type secrets key for use with Vault or DC/OS
* Updated methods where the above information is needed
* Fixed bug in test where the wrong instance was being passed