### PR TITLE
Bug fix - don't pass raw dict to configuration.validate()

### DIFF
--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -2139,7 +2139,8 @@ class JobTypeManager(models.Manager):
         # Scrub configuration for secrets
         if job_type.configuration:
             configuration = JobConfiguration(job_type.configuration)
-            configuration.validate(job_type.interface)
+            interface = JobInterface(job_type.interface)
+            configuration.validate(interface.get_dict())
             job_type.configuration = configuration.get_dict()
 
         # Add recent performance statistics

--- a/scale/port/exporter.py
+++ b/scale/port/exporter.py
@@ -7,6 +7,7 @@ from django.db.models import Q
 
 import port.serializers as serializers
 from error.models import Error
+from job.configuration.interface.job_interface import JobInterface
 from job.configuration.json.job.job_config import JobConfiguration
 from job.models import JobType
 from port.schema import Configuration
@@ -81,7 +82,8 @@ def get_job_types(recipe_types=None, job_type_ids=None, job_type_names=None, job
     for job_type in job_types:
         if job_type.configuration:
             configuration = JobConfiguration(job_type.configuration)
-            configuration.validate(job_type.interface)
+            interface = JobInterface(job_type.interface)
+            configuration.validate(interface.get_dict())
             job_type.configuration = configuration.get_dict()
 
     return job_types


### PR DESCRIPTION
🐛 🐞 👣  Scale was passing the job_type interface directly to the configuration validation before running it through the JobInterface class to ensure it is the most recent version. 