### PR TITLE
Issue 953 - Scheduling fix

### DIFF
--- a/scale/queue/job_exe.py
+++ b/scale/queue/job_exe.py
@@ -17,6 +17,7 @@ class QueuedJobExecution(object):
 
         self.id = queue.id
         self.is_canceled = queue.is_canceled
+        self.configuration = queue.get_execution_configuration()
         self.interface = queue.get_job_interface()
         self.priority = queue.priority
         self.required_resources = queue.get_resources()
@@ -43,7 +44,7 @@ class QueuedJobExecution(object):
         job_exe.exe_num = self._queue.exe_num
         job_exe.timeout = self._queue.timeout
         job_exe.input_file_size = self._queue.input_file_size
-        job_exe.configuration = self._queue.get_execution_configuration().get_dict()
+        job_exe.configuration = self.configuration.get_dict()
         job_exe.queued = self._queue.queued
 
         if self.is_canceled:

--- a/scale/scheduler/scheduling/manager.py
+++ b/scale/scheduler/scheduling/manager.py
@@ -327,9 +327,11 @@ class SchedulingManager(object):
                 continue
             workspace_names = job_exe.configuration.get_input_workspace_names()
             workspace_names.extend(job_exe.configuration.get_output_workspace_names())
+            missing_workspace = False
             for name in workspace_names:
-                if name not in workspaces:
-                    continue
+                missing_workspace = missing_workspace or name not in workspaces
+            if missing_workspace:
+                continue
 
             # Check limit for this execution's job type
             if job_type_id in job_type_limits and job_type_limits[job_type_id] < 1:


### PR DESCRIPTION
This PR is a scheduling fix that ignores queued jobs if the job references a job type or workspace that has not been synced to the scheduler yet. This can happen when a script loads things into Scale so quickly that the scheduler gets a job and doesn't know about its job type or workspaces yet.