### PR TITLE
#952 - Docker cleanup fails on created containers

### DIFF
--- a/scale/job/execution/tasks/cleanup_task.py
+++ b/scale/job/execution/tasks/cleanup_task.py
@@ -41,6 +41,7 @@ class CleanupTask(NodeTask):
         self._running_timeout_threshold = datetime.timedelta(minutes=10)
 
         # Define basic command pieces
+        if_cmd = 'if %s ; then %s ; else %s ; fi'
         for_cmd = 'for %s in `%s`; do %s; done'
         all_containers_cmd = 'docker ps -a --format \'{{.Names}}\''
         nonrunning_filters = '-f status=created -f status=dead -f status=exited'
@@ -49,6 +50,7 @@ class CleanupTask(NodeTask):
         all_scale_dangling_volumes_cmd = 'docker volume ls -f dangling=true -q | grep scale_'
         container_delete_cmd = 'docker rm $cont'
         volume_delete_cmd = 'docker volume rm $vol'
+        is_scale_container = 'docker inspect $cont | grep -q %s' % framework_id
 
         # Create commands that list the containers/volumes to delete
         if self._is_initial_cleanup:
@@ -59,6 +61,9 @@ class CleanupTask(NodeTask):
             # (without grep) starting with "scale_" (and also dangling)
             # Initial clean up deletes all dangling Docker volumes named with "scale_" prefix
             volume_list_cmd = all_scale_dangling_volumes_cmd
+
+            #We do not need to delete any stuck containers on initial cleanup
+            delete_stuck_container_cmd = ':'
         else:
             # Deletes all containers and volumes for the given job executions
             containers = []
@@ -71,11 +76,17 @@ class CleanupTask(NodeTask):
             container_list_cmd = '%s | grep -e %s' % (all_containers_cmd, ' -e '.join(containers))
             volume_list_cmd = '%s | grep -e %s' % (all_volumes_cmd, ' -e '.join(volumes))
 
+            #Delete containers that are stuck so that volumes can be cleaned up properly
+            delete_stuck_container_cmd = for_cmd % ('cont',
+                                                    all_nonrunning_containers_cmd,
+                                                    if_cmd % (is_scale_container, container_delete_cmd, ':'))
+
+
         delete_containers_cmd = for_cmd % ('cont', container_list_cmd, container_delete_cmd)
         delete_volumes_cmd = for_cmd % ('vol', volume_list_cmd, volume_delete_cmd)
 
         # Create overall command that deletes containers and volumes for the job executions
-        self._command = '%s; %s' % (delete_containers_cmd, delete_volumes_cmd)
+        self._command = '%s; %s; %s' % (delete_containers_cmd, delete_stuck_container_cmd, delete_volumes_cmd)
 
         # Node task properties
         self.task_type = 'cleanup'

--- a/scale/job/execution/tasks/cleanup_task.py
+++ b/scale/job/execution/tasks/cleanup_task.py
@@ -62,7 +62,7 @@ class CleanupTask(NodeTask):
             # Initial clean up deletes all dangling Docker volumes named with "scale_" prefix
             volume_list_cmd = all_scale_dangling_volumes_cmd
 
-            #We do not need to delete any stuck containers on initial cleanup
+            # We do not need to delete any stuck containers on initial cleanup
             delete_stuck_container_cmd = ':'
         else:
             # Deletes all containers and volumes for the given job executions
@@ -76,7 +76,7 @@ class CleanupTask(NodeTask):
             container_list_cmd = '%s | grep -e %s' % (all_containers_cmd, ' -e '.join(containers))
             volume_list_cmd = '%s | grep -e %s' % (all_volumes_cmd, ' -e '.join(volumes))
 
-            #Delete containers that are stuck so that volumes can be cleaned up properly
+            # Delete containers that are stuck so that volumes can be cleaned up properly
             delete_stuck_container_cmd = for_cmd % ('cont',
                                                     all_nonrunning_containers_cmd,
                                                     if_cmd % (is_scale_container, container_delete_cmd, ':'))


### PR DESCRIPTION
Added a bit of bash to detect any scale containers that are in a stuck state and delete them.  This will then allow the dangling volumes to be deleted. 

UPDATE: Tested on `dev`, everything appears to work well. 