### PR TITLE
#997: Update docs and broker logic for AMQP / SQS messaging

### DIFF
--- a/scale/docs/architecture/messaging.rst
+++ b/scale/docs/architecture/messaging.rst
@@ -16,7 +16,7 @@ Our general recommendation is to use Amazon SQS, as this will require the least 
 *SCALE_BROKER_URL* environment variable is used by Scale to configure your chosen message broker. When left unset, RabbitMQ will be deployed alongside.
 Specific examples of this format will be given for each message broker below. This variable is provided in the format:
 
-``transport://[userid:password@]hostname[:port]//``
+``transport://[userid:password@]hostname[:port][/virtualhost]``
 
 *SCALE_QUEUE_NAME* environment variable is used to modify the default queue name of ``scale-command-messages``. It applies to all message brokers.
 
@@ -56,12 +56,14 @@ this section can be entirely omitted. Based on the above examples your environme
 
 **API Keys:** 
 
-SCALE_BROKER_URL: ``sqs://accesskeyid:secretaccesskey@us-east-1//``
+SCALE_BROKER_URL: ``sqs://accesskeyid:secretaccesskey@us-east-1``
+
 SCALE_QUEUE_NAME: ``scale-command-message``
 
 **IAM Roles:** 
 
-SCALE_BROKER_URL: ``sqs://us-east-1//``
+SCALE_BROKER_URL: ``sqs://us-east-1``
+
 SCALE_QUEUE_NAME: ``scale-command-message``
 
 --------------------------------------------------------------------------------

--- a/scale/util/test/test_broker.py
+++ b/scale/util/test/test_broker.py
@@ -19,41 +19,38 @@ class TestBroker(TestCase):
         self.assertEqual(broker.get_user_name(), 'access')
         self.assertEqual(broker.get_password(), 'secret')
         self.assertEqual(broker.get_address(), 'us-east-1')
+        self.assertEqual(broker.get_virtual_host(), '/')
 
     def test_valid_sqs_broker_url_no_credentials(self):
         """Tests instantiating broker from URL for SQS without keys."""
-        broker_url = 'sqs://us-east-1//'
+        broker_url = 'sqs://us-east-1'
         broker = BrokerDetails.from_broker_url(broker_url)
 
         self.assertEqual(broker.get_type(), 'sqs')
         self.assertIsNone(broker.get_user_name())
         self.assertIsNone(broker.get_password())
         self.assertEqual(broker.get_address(), 'us-east-1')
+        self.assertIsNone(broker.get_virtual_host())
 
     def test_valid_rabbitmq_broker_url(self):
         """Tests instantiating broker from URL for RabbitMQ."""
-        broker_url = 'amqp://guest:pass@localhost:5672//'
+        broker_url = 'amqp://guest:pass@localhost:5672/custom'
         broker = BrokerDetails.from_broker_url(broker_url)
 
         self.assertEqual(broker.get_type(), 'amqp')
         self.assertEqual(broker.get_user_name(), 'guest')
         self.assertEqual(broker.get_password(), 'pass')
         self.assertEqual(broker.get_address(), 'localhost:5672')
+        self.assertEqual(broker.get_virtual_host(), 'custom')
 
     def test_bad_credentials_broker_url(self):
         """Tests instantiating broker from invalid URL with credential delimiter."""
-        broker_url = 'sqs://@us-east-1//'
+        broker_url = 'sqs://@us-east-1'
         with self.assertRaises(InvalidBrokerUrl):
             BrokerDetails.from_broker_url(broker_url)
 
     def test_missing_solidus_credentials_broker_url(self):
         """Tests instantiating broker from invalid URL missing double solidus delimiter."""
-        broker_url = 'sqs:/us-east-1//'
-        with self.assertRaises(InvalidBrokerUrl):
-            BrokerDetails.from_broker_url(broker_url)
-
-    def test_missing_terminators_credentials_broker_url(self):
-        """Tests instantiating broker from invalid URL missing terminating double solidus."""
-        broker_url = 'sqs://us-east-1'
+        broker_url = 'sqs:/us-east-1'
         with self.assertRaises(InvalidBrokerUrl):
             BrokerDetails.from_broker_url(broker_url)


### PR DESCRIPTION
* Updated docs to clean up formatting.
* Updated docs to remove requirement for trailing solidus. Solidus only needed when specifying broker virtual host
* Added support with regex to extract virtual host and eliminate trailing solidus requirement. 