### PR TITLE
#983 - Create new job execution REST APIs

### DIFF
--- a/scale/docs/rest/job.rst
+++ b/scale/docs/rest/job.rst
@@ -1179,3 +1179,203 @@ These services provide access to information about "all", "currently running" an
 |        ]                                                                                                                |
 |    }                                                                                                                    |
 +-------------------------------------------------------------------------------------------------------------------------+
+
+.. _rest_job_execution_list:
+
++-------------------------------------------------------------------------------------------------------------------------+
+| **Job Executions List**                                                                                                 |
++=========================================================================================================================+
+| Returns detailed information about input files associated with a given Job ID.                                          |
++-------------------------------------------------------------------------------------------------------------------------+
+| **GET** /jobs/{id}/executions/                                                                                          |
+|         Where {id} is the unique identifier of an existing job.                                                         |
++-------------------------------------------------------------------------------------------------------------------------+
+| **Query Parameters**                                                                                                    |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| started            | ISO-8601 Datetime | Optional | The start of the time range to query.                               |
+|                    |                   |          | Supports the ISO-8601 date/time format, (ex: 2015-01-01T00:00:00Z). |
+|                    |                   |          | Supports the ISO-8601 duration format, (ex: PT3H0M0S).              |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| ended              | ISO-8601 Datetime | Optional | The end of the time range to query.                                 |
+|                    |                   |          | Supports the ISO-8601 date/time format, (ex: 2015-01-01T00:00:00Z). |
+|                    |                   |          | Supports the ISO-8601 duration format, (ex: PT3H0M0S).              |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| status             | String            | Optional | Return only executions with a status matching this string.          |
+|                    |                   |          | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].            |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| node_id            | Integer           | Optional | Return only executions that ran on a given node.                    |
+|                    |                   |          | Duplicate it to filter by multiple values.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| **Successful Response**                                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Status**         | 200 OK                                                                                             |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Content Type**   | *application/json*                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| count              | Integer           | The total number of results that match the query parameters.                   |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| next               | URL               | A URL to the next page of results.                                             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| previous           | URL               | A URL to the previous page of results.                                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| results            | Array             | List of result JSON objects that match the query parameters.                   |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .id                | Integer           | The unique identifier of the model. Can be passed to the details API call.     |
+|                    |                   | (See :ref:`Job Execution Details <rest_job_execution_details>`)                |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .status            | String            | The status of the job execution.                                               |
+|                    |                   | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].                       |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .command_arguments | String            | The argument string to execute on the command line for this job execution.     | 
+|                    |                   | This field is populated when the job execution is scheduled to run on a node   |
+|                    |                   | and is updated when any needed pre-job steps are run.                          |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .timeout           | Integer           | The maximum amount of time this job can run before being killed (in seconds).  |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .pre_started       | ISO-8601 Datetime | When the pre-job steps were started on a node.                                 |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .pre_completed     | ISO-8601 Datetime | When the pre-job steps were completed on a node.                               |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .pre_exit_code     | Integer           | The exit code of the pre-steps job process for this job execution.             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .job_started       | ISO-8601 Datetime | When the actual job started running on a node.                                 |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .job_completed     | ISO-8601 Datetime | When the actual job completed running on a node.                               |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .job_exit_code     | Integer           | The exit code of the main job process for this job execution.                  |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .post_started      | ISO-8601 Datetime | When the post-job steps were started on a node.                                |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .post_completed    | ISO-8601 Datetime | When the post-job steps were completed on a node.                              |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .post_exit_code    | Integer           | The exit code of the post-steps job process for this job execution.            |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .created           | ISO-8601 Datetime | When the associated database model was initially created.                      |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .queued            | ISO-8601 Datetime | When the job was added to the queue for this run and went to QUEUED status.    |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .started           | ISO-8601 Datetime | When the job was scheduled and went to RUNNING status.                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .ended             | ISO-8601 Datetime | When the job execution ended. (FAILED, COMPLETED, or CANCELED)                 |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .last_modified     | ISO-8601 Datetime | When the associated database model was last saved.                             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .job               | JSON Object       | The job that is associated with the execution.                                 |
+|                    |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .node              | JSON Object       | The node that ran the execution.                                               |
+|                    |                   | (See :ref:`Node Details <rest_node_details>`)                                  |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .error             | JSON Object       | The last error that was recorded for the execution.                            |
+|                    |                   | (See :ref:`Error Details <rest_error_details>`)                                |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+
+
+| cluster_id         | String            | When the job was scheduled and went to RUNNING status.                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| input_file_size    | ISO-8601 Datetime | When the job execution ended. (FAILED, COMPLETED, or CANCELED)                 |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| cpus_scheduled     | ISO-8601 Datetime | When the associated database model was last saved.                             |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| mem_scheduled      | JSON Object       | The job that is associated with the execution.                                 |
+|                    |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| disk_out_scheduled | JSON Object       | The node that ran the execution.                                               |
+|                    |                   | (See :ref:`Node Details <rest_node_details>`)                                  |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| disk_in_scheduled  | JSON Object       | The last error that was recorded for the execution.                            |
+|                    |                   | (See :ref:`Error Details <rest_error_details>`)                                |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| disk_in_scheduled  | JSON Object       | The last error that was recorded for the execution.                            |
+|                    |                   | (See :ref:`Error Details <rest_error_details>`)                                |
+
+
+
+
+"exe_num": 3,                                                                                            |
+|                "cluster_id": "scale_job_1234_267x0",                                                                    |
+|                "input_file_size": 10.0,                                                                                 |
+|                "cpus_scheduled": 1.0,                                                                                   |
+|                "mem_scheduled": 256,                                                                                    |
+|                "disk_out_scheduled": 10.0,                                                                              |
+|                "disk_in_scheduled": 10.0,                                                                               |
+|                "disk_total_scheduled": 20.0
+
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| .. code-block:: javascript                                                                                              |
+|                                                                                                                         |
+|    {                                                                                                                    |
+|        "count": 57,                                                                                                     | 
+|        "next": null,                                                                                                    |
+|        "previous": null,                                                                                                |
+|        "results": [                                                                                                     |
+|            {                                                                                                            |
+|                "id": 3,                                                                                                 |
+|                "status": "COMPLETED",                                                                                   |
+|                "command_arguments": "",                                                                                 |
+|                "timeout": 1800,                                                                                         |
+|                "pre_started": null,                                                                                     |
+|                "pre_completed": null,                                                                                   |
+|                "pre_exit_code": null,                                                                                   |
+|                "job_started": "2015-08-28T17:57:44.703Z",                                                               |
+|                "job_completed": "2015-08-28T17:57:45.906Z",                                                             |
+|                "job_exit_code": null,                                                                                   |
+|                "post_started": null,                                                                                    |
+|                "post_completed": null,                                                                                  |
+|                "post_exit_code": null,                                                                                  |
+|                "created": "2015-08-28T17:57:41.033Z",                                                                   |
+|                "queued": "2015-08-28T17:57:41.010Z",                                                                    |
+|                "started": "2015-08-28T17:57:44.494Z",                                                                   |
+|                "ended": "2015-08-28T17:57:45.906Z",                                                                     |
+|                "last_modified": "2015-08-28T17:57:45.992Z",                                                             |
+|                "job": {                                                                                                 |
+|                    "id": 3,                                                                                             |
+|                    "job_type": {                                                                                        |
+|                        "id": 1,                                                                                         |
+|                        "name": "scale-ingest",                                                                          |
+|                        "version": "1.0",                                                                                |
+|                        "title": "Scale Ingest",                                                                         |
+|                        "description": "Ingests a source file into a workspace",                                         |
+|                        "category": "system",                                                                            |
+|                        "author_name": null,                                                                             |
+|                        "author_url": null,                                                                              |
+|                        "is_system": true,                                                                               |
+|                        "is_long_running": false,                                                                        |
+|                        "is_active": true,                                                                               |
+|                        "is_operational": true,                                                                          |
+|                        "is_paused": false,                                                                              |
+|                        "icon_code": "f013"                                                                              |
+|                    },                                                                                                   |
+|                    "job_type_rev": {                                                                                    |
+|                        "id": 2                                                                                          |
+|                    },                                                                                                   |
+|                    "event": {                                                                                           |
+|                        "id": 3                                                                                          |
+|                    },                                                                                                   |
+|                    "error": null,                                                                                       |
+|                    "status": "COMPLETED",                                                                               |
+|                    "priority": 10,                                                                                      |
+|                    "num_exes": 1                                                                                        |
+|                },                                                                                                       |
+|                "node": {                                                                                                |
+|                    "id": 1,                                                                                             |
+|                    "hostname": "machine.com",                                                                           |
+|                    "port": 5051,                                                                                        |
+|                    "slave_id": "20150821-123454-1683014024-5050-8216-S2"                                                |
+|                },                                                                                                       |
+|                "error": null,                                                                                           |
+|                "exe_num": 3,                                                                                            |
+|                "cluster_id": "scale_job_1234_267x0",                                                                    |
+|                "input_file_size": 10.0,                                                                                 |
+|                "cpus_scheduled": 1.0,                                                                                   |
+|                "mem_scheduled": 256,                                                                                    |
+|                "disk_out_scheduled": 10.0,                                                                              |
+|                "disk_in_scheduled": 10.0                                                                                |
+|            },                                                                                                           |
+|            ...                                                                                                          |
+|        ]                                                                                                                |
+|    }                                                                                                                    |
++-------------------------------------------------------------------------------------------------------------------------+

--- a/scale/docs/rest/job.rst
+++ b/scale/docs/rest/job.rst
@@ -1180,202 +1180,184 @@ These services provide access to information about "all", "currently running" an
 |    }                                                                                                                    |
 +-------------------------------------------------------------------------------------------------------------------------+
 
-.. _rest_job_execution_list:
+.. _rest_job_executions_list:
 
-+-------------------------------------------------------------------------------------------------------------------------+
-| **Job Executions List**                                                                                                 |
-+=========================================================================================================================+
-| Returns detailed information about input files associated with a given Job ID.                                          |
-+-------------------------------------------------------------------------------------------------------------------------+
-| **GET** /jobs/{id}/executions/                                                                                          |
-|         Where {id} is the unique identifier of an existing job.                                                         |
-+-------------------------------------------------------------------------------------------------------------------------+
-| **Query Parameters**                                                                                                    |
-+--------------------+-------------------+----------+---------------------------------------------------------------------+
-| started            | ISO-8601 Datetime | Optional | The start of the time range to query.                               |
-|                    |                   |          | Supports the ISO-8601 date/time format, (ex: 2015-01-01T00:00:00Z). |
-|                    |                   |          | Supports the ISO-8601 duration format, (ex: PT3H0M0S).              |
-+--------------------+-------------------+----------+---------------------------------------------------------------------+
-| ended              | ISO-8601 Datetime | Optional | The end of the time range to query.                                 |
-|                    |                   |          | Supports the ISO-8601 date/time format, (ex: 2015-01-01T00:00:00Z). |
-|                    |                   |          | Supports the ISO-8601 duration format, (ex: PT3H0M0S).              |
-+--------------------+-------------------+----------+---------------------------------------------------------------------+
-| status             | String            | Optional | Return only executions with a status matching this string.          |
-|                    |                   |          | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].            |
-|                    |                   |          | Duplicate it to filter by multiple values.                          |
-+--------------------+-------------------+----------+---------------------------------------------------------------------+
-| node_id            | Integer           | Optional | Return only executions that ran on a given node.                    |
-|                    |                   |          | Duplicate it to filter by multiple values.                          |
-+--------------------+-------------------+----------+---------------------------------------------------------------------+
-| **Successful Response**                                                                                                 |
-+--------------------+----------------------------------------------------------------------------------------------------+
-| **Status**         | 200 OK                                                                                             |
-+--------------------+----------------------------------------------------------------------------------------------------+
-| **Content Type**   | *application/json*                                                                                 |
-+--------------------+----------------------------------------------------------------------------------------------------+
-| **JSON Fields**                                                                                                         |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| count              | Integer           | The total number of results that match the query parameters.                   |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| next               | URL               | A URL to the next page of results.                                             |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| previous           | URL               | A URL to the previous page of results.                                         |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| results            | Array             | List of result JSON objects that match the query parameters.                   |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .id                | Integer           | The unique identifier of the model. Can be passed to the details API call.     |
-|                    |                   | (See :ref:`Job Execution Details <rest_job_execution_details>`)                |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .status            | String            | The status of the job execution.                                               |
-|                    |                   | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].                       |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .command_arguments | String            | The argument string to execute on the command line for this job execution.     | 
-|                    |                   | This field is populated when the job execution is scheduled to run on a node   |
-|                    |                   | and is updated when any needed pre-job steps are run.                          |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .timeout           | Integer           | The maximum amount of time this job can run before being killed (in seconds).  |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .pre_started       | ISO-8601 Datetime | When the pre-job steps were started on a node.                                 |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .pre_completed     | ISO-8601 Datetime | When the pre-job steps were completed on a node.                               |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .pre_exit_code     | Integer           | The exit code of the pre-steps job process for this job execution.             |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .job_started       | ISO-8601 Datetime | When the actual job started running on a node.                                 |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .job_completed     | ISO-8601 Datetime | When the actual job completed running on a node.                               |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .job_exit_code     | Integer           | The exit code of the main job process for this job execution.                  |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .post_started      | ISO-8601 Datetime | When the post-job steps were started on a node.                                |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .post_completed    | ISO-8601 Datetime | When the post-job steps were completed on a node.                              |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .post_exit_code    | Integer           | The exit code of the post-steps job process for this job execution.            |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .created           | ISO-8601 Datetime | When the associated database model was initially created.                      |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .queued            | ISO-8601 Datetime | When the job was added to the queue for this run and went to QUEUED status.    |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .started           | ISO-8601 Datetime | When the job was scheduled and went to RUNNING status.                         |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .ended             | ISO-8601 Datetime | When the job execution ended. (FAILED, COMPLETED, or CANCELED)                 |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .last_modified     | ISO-8601 Datetime | When the associated database model was last saved.                             |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .job               | JSON Object       | The job that is associated with the execution.                                 |
-|                    |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .node              | JSON Object       | The node that ran the execution.                                               |
-|                    |                   | (See :ref:`Node Details <rest_node_details>`)                                  |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .error             | JSON Object       | The last error that was recorded for the execution.                            |
-|                    |                   | (See :ref:`Error Details <rest_error_details>`)                                |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-
-
-| cluster_id         | String            | When the job was scheduled and went to RUNNING status.                         |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| input_file_size    | ISO-8601 Datetime | When the job execution ended. (FAILED, COMPLETED, or CANCELED)                 |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| cpus_scheduled     | ISO-8601 Datetime | When the associated database model was last saved.                             |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| mem_scheduled      | JSON Object       | The job that is associated with the execution.                                 |
-|                    |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| disk_out_scheduled | JSON Object       | The node that ran the execution.                                               |
-|                    |                   | (See :ref:`Node Details <rest_node_details>`)                                  |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| disk_in_scheduled  | JSON Object       | The last error that was recorded for the execution.                            |
-|                    |                   | (See :ref:`Error Details <rest_error_details>`)                                |
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| disk_in_scheduled  | JSON Object       | The last error that was recorded for the execution.                            |
-|                    |                   | (See :ref:`Error Details <rest_error_details>`)                                |
-
-
-
-
-"exe_num": 3,                                                                                            |
-|                "cluster_id": "scale_job_1234_267x0",                                                                    |
-|                "input_file_size": 10.0,                                                                                 |
-|                "cpus_scheduled": 1.0,                                                                                   |
-|                "mem_scheduled": 256,                                                                                    |
-|                "disk_out_scheduled": 10.0,                                                                              |
-|                "disk_in_scheduled": 10.0,                                                                               |
-|                "disk_total_scheduled": 20.0
-
-+--------------------+-------------------+--------------------------------------------------------------------------------+
-| .. code-block:: javascript                                                                                              |
-|                                                                                                                         |
-|    {                                                                                                                    |
-|        "count": 57,                                                                                                     | 
-|        "next": null,                                                                                                    |
-|        "previous": null,                                                                                                |
-|        "results": [                                                                                                     |
-|            {                                                                                                            |
-|                "id": 3,                                                                                                 |
-|                "status": "COMPLETED",                                                                                   |
-|                "command_arguments": "",                                                                                 |
-|                "timeout": 1800,                                                                                         |
-|                "pre_started": null,                                                                                     |
-|                "pre_completed": null,                                                                                   |
-|                "pre_exit_code": null,                                                                                   |
-|                "job_started": "2015-08-28T17:57:44.703Z",                                                               |
-|                "job_completed": "2015-08-28T17:57:45.906Z",                                                             |
-|                "job_exit_code": null,                                                                                   |
-|                "post_started": null,                                                                                    |
-|                "post_completed": null,                                                                                  |
-|                "post_exit_code": null,                                                                                  |
-|                "created": "2015-08-28T17:57:41.033Z",                                                                   |
-|                "queued": "2015-08-28T17:57:41.010Z",                                                                    |
-|                "started": "2015-08-28T17:57:44.494Z",                                                                   |
-|                "ended": "2015-08-28T17:57:45.906Z",                                                                     |
-|                "last_modified": "2015-08-28T17:57:45.992Z",                                                             |
-|                "job": {                                                                                                 |
-|                    "id": 3,                                                                                             |
-|                    "job_type": {                                                                                        |
-|                        "id": 1,                                                                                         |
-|                        "name": "scale-ingest",                                                                          |
-|                        "version": "1.0",                                                                                |
-|                        "title": "Scale Ingest",                                                                         |
-|                        "description": "Ingests a source file into a workspace",                                         |
-|                        "category": "system",                                                                            |
-|                        "author_name": null,                                                                             |
-|                        "author_url": null,                                                                              |
-|                        "is_system": true,                                                                               |
-|                        "is_long_running": false,                                                                        |
-|                        "is_active": true,                                                                               |
-|                        "is_operational": true,                                                                          |
-|                        "is_paused": false,                                                                              |
-|                        "icon_code": "f013"                                                                              |
-|                    },                                                                                                   |
-|                    "job_type_rev": {                                                                                    |
-|                        "id": 2                                                                                          |
-|                    },                                                                                                   |
-|                    "event": {                                                                                           |
-|                        "id": 3                                                                                          |
-|                    },                                                                                                   |
-|                    "error": null,                                                                                       |
-|                    "status": "COMPLETED",                                                                               |
-|                    "priority": 10,                                                                                      |
-|                    "num_exes": 1                                                                                        |
-|                },                                                                                                       |
-|                "node": {                                                                                                |
-|                    "id": 1,                                                                                             |
-|                    "hostname": "machine.com",                                                                           |
-|                    "port": 5051,                                                                                        |
-|                    "slave_id": "20150821-123454-1683014024-5050-8216-S2"                                                |
-|                },                                                                                                       |
-|                "error": null,                                                                                           |
-|                "exe_num": 3,                                                                                            |
-|                "cluster_id": "scale_job_1234_267x0",                                                                    |
-|                "input_file_size": 10.0,                                                                                 |
-|                "cpus_scheduled": 1.0,                                                                                   |
-|                "mem_scheduled": 256,                                                                                    |
-|                "disk_out_scheduled": 10.0,                                                                              |
-|                "disk_in_scheduled": 10.0                                                                                |
-|            },                                                                                                           |
-|            ...                                                                                                          |
-|        ]                                                                                                                |
-|    }                                                                                                                    |
-+-------------------------------------------------------------------------------------------------------------------------+
++---------------------------------------------------------------------------------------------------------------------------+
+| **Job Executions List**                                                                                                   |
++===========================================================================================================================+
+| Returns a list of job executions associated with a given Job ID.                                                          |
++---------------------------------------------------------------------------------------------------------------------------+
+| **GET** /jobs/{id}/executions/                                                                                            |
+|         Where {id} is the unique identifier of an existing job.                                                           |
++---------------------------------------------------------------------------------------------------------------------------+
+| **Query Parameters**                                                                                                      |
++----------------------+-------------------+----------+---------------------------------------------------------------------+
+| started              | ISO-8601 Datetime | Optional | The start of the time range to query.                               |
+|                      |                   |          | Supports the ISO-8601 date/time format, (ex: 2015-01-01T00:00:00Z). |
+|                      |                   |          | Supports the ISO-8601 duration format, (ex: PT3H0M0S).              |
++----------------------+-------------------+----------+---------------------------------------------------------------------+
+| ended                | ISO-8601 Datetime | Optional | The end of the time range to query.                                 |
+|                      |                   |          | Supports the ISO-8601 date/time format, (ex: 2015-01-01T00:00:00Z). |
+|                      |                   |          | Supports the ISO-8601 duration format, (ex: PT3H0M0S).              |
++----------------------+-------------------+----------+---------------------------------------------------------------------+
+| status               | String            | Optional | Return only executions with a status matching this string.          |
+|                      |                   |          | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].            |
+|                      |                   |          | Duplicate it to filter by multiple values.                          |
++----------------------+-------------------+----------+---------------------------------------------------------------------+
+| node_id              | Integer           | Optional | Return only executions that ran on a given node.                    |
+|                      |                   |          | Duplicate it to filter by multiple values.                          |
++----------------------+-------------------+----------+---------------------------------------------------------------------+
+| **Successful Response**                                                                                                   |
++----------------------+----------------------------------------------------------------------------------------------------+
+| **Status**           | 200 OK                                                                                             |
++----------------------+----------------------------------------------------------------------------------------------------+
+| **Content Type**     | *application/json*                                                                                 |
++----------------------+----------------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                           |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| count                | Integer           | The total number of results that match the query parameters.                   |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| next                 | URL               | A URL to the next page of results.                                             |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| previous             | URL               | A URL to the previous page of results.                                         |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| results              | Array             | List of result JSON objects that match the query parameters.                   |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .id                  | Integer           | The unique identifier of the model. Can be passed to the details API call.     |
+|                      |                   | (See :ref:`Job Execution Details <rest_job_execution_details>`)                |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .status              | String            | The status of the job execution.                                               |
+|                      |                   | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].                       |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .command_arguments   | String            | The argument string to execute on the command line for this job execution.     | 
+|                      |                   | This field is populated when the job execution is scheduled to run on a node   |
+|                      |                   | and is updated when any needed pre-job steps are run.                          |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .timeout             | Integer           | The maximum amount of time this job can run before being killed (in seconds).  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .pre_started         | ISO-8601 Datetime | When the pre-job steps were started on a node.                                 |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .pre_completed       | ISO-8601 Datetime | When the pre-job steps were completed on a node.                               |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .pre_exit_code       | Integer           | The exit code of the pre-steps job process for this job execution.             |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .job_started         | ISO-8601 Datetime | When the actual job started running on a node.                                 |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .job_completed       | ISO-8601 Datetime | When the actual job completed running on a node.                               |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .job_exit_code       | Integer           | The exit code of the main job process for this job execution.                  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .post_started        | ISO-8601 Datetime | When the post-job steps were started on a node.                                |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .post_completed      | ISO-8601 Datetime | When the post-job steps were completed on a node.                              |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .post_exit_code      | Integer           | The exit code of the post-steps job process for this job execution.            |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .created             | ISO-8601 Datetime | When the associated database model was initially created.                      |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .queued              | ISO-8601 Datetime | When the job was added to the queue for this run and went to QUEUED status.    |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .started             | ISO-8601 Datetime | When the job was scheduled and went to RUNNING status.                         |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .ended               | ISO-8601 Datetime | When the job execution ended. (FAILED, COMPLETED, or CANCELED)                 |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .last_modified       | ISO-8601 Datetime | When the associated database model was last saved.                             |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .job                 | JSON Object       | The job that is associated with the execution.                                 |
+|                      |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .node                | JSON Object       | The node that ran the execution.                                               |
+|                      |                   | (See :ref:`Node Details <rest_node_details>`)                                  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .error               | JSON Object       | The last error that was recorded for the execution.                            |
+|                      |                   | (See :ref:`Error Details <rest_error_details>`)                                |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| exe_num              | Integer           | The unique job execution number for the job identifer.                         |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| cluster_id           | String            | The Scale cluster identifier.                                                  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| input_file_size      | ISO-8601 Datetime | When the job execution ended. (FAILED, COMPLETED, or CANCELED)                 |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| cpus_scheduled       | Decimal           | The number of CPUs scheduled for the execution.                                |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| mem_scheduled        | Decimal           | The amount of RAM in MiB scheduled for the execution.                          |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| disk_in_scheduled    | Decimal           | The amount of disk space in MiB scheduled for input files for the execution.   |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| disk_out_scheduled   | Decimal           | The amount of disk space in MiB scheduled for output files for the execution.  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| disk_total_scheduled | Decimal           | The total amount of disk space in MiB scheduled for the execution.             |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .. code-block:: javascript                                                                                                |
+|                                                                                                                           |
+|    {                                                                                                                      |
+|        "count": 57,                                                                                                       | 
+|        "next": null,                                                                                                      |
+|        "previous": null,                                                                                                  |
+|        "results": [                                                                                                       |
+|            {                                                                                                              |
+|                "id": 3,                                                                                                   |
+|                "status": "COMPLETED",                                                                                     |
+|                "command_arguments": "",                                                                                   |
+|                "timeout": 1800,                                                                                           |
+|                "pre_started": null,                                                                                       |
+|                "pre_completed": null,                                                                                     |
+|                "pre_exit_code": null,                                                                                     |
+|                "job_started": "2015-08-28T17:57:44.703Z",                                                                 |
+|                "job_completed": "2015-08-28T17:57:45.906Z",                                                               |
+|                "job_exit_code": null,                                                                                     |
+|                "post_started": null,                                                                                      |
+|                "post_completed": null,                                                                                    |
+|                "post_exit_code": null,                                                                                    |
+|                "created": "2015-08-28T17:57:41.033Z",                                                                     |
+|                "queued": "2015-08-28T17:57:41.010Z",                                                                      |
+|                "started": "2015-08-28T17:57:44.494Z",                                                                     |
+|                "ended": "2015-08-28T17:57:45.906Z",                                                                       |
+|                "last_modified": "2015-08-28T17:57:45.992Z",                                                               |
+|                "job": {                                                                                                   |
+|                    "id": 3,                                                                                               |
+|                    "job_type": {                                                                                          |
+|                        "id": 1,                                                                                           |
+|                        "name": "scale-ingest",                                                                            |
+|                        "version": "1.0",                                                                                  |
+|                        "title": "Scale Ingest",                                                                           |
+|                        "description": "Ingests a source file into a workspace",                                           |
+|                        "category": "system",                                                                              |
+|                        "author_name": null,                                                                               |
+|                        "author_url": null,                                                                                |
+|                        "is_system": true,                                                                                 |
+|                        "is_long_running": false,                                                                          |
+|                        "is_active": true,                                                                                 |
+|                        "is_operational": true,                                                                            |
+|                        "is_paused": false,                                                                                |
+|                        "icon_code": "f013"                                                                                |
+|                    },                                                                                                     |
+|                    "job_type_rev": {                                                                                      |
+|                        "id": 2                                                                                            |
+|                    },                                                                                                     |
+|                    "event": {                                                                                             |
+|                        "id": 3                                                                                            |
+|                    },                                                                                                     |
+|                    "error": null,                                                                                         |
+|                    "status": "COMPLETED",                                                                                 |
+|                    "priority": 10,                                                                                        |
+|                    "num_exes": 1                                                                                          |
+|                },                                                                                                         |
+|                "node": {                                                                                                  |
+|                    "id": 1,                                                                                               |
+|                    "hostname": "machine.com",                                                                             |
+|                    "port": 5051,                                                                                          |
+|                    "slave_id": "20150821-123454-1683014024-5050-8216-S2"                                                  |
+|                },                                                                                                         |
+|                "error": null,                                                                                             |
+|                "exe_num": 3,                                                                                              |
+|                "cluster_id": "scale_job_1234_267x0",                                                                      |
+|                "cpus_scheduled": 1.0,                                                                                     |
+|                "mem_scheduled": 256,                                                                                      |
+|                "disk_out_scheduled": 10.0,                                                                                |
+|                "disk_in_scheduled": 10.0                                                                                  |
+|            },                                                                                                             |
+|            ...                                                                                                            |
+|        ]                                                                                                                  |
+|    }                                                                                                                      |
++---------------------------------------------------------------------------------------------------------------------------+

--- a/scale/docs/rest/job.rst
+++ b/scale/docs/rest/job.rst
@@ -1238,11 +1238,7 @@ These services provide access to information about "all", "currently running" an
 |                      |                   | (See :ref:`Job Execution Details <rest_job_execution_details>`)                |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .status              | String            | The status of the job execution.                                               |
-|                      |                   | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].                       |
-+----------------------+-------------------+--------------------------------------------------------------------------------+
-| .command_arguments   | String            | The argument string to execute on the command line for this job execution.     |
-|                      |                   | This field is populated when the job execution is scheduled to run on a node   |
-|                      |                   | and is updated when any needed pre-job steps are run.                          |
+|                      |                   | Choices: [RUNNING, FAILED, COMPLETED, CANCELED].                               |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .timeout             | Integer           | The maximum amount of time this job can run before being killed (in seconds).  |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
@@ -1254,8 +1250,6 @@ These services provide access to information about "all", "currently running" an
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .ended               | ISO-8601 Datetime | When the job execution ended. (FAILED, COMPLETED, or CANCELED)                 |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| .last_modified       | ISO-8601 Datetime | When the associated database model was last saved.                             |
-+----------------------+-------------------+--------------------------------------------------------------------------------+
 | .job                 | JSON Object       | The job that is associated with the execution.                                 |
 |                      |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
@@ -1265,9 +1259,14 @@ These services provide access to information about "all", "currently running" an
 | .error               | JSON Object       | The last error that was recorded for the execution.                            |
 |                      |                   | (See :ref:`Error Details <rest_error_details>`)                                |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| exe_num              | Integer           | The unique job execution number for the job identifer.                         |
+| .job_type            | JSON Object       | The job type that is associated with the execution.                            |
+|                      |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| cluster_id           | String            | The Scale cluster identifier.                                                  |
+| .exe_num             | Integer           | The unique job execution number for the job identifer.                         |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .cluster_id          | String            | The Scale cluster identifier.                                                  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .input_file_size     | Float             | The total amount of disk space in MiB for all input files for this execution.  |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .. code-block:: javascript                                                                                                |
 |                                                                                                                           |
@@ -1279,16 +1278,19 @@ These services provide access to information about "all", "currently running" an
 |            {                                                                                                              |
 |                "id": 3,                                                                                                   |
 |                "status": "COMPLETED",                                                                                     |
-|                "command_arguments": "",                                                                                   |
 |                "timeout": 1800,                                                                                           |
 |                "created": "2015-08-28T17:57:41.033Z",                                                                     |
 |                "queued": "2015-08-28T17:57:41.010Z",                                                                      |
 |                "started": "2015-08-28T17:57:44.494Z",                                                                     |
 |                "ended": "2015-08-28T17:57:45.906Z",                                                                       |
-|                "last_modified": "2015-08-28T17:57:45.992Z",                                                               |
 |                "job": {                                                                                                   |
-|                    "id": 3                                                                                                |
+|                    "id": 3,                                                                                               |
 |                },                                                                                                         |
+|                "node": {                                                                                                  |
+|                    "id": 1,                                                                                               |
+|                    "hostname": "machine.com"                                                                              |
+|                },                                                                                                         |
+|                "error": null,                                                                                             |
 |                "job_type": {                                                                                              |
 |                    "id": 1,                                                                                               |
 |                    "name": "scale-ingest",                                                                                |
@@ -1305,11 +1307,11 @@ These services provide access to information about "all", "currently running" an
 |                    "is_paused": false,                                                                                    |
 |                    "icon_code": "f013"                                                                                    |
 |                },                                                                                                         |
-|                "node": {                                                                                                  |
-|                    "id": 1,                                                                                               |
-|                    "hostname": "machine.com"                                                                              |
-|                }                                                                                                          |
-|          }                                                                                                                |
+|                "exe_num": 1,                                                                                              |
+|                "cluster_id": "scale_job_1234_263x0",                                                                      |
+|                "input_file_size": 10.0                                                                                    |
+|            }                                                                                                              |
+|        ]                                                                                                                  |
 |    }                                                                                                                      |
 +---------------------------------------------------------------------------------------------------------------------------+
 
@@ -1343,10 +1345,6 @@ These services provide access to information about "all", "currently running" an
 | status               | String            | The status of the job execution.                                               |
 |                      |                   | Choices: [RUNNING, FAILED, COMPLETED, CANCELED].                               |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| command_arguments    | String            | The argument string to execute on the command line for this job execution.     |
-|                      |                   | This field is populated when the job execution is scheduled to run on a node   |
-|                      |                   | and is updated when any needed pre-job steps are run.                          |
-+----------------------+-------------------+--------------------------------------------------------------------------------+
 | timeout              | Integer           | The maximum amount of time this job can run before being killed (in seconds).  |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | created              | ISO-8601 Datetime | When the associated database model was initially created.                      |
@@ -1357,8 +1355,6 @@ These services provide access to information about "all", "currently running" an
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | ended                | ISO-8601 Datetime | When the job execution ended. (FAILED, COMPLETED, or CANCELED)                 |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| last_modified        | ISO-8601 Datetime | When the associated database model was last saved.                             |
-+----------------------+-------------------+--------------------------------------------------------------------------------+
 | job                  | JSON Object       | The job that is associated with the execution.                                 |
 |                      |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
@@ -1368,30 +1364,43 @@ These services provide access to information about "all", "currently running" an
 | error                | JSON Object       | The last error that was recorded for the execution.                            |
 |                      |                   | (See :ref:`Error Details <rest_error_details>`)                                |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| environment          | JSON Object       | An interface description for the environment the job execution executed in.    |
+| job_type             | JSON Object       | The job type that is associated with the execution.                            |
+|                      |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| results              | JSON Object       | An interface description for all the possible job results meta-data.           |
+| exe_num              | Integer           | The unique job execution number for the job identifer.                         |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| results_manifest     | JSON Object       | An interface description for all the actual job results meta-data.             |
+| cluster_id           | String            | The Scale cluster identifier.                                                  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| input_file_size      | Float             | The total amount of disk space in MiB for all input files for this execution.  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| task_results         | JSON Object       | JSON description of the task results for this execution.                       |
+|                      |                   | (See :ref:`Job Task Results <architecture_jobs_task_results_spec>`)            |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| resources            | JSON Object       | JSON description describing the resources allocated to this execution.         |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | configuration        | JSON Object       | JSON description of the configuration for running the job                      |
-|                      |                   | (See :ref:`architecture_jobs_job_configuration_spec`)                          |
+|                      |                   | (See :ref:`Job Execution Configuration <architecture_jobs_exe_configuration`)  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| output               | JSON Object       | JSON description of the job output.                                            |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .. code-block:: javascript                                                                                                |
 |                                                                                                                           |
 |  {                                                                                                                        |
 |      "id": 3,                                                                                                             |
 |      "status": "COMPLETED",                                                                                               |
-|      "command_arguments": "",                                                                                             |
 |      "timeout": 1800,                                                                                                     |
 |      "created": "2015-08-28T17:57:41.033Z",                                                                               |
 |      "queued": "2015-08-28T17:57:41.010Z",                                                                                |
 |      "started": "2015-08-28T17:57:44.494Z",                                                                               |
 |      "ended": "2015-08-28T17:57:45.906Z",                                                                                 |
-|      "last_modified": "2015-08-28T17:57:45.992Z",                                                                         |
 |      "job": {                                                                                                             |
 |          "id": 3,                                                                                                         |
 |      },                                                                                                                   |
+|      "node": {                                                                                                            |
+|          "id": 1,                                                                                                         |
+|          "hostname": "machine.com"                                                                                        |
+|      },                                                                                                                   |
+|      "error": null,                                                                                                       |
 |      "job_type": {                                                                                                        |
 |          "id": 1,                                                                                                         |
 |          "name": "scale-ingest",                                                                                          |
@@ -1408,15 +1417,22 @@ These services provide access to information about "all", "currently running" an
 |          "is_paused": false,                                                                                              |
 |          "icon_code": "f013"                                                                                              |
 |      },                                                                                                                   |
-|      "node": {                                                                                                            |
-|          "id": 1,                                                                                                         |
-|          "hostname": "machine.com",                                                                                       |
-|          "port": 5051,                                                                                                    |
-|          "slave_id": "20150821-123454-1683014024-5050-8216-S2"                                                            |
+|      "exe_num": 1,                                                                                                        |
+|      "cluster_id": "scale_job_1234_263x0",                                                                                |
+|      "input_file_size": 10.0,                                                                                             |
+|      "task_results": {...},                                                                                               |
+|      "resources": {                                                                                                       |
+|          "version": "1.0",                                                                                                |
+|          "resources": {                                                                                                   |
+|              "mem": 128.0,                                                                                                |
+|              "disk": 11.0,                                                                                                |
+|              "cpus": 1.0                                                                                                  |
+|          }                                                                                                                |
 |      },                                                                                                                   |
-|      "error": null,                                                                                                       |
-|      "environment": {...},                                                                                                |
-|      "results": {                                                                                                         |
+|      "configuration": {                                                                                                   |
+|          "tasks": [...],                                                                                                  |
+|          "version": "2.0"}                                                                                                |
+|      "output": {                                                                                                          |
 |          "output_data": [                                                                                                 |
 |              {                                                                                                            |
 |                  "name": "output_file",                                                                                   |
@@ -1424,15 +1440,6 @@ These services provide access to information about "all", "currently running" an
 |              }                                                                                                            |
 |          ],                                                                                                               |
 |          "version": "1.0"                                                                                                 |
-|      },                                                                                                                   |
-|      "results_manifest": {                                                                                                |
-|          "output_data": [],                                                                                               |
-|          "version": "1.1",                                                                                                |
-|          "errors": [],                                                                                                    |
-|          "parse_results": []                                                                                              |
-|      },                                                                                                                   |
-|      "configuration": {                                                                                                   |
-|          "tasks": [...],                                                                                                  |
-|          "version": "2.0"}                                                                                                |
+|      }                                                                                                                    |
 |  }                                                                                                                        |
 +---------------------------------------------------------------------------------------------------------------------------+

--- a/scale/docs/rest/job.rst
+++ b/scale/docs/rest/job.rst
@@ -1240,7 +1240,9 @@ These services provide access to information about "all", "currently running" an
 | .status              | String            | The status of the job execution.                                               |
 |                      |                   | Choices: [RUNNING, FAILED, COMPLETED, CANCELED].                               |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| .timeout             | Integer           | The maximum amount of time this job can run before being killed (in seconds).  |
+| .exe_num             | Integer           | The unique job execution number for the job identifer.                         |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .cluster_id          | String            | The Scale cluster identifier.                                                  |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .created             | ISO-8601 Datetime | When the associated database model was initially created.                      |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
@@ -1262,9 +1264,7 @@ These services provide access to information about "all", "currently running" an
 | .job_type            | JSON Object       | The job type that is associated with the execution.                            |
 |                      |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| .exe_num             | Integer           | The unique job execution number for the job identifer.                         |
-+----------------------+-------------------+--------------------------------------------------------------------------------+
-| .cluster_id          | String            | The Scale cluster identifier.                                                  |
+| .timeout             | Integer           | The maximum amount of time this job can run before being killed (in seconds).  |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .input_file_size     | Float             | The total amount of disk space in MiB for all input files for this execution.  |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
@@ -1278,7 +1278,8 @@ These services provide access to information about "all", "currently running" an
 |            {                                                                                                              |
 |                "id": 3,                                                                                                   |
 |                "status": "COMPLETED",                                                                                     |
-|                "timeout": 1800,                                                                                           |
+|                "exe_num": 1,                                                                                              |
+|                "cluster_id": "scale_job_1234_263x0",                                                                      |
 |                "created": "2015-08-28T17:57:41.033Z",                                                                     |
 |                "queued": "2015-08-28T17:57:41.010Z",                                                                      |
 |                "started": "2015-08-28T17:57:44.494Z",                                                                     |
@@ -1307,8 +1308,7 @@ These services provide access to information about "all", "currently running" an
 |                    "is_paused": false,                                                                                    |
 |                    "icon_code": "f013"                                                                                    |
 |                },                                                                                                         |
-|                "exe_num": 1,                                                                                              |
-|                "cluster_id": "scale_job_1234_263x0",                                                                      |
+|                "timeout": 1800,                                                                                           |
 |                "input_file_size": 10.0                                                                                    |
 |            }                                                                                                              |
 |        ]                                                                                                                  |
@@ -1345,7 +1345,9 @@ These services provide access to information about "all", "currently running" an
 | status               | String            | The status of the job execution.                                               |
 |                      |                   | Choices: [RUNNING, FAILED, COMPLETED, CANCELED].                               |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| timeout              | Integer           | The maximum amount of time this job can run before being killed (in seconds).  |
+| exe_num              | Integer           | The unique job execution number for the job identifer.                         |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| cluster_id           | String            | The Scale cluster identifier.                                                  |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | created              | ISO-8601 Datetime | When the associated database model was initially created.                      |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
@@ -1367,9 +1369,7 @@ These services provide access to information about "all", "currently running" an
 | job_type             | JSON Object       | The job type that is associated with the execution.                            |
 |                      |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| exe_num              | Integer           | The unique job execution number for the job identifer.                         |
-+----------------------+-------------------+--------------------------------------------------------------------------------+
-| cluster_id           | String            | The Scale cluster identifier.                                                  |
+| timeout              | Integer           | The maximum amount of time this job can run before being killed (in seconds).  |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | input_file_size      | Float             | The total amount of disk space in MiB for all input files for this execution.  |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
@@ -1388,7 +1388,8 @@ These services provide access to information about "all", "currently running" an
 |  {                                                                                                                        |
 |      "id": 3,                                                                                                             |
 |      "status": "COMPLETED",                                                                                               |
-|      "timeout": 1800,                                                                                                     |
+|      "exe_num": 1,                                                                                                        |
+|      "cluster_id": "scale_job_1234_263x0",                                                                                |
 |      "created": "2015-08-28T17:57:41.033Z",                                                                               |
 |      "queued": "2015-08-28T17:57:41.010Z",                                                                                |
 |      "started": "2015-08-28T17:57:44.494Z",                                                                               |
@@ -1417,10 +1418,9 @@ These services provide access to information about "all", "currently running" an
 |          "is_paused": false,                                                                                              |
 |          "icon_code": "f013"                                                                                              |
 |      },                                                                                                                   |
-|      "exe_num": 1,                                                                                                        |
-|      "cluster_id": "scale_job_1234_263x0",                                                                                |
+|      "timeout": 1800,                                                                                                     |
 |      "input_file_size": 10.0,                                                                                             |
-|      "task_results": {...},                                                                                               |
+|      "task_results": null,                                                                                                |
 |      "resources": {                                                                                                       |
 |          "version": "1.0",                                                                                                |
 |          "resources": {                                                                                                   |

--- a/scale/docs/rest/job.rst
+++ b/scale/docs/rest/job.rst
@@ -1180,12 +1180,17 @@ These services provide access to information about "all", "currently running" an
 |    }                                                                                                                    |
 +-------------------------------------------------------------------------------------------------------------------------+
 
-.. _rest_job_executions_list:
+.. _rest_job_execution_list_v6:
 
+.. TODO: un-version this rST table link and remove the note when API REST v5 is removed
 +---------------------------------------------------------------------------------------------------------------------------+
 | **Job Executions List**                                                                                                   |
 +===========================================================================================================================+
 | Returns a list of job executions associated with a given Job ID.                                                          |
++---------------------------------------------------------------------------------------------------------------------------+
+| **NOTE**                                                                                                                  |
+|                This API endpoint is available starting with API **v6**.  It replaces a very similar API endpoint which    |
+|                you can see described here: :ref:`Job Execution List <rest_job_execution_list>`.                           |
 +---------------------------------------------------------------------------------------------------------------------------+
 | **GET** /jobs/{id}/executions/                                                                                            |
 |         Where {id} is the unique identifier of an existing job.                                                           |
@@ -1276,8 +1281,6 @@ These services provide access to information about "all", "currently running" an
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | cluster_id           | String            | The Scale cluster identifier.                                                  |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
-| input_file_size      | ISO-8601 Datetime | When the job execution ended. (FAILED, COMPLETED, or CANCELED)                 |
-+----------------------+-------------------+--------------------------------------------------------------------------------+
 | cpus_scheduled       | Decimal           | The number of CPUs scheduled for the execution.                                |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | mem_scheduled        | Decimal           | The amount of RAM in MiB scheduled for the execution.                          |
@@ -1360,4 +1363,185 @@ These services provide access to information about "all", "currently running" an
 |            ...                                                                                                            |
 |        ]                                                                                                                  |
 |    }                                                                                                                      |
++---------------------------------------------------------------------------------------------------------------------------+
+
+.. _rest_job_execution_details_v6:
+
+.. TODO: un-version this rst table link and remove the note when API REST v5 is removed
++---------------------------------------------------------------------------------------------------------------------------+
+| **Job Execution Details**                                                                                                 |
++===========================================================================================================================+
+| Returns a specific job execution and all its related model information including job, node, environment, and results.     |
++---------------------------------------------------------------------------------------------------------------------------+
+| **NOTE**                                                                                                                  |
+|                This API endpoint is available starting with API **v6**.  It replaces a very similar API endpoint which    |
+|                you can see described here: :ref:`Job Execution List <rest_job_execution_details>`.                        |
++---------------------------------------------------------------------------------------------------------------------------+
+| **GET** /jobs/{id}/executions/{exe_num}                                                                                   |
+|         Where {id} is the unique identifier of an existing job and {exe_num} is the execution number of a job execution   |
+|         as it relates to the job.                                                                                         |
++----------------------+----------------------------------------------------------------------------------------------------+
+| **Successful Response**                                                                                                   |
++----------------------+----------------------------------------------------------------------------------------------------+
+| **Status**           | 200 OK                                                                                             |
++----------------------+----------------------------------------------------------------------------------------------------+
+| **Content Type**     | *application/json*                                                                                 |
++----------------------+----------------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                           |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| id                   | Integer           | The unique identifier of the model. Can be passed to the details API call.     |
+|                      |                   | (See :ref:`Job Execution Details <rest_job_execution_details>`)                |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| status               | String            | The status of the job execution.                                               |
+|                      |                   | Choices: [QUEUED, RUNNING, FAILED, COMPLETED, CANCELED].                       |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| command_arguments    | String            | The argument string to execute on the command line for this job execution.     | 
+|                      |                   | This field is populated when the job execution is scheduled to run on a node   |
+|                      |                   | and is updated when any needed pre-job steps are run.                          |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| timeout              | Integer           | The maximum amount of time this job can run before being killed (in seconds).  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| pre_started          | ISO-8601 Datetime | When the pre-job steps were started on a node.                                 |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| pre_completed        | ISO-8601 Datetime | When the pre-job steps were completed on a node.                               |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| pre_exit_code        | Integer           | The exit code of the pre-steps job process for this job execution.             |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| job_started          | ISO-8601 Datetime | When the actual job started running on a node.                                 |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| job_completed        | ISO-8601 Datetime | When the actual job completed running on a node.                               |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| job_exit_code        | Integer           | The exit code of the main job process for this job execution.                  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| post_started         | ISO-8601 Datetime | When the post-job steps were started on a node.                                |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| post_completed       | ISO-8601 Datetime | When the post-job steps were completed on a node.                              |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| post_exit_code       | Integer           | The exit code of the post-steps job process for this job execution.            |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| created              | ISO-8601 Datetime | When the associated database model was initially created.                      |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| queued               | ISO-8601 Datetime | When the job was added to the queue for this run and went to QUEUED status.    |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| started              | ISO-8601 Datetime | When the job was scheduled and went to RUNNING status.                         |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| ended                | ISO-8601 Datetime | When the job execution ended. (FAILED, COMPLETED, or CANCELED)                 |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| last_modified        | ISO-8601 Datetime | When the associated database model was last saved.                             |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| job                  | JSON Object       | The job that is associated with the execution.                                 |
+|                      |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| node                 | JSON Object       | The node that ran the execution.                                               |
+|                      |                   | (See :ref:`Node Details <rest_node_details>`)                                  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| error                | JSON Object       | The last error that was recorded for the execution.                            |
+|                      |                   | (See :ref:`Error Details <rest_error_details>`)                                |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| environment          | JSON Object       | An interface description for the environment the job execution executed in.    |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| cpus_scheduled       | Decimal           | The number of CPUs scheduled for the execution.                                |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| mem_scheduled        | Decimal           | The amount of RAM in MiB scheduled for the execution.                          |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| disk_in_scheduled    | Decimal           | The amount of disk space in MiB scheduled for input files for the execution.   |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| disk_out_scheduled   | Decimal           | The amount of disk space in MiB scheduled for output files for the execution.  |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| disk_total_scheduled | Decimal           | The total amount of disk space in MiB scheduled for the execution.             |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| results              | JSON Object       | An interface description for all the possible job results meta-data.           |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| results_manifest     | JSON Object       | An interface description for all the actual job results meta-data.             |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| configuration        | JSON Object       | JSON description of the configuration for running the job                      |
+|                      |                   | (See :ref:`architecture_jobs_job_configuration_spec`)                          |
++----------------------+-------------------+--------------------------------------------------------------------------------+
+| .. code-block:: javascript                                                                                                |
+|                                                                                                                           |
+|  {                                                                                                                        |
+|      "id": 3,                                                                                                             |
+|      "status": "COMPLETED",                                                                                               |
+|      "command_arguments": "",                                                                                             |
+|      "timeout": 1800,                                                                                                     |
+|      "pre_started": null,                                                                                                 |
+|      "pre_completed": null,                                                                                               |
+|      "pre_exit_code": null,                                                                                               |
+|      "job_started": "2015-08-28T17:57:44.703Z",                                                                           |
+|      "job_completed": "2015-08-28T17:57:45.906Z",                                                                         |
+|      "job_exit_code": null,                                                                                               |
+|      "post_started": null,                                                                                                |
+|      "post_completed": null,                                                                                              |
+|      "post_exit_code": null,                                                                                              |
+|      "created": "2015-08-28T17:57:41.033Z",                                                                               |
+|      "queued": "2015-08-28T17:57:41.010Z",                                                                                |
+|      "started": "2015-08-28T17:57:44.494Z",                                                                               |
+|      "ended": "2015-08-28T17:57:45.906Z",                                                                                 |
+|      "last_modified": "2015-08-28T17:57:45.992Z",                                                                         |
+|      "job": {                                                                                                             |
+|          "id": 3,                                                                                                         |
+|          "job_type": {                                                                                                    |
+|              "id": 1,                                                                                                     |
+|              "name": "scale-ingest",                                                                                      |
+|              "version": "1.0",                                                                                            |
+|              "title": "Scale Ingest",                                                                                     |
+|              "description": "Ingests a source file into a workspace",                                                     |
+|              "category": "system",                                                                                        |
+|              "author_name": null,                                                                                         |
+|              "author_url": null,                                                                                          |
+|              "is_system": true,                                                                                           |
+|              "is_long_running": false,                                                                                    |
+|              "is_active": true,                                                                                           |
+|              "is_operational": true,                                                                                      |
+|              "is_paused": false,                                                                                          |
+|              "icon_code": "f013"                                                                                          |
+|          },                                                                                                               |
+|          "job_type_rev": {                                                                                                |
+|              "id": 2                                                                                                      |
+|          },                                                                                                               |
+|          "event": {                                                                                                       |
+|              "id": 3                                                                                                      |
+|          },                                                                                                               |
+|          "error": null,                                                                                                   |
+|          "status": "COMPLETED",                                                                                           |
+|          "priority": 10,                                                                                                  |
+|          "num_exes": 1                                                                                                    |
+|      },                                                                                                                   |
+|      "node": {                                                                                                            |
+|          "id": 1,                                                                                                         |
+|          "hostname": "machine.com",                                                                                       |
+|          "port": 5051,                                                                                                    |
+|          "slave_id": "20150821-123454-1683014024-5050-8216-S2",                                                           |
+|          "is_paused": false,                                                                                              |
+|          "is_active": true,                                                                                               |
+|          "archived": null,                                                                                                |
+|          "created": "2015-09-02T18:05:54.730Z",                                                                           |
+|          "last_modified": "2015-09-08T16:53:57.439Z"                                                                      |
+|      },                                                                                                                   |
+|      "error": null,                                                                                                       |
+|      "environment": {...},                                                                                                |
+|      "cpus_scheduled": 0.5,                                                                                               |
+|      "mem_scheduled": 15360.0,                                                                                            |
+|      "disk_in_scheduled": 1.0,                                                                                            |
+|      "disk_out_scheduled": 0.0,                                                                                           |
+|      "disk_total_scheduled": 1.0,                                                                                         |
+|      "results": {                                                                                                         |
+|          "output_data": [                                                                                                 |
+|              {                                                                                                            |
+|                  "name": "output_file",                                                                                   |
+|                  "file_id": 3                                                                                             |
+|              }                                                                                                            |
+|          ],                                                                                                               |
+|          "version": "1.0"                                                                                                 |
+|      },                                                                                                                   |
+|      "results_manifest": {                                                                                                |
+|          "output_data": [],                                                                                               |
+|          "version": "1.1",                                                                                                |
+|          "errors": [],                                                                                                    |
+|          "parse_results": []                                                                                              |
+|      },                                                                                                                   |
+|      "configuration": {                                                                                                   |
+|          "tasks": [...],                                                                                                  |
+|          "version": "2.0"}                                                                                                |
+|  }                                                                                                                        |
 +---------------------------------------------------------------------------------------------------------------------------+

--- a/scale/docs/rest/job_execution.rst
+++ b/scale/docs/rest/job_execution.rst
@@ -13,6 +13,11 @@ These services provide access to information about "all", "currently running" an
 +=========================================================================================================================+
 | Returns a list of all job executions.                                                                                   |
 +-------------------------------------------------------------------------------------------------------------------------+
+| **DEPRECATED**                                                                                                          |
+|                This table describes the current v5 version of the job execution list API, which is now deprecated.      |
+|                The new v6 version of this API is queried differently but returns much of the same information.          |
+|                See :ref:`Job Executions List <rest_job_executions_list>` more details on the new endpoint.              |
++-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /job-executions/                                                                                                |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Query Parameters**                                                                                                    |

--- a/scale/docs/rest/job_execution.rst
+++ b/scale/docs/rest/job_execution.rst
@@ -8,15 +8,16 @@ These services provide access to information about "all", "currently running" an
 
 .. _rest_job_execution_list:
 
+.. TODO: remove this rST table when REST API v5 is removed
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Job Execution List**                                                                                                  |
 +=========================================================================================================================+
 | Returns a list of all job executions.                                                                                   |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **DEPRECATED**                                                                                                          |
-|                This table describes the current v5 version of the job execution list API, which is now deprecated.      |
-|                The new v6 version of this API is queried differently but returns much of the same information.          |
-|                See :ref:`Job Executions List <rest_job_executions_list>` more details on the new endpoint.              |
+|                This table describes the current **v5** version of the job execution list API, which is now deprecated.  |
+|                The new v6 version of this API is queried differently, but returns much of the same information.         |
+|                See :ref:`Job Execution List <rest_job_execution_list_v6>` for more details on the new endpoint.         |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /job-executions/                                                                                                |
 +-------------------------------------------------------------------------------------------------------------------------+
@@ -191,10 +192,16 @@ These services provide access to information about "all", "currently running" an
 
 .. _rest_job_execution_details:
 
+.. TODO: remove this rST table when REST API v5 is removed
 +---------------------------------------------------------------------------------------------------------------------------+
 | **Job Execution Details**                                                                                                 |
 +===========================================================================================================================+
 | Returns a specific job execution and all its related model information including job, node, environment, and results.     |
++---------------------------------------------------------------------------------------------------------------------------+
+| **DEPRECATED**                                                                                                            |
+|                This table describes the current **v5** version of the job execution details API, which is now deprecated. |
+|                The new v6 version of this API is queried differently, but returns much of the same information.           |
+|                See :ref:`Job Executions Details <rest_job_execution_details_v6>` more details on the new endpoint.        |
 +---------------------------------------------------------------------------------------------------------------------------+
 | **GET** /job-executions/{id}/                                                                                             |
 |         Where {id} is the unique identifier of an existing model.                                                         |

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1072,6 +1072,27 @@ class JobExecutionManager(models.Manager):
         job_exes = job_exes.order_by('exe_num')
         return job_exes
 
+    def get_job_exe_details(self, job_id, exe_num):
+        """Returns the details of a job execution for the given job identifier and execution number.
+
+        :param job_type_ids: Query job executions of the type associated with the identifier.
+        :type job_type_ids: int
+        :param exe_num: The execution number
+        :type exe_num: int
+        :returns: The job execution model with associated models.
+        :rtype: [:class:`job.models.JobExecution`]
+        """
+
+        # Fetch a list of job executions
+        job_exe = JobExecution.objects.all().select_related('job', 'job_type', 'node', 'jobexecutionend',
+                                                             'jobexecutionoutput')
+        job_exe = job_exe.defer('stdout', 'stderr')
+        
+        # Apply job filtering
+        job_exe = job_exe.filter(job__id=job_id, exe_num=exe_num)
+
+        return job_exe
+
     
     def get_job_exe_with_job_and_job_type(self, job_id, exe_num):
         """Gets a job execution with its related job and job_type models populated using only one database query

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1056,6 +1056,14 @@ class JobExecutionManager(models.Manager):
 
         :param job_id: Query job executions associated with the job identifier.
         :type job_id: int
+        :param started: Query job executions updated after this amount of time.
+        :type started: :class:`datetime.datetime`
+        :param ended: Query job executions updated before this amount of time.
+        :type ended: :class:`datetime.datetime`
+        :param statuses: Query job executions with the a specific status.
+        :type statuses: [string]
+        :param node_ids: Query job executions that ran on a node with the identifier.
+        :type node_ids: [int]
         :returns: The list of job executions that match the job identifier.
         :rtype: [:class:`job.models.JobExecution`]
         """

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1073,7 +1073,7 @@ class JobExecutionManager(models.Manager):
         return job_exes
 
     def get_job_exe_details(self, job_id, exe_num):
-        """Returns additional details about a job execution related to the given job execution and execution number.
+        """Returns additional details about a job execution related to the given job identifier and execution number.
 
         :param job_id: Query job executions associated with the job identifier.
         :type job_id: int

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1052,48 +1052,47 @@ class JobExecutionManager(models.Manager):
         return job_exes
 
     def get_job_exes(self, job_id):
-        """Returns a list of job executions for the given job and filters.
+        """Returns a list of job executions for the given job.
 
-        :param job_type_ids: Query job executions of the type associated with the identifier.
-        :type job_type_ids: int
+        :param job_id: Query job executions associated with the job identifier.
+        :type job_id: int
         :returns: The list of job executions that match the job identifier.
         :rtype: [:class:`job.models.JobExecution`]
         """
 
         # Fetch a list of job executions
-        job_exes = JobExecution.objects.all().select_related('job', 'job_type', 'node', 'jobexecutionend__error',
-                                                             'jobexecutionoutput')
+        job_exes = JobExecution.objects.all().select_related('job', 'job_type', 'node', 'jobexecutionend')
         job_exes = job_exes.defer('stdout', 'stderr')
-        
+
         # Apply job filtering
         job_exes = job_exes.filter(job__id=job_id)
 
         # Apply sorting
         job_exes = job_exes.order_by('exe_num')
+
         return job_exes
 
     def get_job_exe_details(self, job_id, exe_num):
-        """Returns the details of a job execution for the given job identifier and execution number.
+        """Returns additional details about a job execution related to the given job execution and execution number.
 
-        :param job_type_ids: Query job executions of the type associated with the identifier.
-        :type job_type_ids: int
-        :param exe_num: The execution number
+        :param job_id: Query job executions associated with the job identifier.
+        :type job_id: int
+        :param exe_num: Query job executions associated with the execution number.
         :type exe_num: int
-        :returns: The job execution model with associated models.
+        :returns: Details about the job execution that match the job execution identifier.
         :rtype: [:class:`job.models.JobExecution`]
         """
 
         # Fetch a list of job executions
         job_exe = JobExecution.objects.all().select_related('job', 'job_type', 'node', 'jobexecutionend',
-                                                             'jobexecutionoutput')
+                                                            'jobexecutionoutput')
         job_exe = job_exe.defer('stdout', 'stderr')
-        
-        # Apply job filtering
+
+        # Apply job and execution filtering
         job_exe = job_exe.filter(job__id=job_id, exe_num=exe_num)
 
         return job_exe
 
-    
     def get_job_exe_with_job_and_job_type(self, job_id, exe_num):
         """Gets a job execution with its related job and job_type models populated using only one database query
 

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1074,7 +1074,7 @@ class JobExecutionManager(models.Manager):
 
         # Apply job filtering
         job_exes = job_exes.filter(job__id=job_id)
-        
+
         # Apply time range filtering
         if started:
             job_exes = job_exes.filter(started__gte=started)
@@ -1118,7 +1118,7 @@ class JobExecutionManager(models.Manager):
         job_exe = job_exe.defer('stdout', 'stderr')
 
         # Apply job and execution filtering
-        job_exe = job_exe.filter(job__id=job_id, exe_num=exe_num)
+        job_exe = job_exe.get(job__id=job_id, exe_num=exe_num)
 
         return job_exe
 

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -939,6 +939,7 @@ class Job(models.Model):
 class JobExecutionManager(models.Manager):
     """Provides additional methods for handling job executions."""
 
+    # TODO: remove when REST API v5 is removed
     def get_details(self, job_exe_id):
         """Gets additional details for the given job execution model based on related model attributes.
 
@@ -987,6 +988,7 @@ class JobExecutionManager(models.Manager):
 
         return job_exe
 
+    # TODO: remove when REST API v5 is removed
     def get_exes(self, started=None, ended=None, statuses=None, job_type_ids=None, job_type_names=None,
                  job_type_categories=None, node_ids=None, order=None):
         """Returns a list of job executions within the given time range.
@@ -1070,6 +1072,7 @@ class JobExecutionManager(models.Manager):
         logger.info('Found job execution with ID %d', job_exe.id)
         return job_exe
 
+    # TODO: remove when REST API v5 is removed
     def get_latest(self, jobs):
         """Gets the latest job execution associated with each given job.
 
@@ -1087,6 +1090,7 @@ class JobExecutionManager(models.Manager):
 
         return results
 
+    # TODO: remove when REST API v5 is removed
     def get_logs(self, job_exe_id):
         """Gets additional details for the given job execution model based on related model attributes.
 

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1051,6 +1051,28 @@ class JobExecutionManager(models.Manager):
             job_exes = job_exes.order_by('created')
         return job_exes
 
+    def get_job_exes(self, job_id):
+        """Returns a list of job executions for the given job and filters.
+
+        :param job_type_ids: Query job executions of the type associated with the identifier.
+        :type job_type_ids: int
+        :returns: The list of job executions that match the job identifier.
+        :rtype: [:class:`job.models.JobExecution`]
+        """
+
+        # Fetch a list of job executions
+        job_exes = JobExecution.objects.all().select_related('job', 'job_type', 'node', 'jobexecutionend__error',
+                                                             'jobexecutionoutput')
+        job_exes = job_exes.defer('stdout', 'stderr')
+        
+        # Apply job filtering
+        job_exes = job_exes.filter(job__id=job_id)
+
+        # Apply sorting
+        job_exes = job_exes.order_by('exe_num')
+        return job_exes
+
+    
     def get_job_exe_with_job_and_job_type(self, job_id, exe_num):
         """Gets a job execution with its related job and job_type models populated using only one database query
 

--- a/scale/job/serializers.py
+++ b/scale/job/serializers.py
@@ -168,7 +168,7 @@ class JobRevisionSerializer(JobSerializer):
     """Converts job model fields to REST output."""
     job_type_rev = JobTypeRevisionSerializer()
 
-
+# TODO: remove this function when REST API v5 is removed 
 class JobExecutionBaseSerializer(ModelIdSerializer):
     """Converts job execution model fields to REST output"""
     status = serializers.CharField(source='get_status')
@@ -289,20 +289,14 @@ class JobExecutionSerializer(JobExecutionBaseSerializer):
     from error.serializers import ErrorBaseSerializer
     from node.serializers import NodeBaseSerializerV4
 
-    job = JobBaseSerializer()
+    job = ModelIdSerializer()
     node = NodeBaseSerializerV4()
     error = ErrorBaseSerializer(source='jobexecutionend.error')
+    job_type = JobTypeBaseSerializer()
 
-    job_type = JobTypeSerializer()
     exe_num = serializers.IntegerField()
     cluster_id = serializers.CharField()
     input_file_size = serializers.FloatField()
-
-    cpus_scheduled = serializers.FloatField()
-    mem_scheduled = serializers.FloatField()
-    disk_out_scheduled = serializers.FloatField()
-    disk_in_scheduled = serializers.FloatField(source='input_file_size')
-    disk_total_scheduled = serializers.FloatField()
 
 
 # TODO: remove this function when REST API v5 is removed
@@ -315,16 +309,6 @@ class OldJobExecutionDetailsSerializer(OldJobExecutionSerializer):
     job = JobSerializer()
     node = NodeSerializerV4()
     error = ErrorSerializer(source='jobexecutionend.error')
-
-    cpus_scheduled = serializers.FloatField()
-    mem_scheduled = serializers.FloatField()
-    disk_in_scheduled = serializers.FloatField(source='input_file_size')
-    disk_out_scheduled = serializers.FloatField()
-    disk_total_scheduled = serializers.FloatField()
-
-    environment = serializers.JSONField(default=dict)
-    results = serializers.JSONField(default=dict, source='jobexecutionoutput.output')
-    results_manifest = serializers.JSONField(default=dict)
 
 
 class JobExecutionDetailsSerializer(JobExecutionSerializer):

--- a/scale/job/serializers.py
+++ b/scale/job/serializers.py
@@ -271,9 +271,10 @@ class JobUpdateSerializer(JobSerializer):
     input_files = ScaleFileSerializer(many=True)
 
 
-# TODO: remove when REST API v5 is removed
-class JobExecutionSerializer(JobExecutionBaseSerializer):
+# TODO: remove this function when REST API v5 is removed
+class OldJobExecutionSerializer(JobExecutionBaseSerializer):
     """Converts job execution model fields to REST output"""
+
     from error.serializers import ErrorBaseSerializer
     from node.serializers import NodeBaseSerializerV4
 
@@ -282,9 +283,32 @@ class JobExecutionSerializer(JobExecutionBaseSerializer):
     error = ErrorBaseSerializer(source='jobexecutionend.error')
 
 
-# TODO: remove when REST API v5 is removed
-class JobExecutionDetailsSerializer(JobExecutionSerializer):
+class JobExecutionSerializer(JobExecutionBaseSerializer):
     """Converts job execution model fields to REST output"""
+
+    from error.serializers import ErrorBaseSerializer
+    from node.serializers import NodeBaseSerializerV4
+
+    job = JobBaseSerializer()
+    node = NodeBaseSerializerV4()
+    error = ErrorBaseSerializer(source='jobexecutionend.error')
+
+    job_type = JobTypeSerializer()
+    exe_num = serializers.IntegerField()
+    cluster_id = serializers.CharField()
+    input_file_size = serializers.FloatField()
+
+    cpus_scheduled = serializers.FloatField()
+    mem_scheduled = serializers.FloatField()
+    disk_out_scheduled = serializers.FloatField()
+    disk_in_scheduled = serializers.FloatField(source='input_file_size')
+    disk_total_scheduled = serializers.FloatField()
+
+
+# TODO: remove this function when REST API v5 is removed
+class OldJobExecutionDetailsSerializer(OldJobExecutionSerializer):
+    """Converts job execution model fields to REST output"""
+
     from error.serializers import ErrorSerializer
     from node.serializers import NodeSerializerV4
 
@@ -292,15 +316,33 @@ class JobExecutionDetailsSerializer(JobExecutionSerializer):
     node = NodeSerializerV4()
     error = ErrorSerializer(source='jobexecutionend.error')
 
-    environment = serializers.JSONField(default=dict)
     cpus_scheduled = serializers.FloatField()
     mem_scheduled = serializers.FloatField()
     disk_in_scheduled = serializers.FloatField(source='input_file_size')
     disk_out_scheduled = serializers.FloatField()
     disk_total_scheduled = serializers.FloatField()
 
+    environment = serializers.JSONField(default=dict)
     results = serializers.JSONField(default=dict, source='jobexecutionoutput.output')
+    results_manifest = serializers.JSONField(default=dict)
 
+
+class JobExecutionDetailsSerializer(JobExecutionSerializer):
+    """Converts job execution model fields to REST output"""
+
+    from error.serializers import ErrorSerializer
+    from node.serializers import NodeSerializerV4
+
+    job = JobSerializer()
+    node = NodeSerializerV4()
+    error = ErrorSerializer(source='jobexecutionend.error')
+
+    task_results = serializers.JSONField(default=dict)
+    resources = serializers.JSONField(default=dict)
+    configuration = serializers.JSONField(default=dict)
+
+    environment = serializers.JSONField(default=dict)
+    results = serializers.JSONField(default=dict, source='jobexecutionoutput.output')
     results_manifest = serializers.JSONField(default=dict)
 
 

--- a/scale/job/serializers.py
+++ b/scale/job/serializers.py
@@ -201,7 +201,8 @@ class OldJobExecutionBaseSerializer(ModelIdSerializer):
 class JobExecutionBaseSerializer(ModelIdSerializer):
     """Converts job execution model fields to REST output"""
     status = serializers.CharField(source='get_status')
-    timeout = serializers.IntegerField()
+    exe_num = serializers.IntegerField()
+    cluster_id = serializers.CharField()
 
     created = serializers.DateTimeField()
     queued = serializers.DateTimeField()
@@ -211,6 +212,7 @@ class JobExecutionBaseSerializer(ModelIdSerializer):
     job = ModelIdSerializer()
     node = ModelIdSerializer()
     error = ModelIdSerializer()
+    job_type = ModelIdSerializer()
 
 
 class JobDetailsInputSerializer(serializers.Serializer):
@@ -309,8 +311,7 @@ class JobExecutionSerializer(JobExecutionBaseSerializer):
     error = ErrorBaseSerializer(source='jobexecutionend.error')
     job_type = JobTypeBaseSerializer()
 
-    exe_num = serializers.IntegerField()
-    cluster_id = serializers.CharField()
+    timeout = serializers.IntegerField()
     input_file_size = serializers.FloatField()
 
 
@@ -329,7 +330,7 @@ class OldJobExecutionDetailsSerializer(OldJobExecutionSerializer):
 class JobExecutionDetailsSerializer(JobExecutionSerializer):
     """Converts job execution model fields to REST output"""
 
-    task_results = serializers.JSONField(default=dict)
+    task_results = serializers.JSONField(default=dict, source='jobexecutionend.task_results')
     resources = serializers.JSONField(default=dict)
     configuration = serializers.JSONField(default=dict)
     output = serializers.JSONField(default=dict, source='jobexecutionoutput.output')

--- a/scale/job/serializers.py
+++ b/scale/job/serializers.py
@@ -169,7 +169,7 @@ class JobRevisionSerializer(JobSerializer):
     job_type_rev = JobTypeRevisionSerializer()
 
 # TODO: remove this function when REST API v5 is removed 
-class JobExecutionBaseSerializer(ModelIdSerializer):
+class OldJobExecutionBaseSerializer(ModelIdSerializer):
     """Converts job execution model fields to REST output"""
     status = serializers.CharField(source='get_status')
     command_arguments = serializers.CharField()
@@ -186,6 +186,23 @@ class JobExecutionBaseSerializer(ModelIdSerializer):
     post_started = serializers.DateTimeField()
     post_completed = serializers.DateTimeField()
     post_exit_code = serializers.IntegerField()
+
+    created = serializers.DateTimeField()
+    queued = serializers.DateTimeField()
+    started = serializers.DateTimeField()
+    ended = serializers.DateTimeField(source='jobexecutionend.ended')
+    last_modified = serializers.DateTimeField(source='created')
+
+    job = ModelIdSerializer()
+    node = ModelIdSerializer()
+    error = ModelIdSerializer()
+
+
+class JobExecutionBaseSerializer(ModelIdSerializer):
+    """Converts job execution model fields to REST output"""
+    status = serializers.CharField(source='get_status')
+    command_arguments = serializers.CharField()
+    timeout = serializers.IntegerField()
 
     created = serializers.DateTimeField()
     queued = serializers.DateTimeField()
@@ -258,7 +275,7 @@ class JobDetailsSerializer(JobSerializer):
     except:
         recipes = []
 
-    job_exes = JobExecutionBaseSerializer(many=True)
+    job_exes = OldJobExecutionBaseSerializer(many=True)
 
     inputs = JobDetailsInputSerializer(many=True)
     outputs = JobDetailsOutputSerializer(many=True)
@@ -272,7 +289,7 @@ class JobUpdateSerializer(JobSerializer):
 
 
 # TODO: remove this function when REST API v5 is removed
-class OldJobExecutionSerializer(JobExecutionBaseSerializer):
+class OldJobExecutionSerializer(OldJobExecutionBaseSerializer):
     """Converts job execution model fields to REST output"""
 
     from error.serializers import ErrorBaseSerializer
@@ -314,13 +331,6 @@ class OldJobExecutionDetailsSerializer(OldJobExecutionSerializer):
 class JobExecutionDetailsSerializer(JobExecutionSerializer):
     """Converts job execution model fields to REST output"""
 
-    from error.serializers import ErrorSerializer
-    from node.serializers import NodeSerializerV4
-
-    job = JobSerializer()
-    node = NodeSerializerV4()
-    error = ErrorSerializer(source='jobexecutionend.error')
-
     task_results = serializers.JSONField(default=dict)
     resources = serializers.JSONField(default=dict)
     configuration = serializers.JSONField(default=dict)
@@ -340,4 +350,4 @@ class JobExecutionLogSerializer(JobExecutionSerializer):
 # TODO: remove when REST API v5 is removed
 class JobWithExecutionSerializer(JobSerializer):
     """Converts job with latest execution model fields to REST output"""
-    latest_job_exe = JobExecutionBaseSerializer()
+    latest_job_exe = OldJobExecutionBaseSerializer()

--- a/scale/job/serializers.py
+++ b/scale/job/serializers.py
@@ -201,14 +201,12 @@ class OldJobExecutionBaseSerializer(ModelIdSerializer):
 class JobExecutionBaseSerializer(ModelIdSerializer):
     """Converts job execution model fields to REST output"""
     status = serializers.CharField(source='get_status')
-    command_arguments = serializers.CharField()
     timeout = serializers.IntegerField()
 
     created = serializers.DateTimeField()
     queued = serializers.DateTimeField()
     started = serializers.DateTimeField()
     ended = serializers.DateTimeField(source='jobexecutionend.ended')
-    last_modified = serializers.DateTimeField(source='created')
 
     job = ModelIdSerializer()
     node = ModelIdSerializer()
@@ -304,10 +302,10 @@ class JobExecutionSerializer(JobExecutionBaseSerializer):
     """Converts job execution model fields to REST output"""
 
     from error.serializers import ErrorBaseSerializer
-    from node.serializers import NodeBaseSerializerV4
+    from node.serializers import NodeBaseSerializer
 
     job = ModelIdSerializer()
-    node = NodeBaseSerializerV4()
+    node = NodeBaseSerializer()
     error = ErrorBaseSerializer(source='jobexecutionend.error')
     job_type = JobTypeBaseSerializer()
 
@@ -334,10 +332,7 @@ class JobExecutionDetailsSerializer(JobExecutionSerializer):
     task_results = serializers.JSONField(default=dict)
     resources = serializers.JSONField(default=dict)
     configuration = serializers.JSONField(default=dict)
-
-    environment = serializers.JSONField(default=dict)
-    results = serializers.JSONField(default=dict, source='jobexecutionoutput.output')
-    results_manifest = serializers.JSONField(default=dict)
+    output = serializers.JSONField(default=dict, source='jobexecutionoutput.output')
 
 
 class JobExecutionLogSerializer(JobExecutionSerializer):

--- a/scale/job/serializers.py
+++ b/scale/job/serializers.py
@@ -271,6 +271,7 @@ class JobUpdateSerializer(JobSerializer):
     input_files = ScaleFileSerializer(many=True)
 
 
+# TODO: remove when REST API v5 is removed
 class JobExecutionSerializer(JobExecutionBaseSerializer):
     """Converts job execution model fields to REST output"""
     from error.serializers import ErrorBaseSerializer
@@ -281,6 +282,7 @@ class JobExecutionSerializer(JobExecutionBaseSerializer):
     error = ErrorBaseSerializer(source='jobexecutionend.error')
 
 
+# TODO: remove when REST API v5 is removed
 class JobExecutionDetailsSerializer(JobExecutionSerializer):
     """Converts job execution model fields to REST output"""
     from error.serializers import ErrorSerializer
@@ -309,6 +311,7 @@ class JobExecutionLogSerializer(JobExecutionSerializer):
     stderr = serializers.CharField()
 
 
+# TODO: remove when REST API v5 is removed
 class JobWithExecutionSerializer(JobSerializer):
     """Converts job with latest execution model fields to REST output"""
     latest_job_exe = JobExecutionBaseSerializer()

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -13,6 +13,7 @@ from rest_framework import status
 import batch.test.utils as batch_test_utils
 import error.test.utils as error_test_utils
 import job.test.utils as job_test_utils
+import node.test.utils as node_test_utils
 import storage.test.utils as storage_test_utils
 import trigger.test.utils as trigger_test_utils
 import util.rest as rest_util
@@ -2483,15 +2484,21 @@ class TestJobExecutionsView(TransactionTestCase):
 
         self.job_type_1 = job_test_utils.create_job_type()
         self.job_1 = job_test_utils.create_job(job_type=self.job_type_1, status='COMPLETED')
+        self.node_1 = node_test_utils.create_node()
+        self.node_2 = node_test_utils.create_node()
 
-        self.job_exe_1a = job_test_utils.create_job_exe(job=self.job_1, exe_num=1, status='FAILED')
-        self.job_exe_1b = job_test_utils.create_job_exe(job=self.job_1, exe_num=2, status='COMPLETED')
-        self.job_exe_1c = job_test_utils.create_job_exe(job=self.job_1, exe_num=3, status='COMPLETED')
-        self.last_exe_1 = job_test_utils.create_job_exe(job=self.job_1, exe_num=4, status='RUNNING')
+        self.job_exe_1a = job_test_utils.create_job_exe(job=self.job_1, exe_num=1, status='FAILED', node=self.node_1,
+                                                        started='2017-01-02T00:00:00Z', ended='2017-01-02T01:00:00Z')
+        self.job_exe_1b = job_test_utils.create_job_exe(job=self.job_1, exe_num=2, status='COMPLETED', node=self.node_2,
+                                                        started='2017-01-01T00:00:00Z', ended='2017-01-01T01:00:00Z')
+        self.job_exe_1c = job_test_utils.create_job_exe(job=self.job_1, exe_num=3, status='COMPLETED', node=self.node_2,
+                                                        started='2017-01-01T00:00:00Z', ended='2017-01-01T01:00:00Z')
+        self.last_exe_1 = job_test_utils.create_job_exe(job=self.job_1, exe_num=4, status='RUNNING', node=self.node_2,
+                                                        started='2017-01-03T00:00:00Z', ended='2017-01-03T01:00:00Z')
 
     def test_get_job_executions(self):
         """This test checks to make sure there are 4 job executions."""
-        url = rest_util.get_url('/jobs/%d/executions' % self.job_1.id)
+        url = rest_util.get_url('/jobs/%d/executions/' % self.job_1.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -2500,12 +2507,39 @@ class TestJobExecutionsView(TransactionTestCase):
         self.assertEqual(job_exe_count, 4)
 
     def test_get_job_execution_bad_id(self):
-        url = rest_util.get_url('/jobs/999999999/executions')
+        url = rest_util.get_url('/jobs/999999999/executions/')
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
 
+    def test_get_job_execution_filter_node(self):
+        url = rest_util.get_url('/jobs/%d/executions/?node_id=%d' % (self.job_1.id, self.node_1.id))
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
-class TestJobExecutionsView(TransactionTestCase):
+        results = json.loads(response.content)
+        job_exe_count = results['count']
+        self.assertEqual(job_exe_count, 1)
+
+    def test_get_job_execution_filter_status(self):
+        url = rest_util.get_url('/jobs/%d/executions/?status=COMPLETED' % self.job_1.id)
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        job_exe_count = results['count']
+        self.assertEqual(job_exe_count, 2)
+
+    def test_get_job_execution_filter_time(self):
+        url = rest_util.get_url('/jobs/%d/executions/?started=2017-01-01T00:00:00Z&ended=2017-01-02T00:00:00Z' % self.job_1.id)
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        job_exe_count = results['count']
+        self.assertEqual(job_exe_count, 2)
+
+
+class TestJobExecutionDetailsView(TransactionTestCase):
 
     def setUp(self):
         django.setup()

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -2509,7 +2509,8 @@ class TestJobExecutionsView(TransactionTestCase):
     def test_get_job_execution_bad_id(self):
         url = rest_util.get_url('/jobs/999999999/executions/')
         response = self.client.generic('GET', url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
+        result = json.loads(response.content)
+        self.assertEqual(result['results'], [])
 
     def test_get_job_execution_filter_node(self):
         url = rest_util.get_url('/jobs/%d/executions/?node_id=%d' % (self.job_1.id, self.node_1.id))
@@ -2555,6 +2556,7 @@ class TestJobExecutionDetailsView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         results = json.loads(response.content)
+        print results
         self.assertEqual(results['id'], self.job_exe_1a.id)
 
     def test_get_job_execution_bad_exe_num(self):

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -2555,7 +2555,7 @@ class TestJobExecutionDetailsView(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         results = json.loads(response.content)
-        self.assertEqual(results[0]['id'], self.job_exe_1a.id)
+        self.assertEqual(results['id'], self.job_exe_1a.id)
 
     def test_get_job_execution_bad_exe_num(self):
         url = rest_util.get_url('/jobs/%d/executions/%d/' % (self.job_1.id, 999999999))

--- a/scale/job/urls.py
+++ b/scale/job/urls.py
@@ -19,6 +19,8 @@ urlpatterns = [
     # Job views
     url(r'^jobs/$', views.JobsView.as_view(), name='jobs_view'),
     url(r'^jobs/(\d+)/$', views.JobDetailsView.as_view(), name='job_details_view'),
+    url(r'^jobs/(\d+)/executions/$', views.JobExecutionsView.as_view(), name=''),
+    url(r'^jobs/(\d+)/executions/(\d+)/$', views.JobExecutionDetailsView.as_view(), name=''),
     url(r'^jobs/(\d+)/input_files/$', views.JobInputFilesView.as_view(), name='job_input_files_view'),
     url(r'^jobs/updates/$', views.JobUpdatesView.as_view(), name='job_updates_view'),
 

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -806,9 +806,12 @@ class JobExecutionsView(ListAPIView):
             job_exes = JobExecution.objects.get_job_exes(job_id=job_id, started=started, ended=ended,
                                                          statuses=statuses, node_ids=node_ids)
 
-            page = self.paginate_queryset(job_exes)
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
+            if job_exes.exists():
+                page = self.paginate_queryset(job_exes)
+                serializer = self.get_serializer(page, many=True)
+                return self.get_paginated_response(serializer.data)
+            else:
+                raise Http404
 
     # TODO: remove when REST API v5 is removed
     def list_v5(self, request):
@@ -868,11 +871,11 @@ class JobExecutionDetailsView(RetrieveAPIView):
         else:
             job_exe = JobExecution.objects.get_job_exe_details(job_id=job_id, exe_num=exe_num)
 
-            if not job_exe.exists():
+            if job_exe.exists():
+                serializer = self.get_serializer(job_exe, many=True)
+                return Response(serializer.data)
+            else:
                 raise Http404
-
-            serializer = self.get_serializer(job_exe, many=True)
-            return Response(serializer.data)
 
     # TODO: remove when REST API v5 is removed
     def retrieve_v5(self, request, job_exe_id):

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -800,7 +800,7 @@ class JobExecutionsView(ListAPIView):
             job_exes = JobExecution.objects.get_job_exes(job_id=job_id)
 
             page = self.paginate_queryset(job_exes)
-            serializer = OldJobExecutionSerializer(page, many=True)
+            serializer = self.get_serializer(page, many=True)
             return self.get_paginated_response(serializer.data)
 
     # TODO: remove when REST API v5 is removed
@@ -838,21 +838,21 @@ class JobExecutionDetailsView(RetrieveAPIView):
     queryset = JobExecution.objects.all()
     serializer_class = JobExecutionDetailsSerializer
 
-    def retrieve(self, request, job_id, job_exe_id=None):
+    def retrieve(self, request, job_id, exe_num=None):
         """Gets job execution and associated job_type id, name, and version
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
         :param job_id: The ID for the job.
         :type job_id: int encoded as a str
-        :param job_exe_id: the job execution id
-        :type job_exe_id: int encoded as a str
+        :param exe_num: the execution number
+        :type exe_num: int encoded as a str
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
 
         # TODO: remove this check when REST API v5 is removed
-        if not job_exe_id:
+        if not exe_num:
             if request.version == 'v5':
                 job_exe_id = job_id
                 return self.retrieve_v5(request, job_exe_id)
@@ -860,10 +860,12 @@ class JobExecutionDetailsView(RetrieveAPIView):
                 raise Http404
         else:
             try:
-                job_exe = JobExecution.objects.get_details(job_id)
+                job_exe = JobExecution.objects.get_job_exe_details(job_id=job_id, exe_num=exe_num)
             except JobExecution.DoesNotExist:
                 raise Http404
 
+            serializer = self.get_serializer(job_exe)
+            return Response(serializer.data)
 
     # TODO: remove when REST API v5 is removed
     def retrieve_v5(self, request, job_exe_id):

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -731,6 +731,21 @@ class JobsWithExecutionView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+
+        if request.version == 'v5':
+            return self.list_v5(request)
+        else:
+            raise Http404
+
+    # TODO: remove when REST API v5 is removed
+    def list_v5(self, request):
+        """Gets jobs and their associated latest execution
+
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
         started = rest_util.parse_timestamp(request, 'started', required=False)
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
@@ -772,6 +787,21 @@ class JobExecutionsView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+
+        if request.version == 'v5':
+            return self.list_v5(request)
+        else:
+            raise Http404
+
+    # TODO: remove when REST API v5 is removed
+    def list_v5(self, request):
+        """Gets job executions and their associated job_type id, name, and version
+
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
         started = rest_util.parse_timestamp(request, 'started', required=False)
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
@@ -799,6 +829,23 @@ class JobExecutionDetailsView(RetrieveAPIView):
     serializer_class = JobExecutionDetailsSerializer
 
     def retrieve(self, request, job_exe_id):
+        """Gets job execution and associated job_type id, name, and version
+
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :param job_exe_id: the job execution id
+        :type job_exe_id: int
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+
+        if request.version == 'v5':
+            self.retrieve_v5(request, job_exe_id)
+        else:
+            return Http404
+
+    # TODO: remove when REST API v5 is removed
+    def retrieve_v5(self, request, job_exe_id):
         """Gets job execution and associated job_type id, name, and version
 
         :param request: the HTTP GET request

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -840,9 +840,9 @@ class JobExecutionDetailsView(RetrieveAPIView):
         """
 
         if request.version == 'v5':
-            self.retrieve_v5(request, job_exe_id)
+            return self.retrieve_v5(request, job_exe_id)
         else:
-            return Http404
+            raise Http404
 
     # TODO: remove when REST API v5 is removed
     def retrieve_v5(self, request, job_exe_id):

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -803,15 +803,13 @@ class JobExecutionsView(ListAPIView):
             statuses = rest_util.parse_string_list(request, 'status', required=False)
             node_ids = rest_util.parse_int_list(request, 'node_id', required=False)
 
+
             job_exes = JobExecution.objects.get_job_exes(job_id=job_id, started=started, ended=ended,
                                                          statuses=statuses, node_ids=node_ids)
 
-            if job_exes.exists():
-                page = self.paginate_queryset(job_exes)
-                serializer = self.get_serializer(page, many=True)
-                return self.get_paginated_response(serializer.data)
-            else:
-                raise Http404
+            page = self.paginate_queryset(job_exes)
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
 
     # TODO: remove when REST API v5 is removed
     def list_v5(self, request):
@@ -869,13 +867,13 @@ class JobExecutionDetailsView(RetrieveAPIView):
             else:
                 raise Http404
         else:
-            job_exe = JobExecution.objects.get_job_exe_details(job_id=job_id, exe_num=exe_num)
-
-            if job_exe.exists():
-                serializer = self.get_serializer(job_exe, many=True)
-                return Response(serializer.data)
-            else:
+            try:
+                job_exe = JobExecution.objects.get_job_exe_details(job_id=job_id, exe_num=exe_num)
+            except JobExecution.DoesNotExist:
                 raise Http404
+
+            serializer = self.get_serializer(job_exe)
+            return Response(serializer.data)
 
     # TODO: remove when REST API v5 is removed
     def retrieve_v5(self, request, job_exe_id):

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -859,12 +859,12 @@ class JobExecutionDetailsView(RetrieveAPIView):
             else:
                 raise Http404
         else:
-            try:
-                job_exe = JobExecution.objects.get_job_exe_details(job_id=job_id, exe_num=exe_num)
-            except JobExecution.DoesNotExist:
+            job_exe = JobExecution.objects.get_job_exe_details(job_id=job_id, exe_num=exe_num)
+            
+            if not job_exe.exists():
                 raise Http404
 
-            serializer = self.get_serializer(job_exe)
+            serializer = self.get_serializer(job_exe, many=True)
             return Response(serializer.data)
 
     # TODO: remove when REST API v5 is removed


### PR DESCRIPTION
 * Deprecated old views, functions, tests, serializers, and docs. 
 * Added 2 new `/jobs/` endpoints for viewing job_exes associated with the requested job_id.
 * Added views, functions, and serializers to handle the two new endpoints.