### PR TITLE
#948 Add job type to elasticsearch logs

### DIFF
--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -300,8 +300,16 @@ def deploy_logstash(client, app_name, es_urls, es_lb):
     # attempt to delete an old instance..if it doesn't exists it will error but we don't care so we ignore it
     delete_marathon_app(client, app_name)
 
+    #default based on MARATHON_APP_DOCKER_IMAGE with repo/scale:tag updated to repo/scale-logstash:tag
+    marathon_img_default = os.getenv('MARATHON_APP_DOCKER_IMAGE')
+    if marathon_img_default.endswith(':'):
+        logstash_docker_img_default = marathon_img_default.replace(':', '-logstash:')
+    else:
+        logstash_docker_img_default = marathon_img_default + '-logstash'
+
     # Load marathon template file
-    marathon = initialize_app_template('logstash', app_name, os.getenv('LOGSTASH_DOCKER_IMAGE'))
+    marathon = initialize_app_template('logstash', app_name, os.getenv(
+        'LOGSTASH_DOCKER_IMAGE', logstash_docker_img_default))
 
     arbitrary_env = {
         'ELASTICSEARCH_LB': es_lb,

--- a/dockerfiles/logstash/logstash.conf-template
+++ b/dockerfiles/logstash/logstash.conf-template
@@ -18,7 +18,7 @@ filter {
     ruby {
       init => "@ordernum = 0"
       code => "@ordernum += 1; tag_items = event['program'].split('++'); event['scale_order_num'] = @ordernum; event['scale_task'] = tag_items[0].sub(%r{^docker/}, ''); event['scale_job_exe'] = event['scale_task'].sub(%r{_[^_]*$}, ''); event['scale_node'] = event['logsource']; event['stream'] = event['severity'] == 3 ? 'stderr' : 'stdout'; event['job_type'] = tag_items[1]"
-     remove_field => ["host", "priority", "timestamp8601", "logsource", "program", "pid", "severity", "facility", "timestamp", "facility_label", "severity_label", "job_type"]
+      remove_field => ["host", "priority", "timestamp8601", "logsource", "program", "pid", "severity", "facility", "timestamp", "facility_label", "severity_label", "job_type"]
     }
   }
   else {

--- a/dockerfiles/logstash/logstash.conf-template
+++ b/dockerfiles/logstash/logstash.conf-template
@@ -17,14 +17,14 @@ filter {
   if [@metadata][DEBUG] != 'true' {
     ruby {
       init => "@ordernum = 0"
-      code => "@ordernum += 1; tag_items = event['program'].split('++'); event['scale_order_num'] = @ordernum; event['scale_task'] = tag_items[0].sub(%r{^docker/}, ''); event['scale_job_exe'] = event['scale_task'].sub(%r{_[^_]*$}, ''); event['scale_node'] = event['logsource']; event['stream'] = event['severity'] == 3 ? 'stderr' : 'stdout'; event['job_type'] = tag_items[1]"
+      code => "@ordernum += 1; tag_items = event['program'].split('|'); event['scale_order_num'] = @ordernum; event['scale_task'] = tag_items[0].sub(%r{^docker/}, ''); event['scale_job_exe'] = event['scale_task'].sub(%r{_[^_]*$}, ''); event['scale_node'] = event['logsource']; event['stream'] = event['severity'] == 3 ? 'stderr' : 'stdout'; event['job_type'] = tag_items[1]"
       remove_field => ["host", "priority", "timestamp8601", "logsource", "program", "pid", "severity", "facility", "timestamp", "facility_label", "severity_label", "job_type"]
     }
   }
   else {
     ruby {
       init => "@ordernum = 0"
-      code => "@ordernum += 1; tag_items = event['program'].split('++'); event['scale_order_num'] = @ordernum; event['scale_task'] = tag_items[0].sub(%r{^docker/}, ''); event['scale_job_exe'] = event['scale_task'].sub(%r{_[^_]*$}, ''); event['scale_node'] = event['logsource']; event['stream'] = event['severity'] == 3 ? 'stderr' : 'stdout'; event['job_type'] = tag_items[1]"
+      code => "@ordernum += 1; tag_items = event['program'].split('|'); event['scale_order_num'] = @ordernum; event['scale_task'] = tag_items[0].sub(%r{^docker/}, ''); event['scale_job_exe'] = event['scale_task'].sub(%r{_[^_]*$}, ''); event['scale_node'] = event['logsource']; event['stream'] = event['severity'] == 3 ? 'stderr' : 'stdout'; event['job_type'] = tag_items[1]"
     }
   }
 

--- a/dockerfiles/logstash/logstash.conf-template
+++ b/dockerfiles/logstash/logstash.conf-template
@@ -17,14 +17,14 @@ filter {
   if [@metadata][DEBUG] != 'true' {
     ruby {
       init => "@ordernum = 0"
-      code => "@ordernum += 1; event['scale_order_num'] = @ordernum; event['scale_task'] = event['program'].sub(%r{^docker/}, ''); event['scale_job_exe'] = event['scale_task'].sub(%r{_[^_]*$}, ''); event['scale_node'] = event['logsource']; event['stream'] = event['severity'] == 3 ? 'stderr' : 'stdout'"
-      remove_field => ["host", "priority", "timestamp8601", "logsource", "program", "pid", "severity", "facility", "timestamp", "facility_label", "severity_label"]
+      code => "@ordernum += 1; tag_items = event['program'].split('++'); event['scale_order_num'] = @ordernum; event['scale_task'] = tag_items[0].sub(%r{^docker/}, ''); event['scale_job_exe'] = event['scale_task'].sub(%r{_[^_]*$}, ''); event['scale_node'] = event['logsource']; event['stream'] = event['severity'] == 3 ? 'stderr' : 'stdout'; event['job_type'] = tag_items[1]"
+     remove_field => ["host", "priority", "timestamp8601", "logsource", "program", "pid", "severity", "facility", "timestamp", "facility_label", "severity_label", "job_type"]
     }
   }
   else {
     ruby {
       init => "@ordernum = 0"
-      code => "@ordernum += 1; event['scale_order_num'] = @ordernum; event['scale_task'] = event['program'].sub(%r{^docker/}, ''); event['scale_job_exe'] = event['scale_task'].sub(%r{_[^_]*$}, ''); event['scale_node'] = event['logsource']; event['stream'] = event['severity'] == 3 ? 'stderr' : 'stdout'"
+      code => "@ordernum += 1; tag_items = event['program'].split('++'); event['scale_order_num'] = @ordernum; event['scale_task'] = tag_items[0].sub(%r{^docker/}, ''); event['scale_job_exe'] = event['scale_task'].sub(%r{_[^_]*$}, ''); event['scale_node'] = event['logsource']; event['stream'] = event['severity'] == 3 ? 'stderr' : 'stdout'; event['job_type'] = tag_items[1]"
     }
   }
 

--- a/scale/job/configuration/configurators.py
+++ b/scale/job/configuration/configurators.py
@@ -322,9 +322,9 @@ class ScheduledExecutionConfigurator(object):
             syslog_format = DockerParameter('log-opt', 'syslog-format=rfc3164')
             log_address = DockerParameter('log-opt', 'syslog-address=%s' % settings.LOGGING_ADDRESS)
             if not job_type.is_system:
-                pre_task_tag = DockerParameter('log-opt', 'tag=%s' % config.get_task_id('pre'))
+                pre_task_tag = DockerParameter('log-opt', 'tag=%s++%s' % (config.get_task_id('pre'),job_type.name))
                 config.add_to_task('pre', docker_params=[log_driver, syslog_format, log_address, pre_task_tag])
-                post_task_tag = DockerParameter('log-opt', 'tag=%s' % config.get_task_id('post'))
+                post_task_tag = DockerParameter('log-opt', 'tag=%s++%s' % (config.get_task_id('post'),job_type.name))
                 config.add_to_task('post', docker_params=[log_driver, syslog_format, log_address, post_task_tag])
                 # TODO: remove es_urls parameter when Scale no longer supports old style job types
                 es_urls = None
@@ -335,7 +335,7 @@ class ScheduledExecutionConfigurator(object):
                 # Post task needs ElasticSearch URL to grab logs for old artifact registration
                 es_param = DockerParameter('env', 'SCALE_ELASTICSEARCH_URLS=%s' % es_urls)
                 config.add_to_task('post', docker_params=[es_param])
-            main_task_tag = DockerParameter('log-opt', 'tag=%s' % config.get_task_id('main'))
+            main_task_tag = DockerParameter('log-opt', 'tag=%s++%s' % (config.get_task_id('main'),job_type.name))
             config.add_to_task('main', docker_params=[log_driver, syslog_format, log_address, main_task_tag])
 
     @staticmethod

--- a/scale/job/configuration/configurators.py
+++ b/scale/job/configuration/configurators.py
@@ -322,9 +322,9 @@ class ScheduledExecutionConfigurator(object):
             syslog_format = DockerParameter('log-opt', 'syslog-format=rfc3164')
             log_address = DockerParameter('log-opt', 'syslog-address=%s' % settings.LOGGING_ADDRESS)
             if not job_type.is_system:
-                pre_task_tag = DockerParameter('log-opt', 'tag=%s++%s' % (config.get_task_id('pre'),job_type.name))
+                pre_task_tag = DockerParameter('log-opt', 'tag=%s|%s' % (config.get_task_id('pre'),job_type.name))
                 config.add_to_task('pre', docker_params=[log_driver, syslog_format, log_address, pre_task_tag])
-                post_task_tag = DockerParameter('log-opt', 'tag=%s++%s' % (config.get_task_id('post'),job_type.name))
+                post_task_tag = DockerParameter('log-opt', 'tag=%s|%s' % (config.get_task_id('post'),job_type.name))
                 config.add_to_task('post', docker_params=[log_driver, syslog_format, log_address, post_task_tag])
                 # TODO: remove es_urls parameter when Scale no longer supports old style job types
                 es_urls = None
@@ -335,7 +335,7 @@ class ScheduledExecutionConfigurator(object):
                 # Post task needs ElasticSearch URL to grab logs for old artifact registration
                 es_param = DockerParameter('env', 'SCALE_ELASTICSEARCH_URLS=%s' % es_urls)
                 config.add_to_task('post', docker_params=[es_param])
-            main_task_tag = DockerParameter('log-opt', 'tag=%s++%s' % (config.get_task_id('main'),job_type.name))
+            main_task_tag = DockerParameter('log-opt', 'tag=%s|%s' % (config.get_task_id('main'),job_type.name))
             config.add_to_task('main', docker_params=[log_driver, syslog_format, log_address, main_task_tag])
 
     @staticmethod

--- a/scale/job/test/configuration/test_configurators.py
+++ b/scale/job/test/configuration/test_configurators.py
@@ -385,7 +385,8 @@ class TestScheduledExecutionConfigurator(TestCase):
                         self.assertEqual(opt_value, 'test-logging-address')
                         found_syslog_address = True
                     elif opt_name == 'tag':
-                        self.assertEqual(opt_value, exe_config_with_secrets.get_task_id(task_type))
+                        tag_value = '%s|%s' % (exe_config_with_secrets.get_task_id(task_type), job_type.name)
+                        self.assertEqual(opt_value, tag_value)
                         found_tag = True
             self.assertTrue(found_log_driver)
             self.assertTrue(found_syslog_format)


### PR DESCRIPTION
added job_type to logstash output. 
added job_type to main_task_tag, separated by '++' and split out within logstash.conf-template
fixes #948 