### PR TITLE
Issue 1031 - Scale does not recover from database crashes

### DIFF
--- a/scale/scheduler/management/commands/scale_scheduler.py
+++ b/scale/scheduler/management/commands/scale_scheduler.py
@@ -31,6 +31,9 @@ DEFAULT_PRINCIPLE = None
 DEFAULT_SECRET = None
 
 
+GLOBAL_SHUTDOWN = None
+
+
 class Command(BaseCommand):
     """Command that launches the Scale scheduler
     """
@@ -50,6 +53,10 @@ class Command(BaseCommand):
 
         # Register a listener to handle clean shutdowns
         signal.signal(signal.SIGTERM, self._onsigterm)
+
+        # Set up global shutdown
+        global GLOBAL_SHUTDOWN
+        GLOBAL_SHUTDOWN = self._shutdown
 
         # TODO: clean this up
         mesos_master = options.get('master')
@@ -115,7 +122,7 @@ class Command(BaseCommand):
             logger.exception('Mesos Scheduler Driver returned an exception')
 
         #Perform a shut down and return any non-zero status
-        shutdown_status = self._shutdown
+        shutdown_status = self._shutdown()
         status = status or shutdown_status
 
         logger.info('Exiting...')

--- a/scale/scheduler/threads/base_thread.py
+++ b/scale/scheduler/threads/base_thread.py
@@ -9,8 +9,6 @@ from abc import ABCMeta
 from django.db.utils import InterfaceError
 from django.utils.timezone import now
 
-from scheduler.management.commands.scale_scheduler import GLOBAL_SHUTDOWN
-
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +52,7 @@ class BaseSchedulerThread(object):
                     msg = '%s thread has detected that the database connection is closed and cannot be recovered.'
                     msg += ' Shutting down the scheduler...'
                     logger.error(msg, self._name)
+                    from scheduler.management.commands.scale_scheduler import GLOBAL_SHUTDOWN
                     GLOBAL_SHUTDOWN()
             except Exception:
                 logger.exception('%s thread had a critical error', self._name)

--- a/scale/scheduler/threads/base_thread.py
+++ b/scale/scheduler/threads/base_thread.py
@@ -6,7 +6,10 @@ import math
 import time
 from abc import ABCMeta
 
+from django.db.utils import InterfaceError
 from django.utils.timezone import now
+
+from scheduler.management.commands.scale_scheduler import GLOBAL_SHUTDOWN
 
 
 logger = logging.getLogger(__name__)
@@ -45,6 +48,13 @@ class BaseSchedulerThread(object):
 
             try:
                 self._execute()
+            except InterfaceError as err:
+                logger.exception('%s thread had a critical error interfacing with the database', self._name)
+                if err.message == 'connection already closed':
+                    msg = '%s thread has detected that the database connection is closed and cannot be recovered.'
+                    msg += ' Shutting down the scheduler...'
+                    logger.error(msg, self._name)
+                    GLOBAL_SHUTDOWN()
             except Exception:
                 logger.exception('%s thread had a critical error', self._name)
 


### PR DESCRIPTION
I put in a fix so that when a thread detects a closed, unrecoverable database connection, the Scale scheduler shut downs (allowing it to be restarted by Marathon).