### PR TITLE
Issue 1077 - Clean up duplicate job executions

### DIFF
--- a/scale/scheduler/database/updater.py
+++ b/scale/scheduler/database/updater.py
@@ -80,10 +80,10 @@ class DatabaseUpdater(object):
         job_ids_by_exe_num = {}  # {Exe num: [Job ID]}
         job_exe_ids_by_exe_num = {}  # {Exe num: [Job Exe ID]}, these are the "good" exes to keep
         qry = 'SELECT job_id, exe_num, count(*), min(id) FROM job_exe'
-        qry += ' WHERE job_id BETWEEN %d AND %d GROUP BY job_id, exe_num'
+        qry += ' WHERE job_id BETWEEN %s AND %s GROUP BY job_id, exe_num'
         qry = 'SELECT job_id, exe_num, count, min FROM (%s) c WHERE count > 1' % qry
         with connection.cursor() as cursor:
-            cursor.execute(qry, [batch_start_job_id, batch_end_job_id])
+            cursor.execute(qry, [str(batch_start_job_id), str(batch_end_job_id)])
             for row in cursor.fetchall():
                 job_id = row[0]
                 exe_num = row[1]
@@ -111,7 +111,7 @@ class DatabaseUpdater(object):
         TaskUpdate.objects.filter(job_exe_id__in=job_exe_ids_to_delete).delete()
         JobExecutionOutput.objects.filter(job_exe_id__in=job_exe_ids_to_delete).delete()
         JobExecutionEnd.objects.filter(job_exe_id__in=job_exe_ids_to_delete).delete()
-        deleted_count = JobExecution.objects.filter(job_exe_id__in=job_exe_ids_to_delete).delete()[0]
+        deleted_count = JobExecution.objects.filter(id__in=job_exe_ids_to_delete).delete()[0]
         logger.info('Deleted %d duplicates', deleted_count)
 
         self._updated_job += job_batch_size

--- a/scale/scheduler/database/updater.py
+++ b/scale/scheduler/database/updater.py
@@ -114,6 +114,8 @@ class DatabaseUpdater(object):
             logger.info('No duplicates found')
 
         self._updated_job += job_batch_size
+        if self._updated_job > self._total_job:
+            self._updated_job = self._total_job
         percent = (float(self._updated_job) / float(self._total_job)) * 100.00
         logger.info('Completed %s of %s jobs (%.1f%%)', self._updated_job, self._total_job, percent)
 

--- a/scale/scheduler/database/updater.py
+++ b/scale/scheduler/database/updater.py
@@ -3,10 +3,10 @@ from __future__ import unicode_literals
 
 import logging
 
-from django.db import transaction
+from django.db import connection, transaction
 
 from job.execution.tasks.json.results.task_results import TaskResults
-from job.models import JobExecution, JobExecutionEnd, JobExecutionOutput
+from job.models import Job, JobExecution, JobExecutionEnd, JobExecutionOutput, TaskUpdate
 from util.exceptions import TerminatedCommand
 from util.parse import datetime_to_string
 
@@ -24,13 +24,15 @@ class DatabaseUpdater(object):
         self._running = True
         self._updated_job_exe = 0
         self._total_job_exe = 0
+        self._updated_job = 0
+        self._total_job = 0
 
     def update(self):
         """Runs the database update
         """
 
+        # Converting job execution models
         self._perform_update_init()
-
         while True:
             if not self._running:
                 raise TerminatedCommand()
@@ -39,12 +41,82 @@ class DatabaseUpdater(object):
                 break
             self._perform_update_iteration()
 
+        # Removing job execution duplicates
+        self._perform_job_exe_dup_init()
+        while True:
+            if not self._running:
+                raise TerminatedCommand()
+
+            if self._updated_job >= self._total_job:
+                break
+            self._perform_job_exe_dup_iteration()
+
     def stop(self):
         """Informs the database updater to stop running
         """
 
         logger.info('Scale database updater has been told to stop')
         self._running = False
+
+    def _perform_job_exe_dup_init(self):
+        """Performs any initialization piece of the removal of job execution duplicates
+        """
+
+        logger.info('Scale is now removing duplicate job execution models')
+        logger.info('Counting the number of jobs that need to be checked...')
+        self._total_job = Job.objects.all().count()
+        logger.info('Found %d jobs that need to be checked for duplicate executions', self._total_job)
+
+    def _perform_job_exe_dup_iteration(self):
+        """Performs a single iteration of the removal of job execution duplicates
+        """
+
+        job_batch_size = 10000
+
+        batch_start_job_id = self._updated_job
+        batch_end_job_id = batch_start_job_id + job_batch_size - 1
+
+        # Find (job_id, exe_num) pairs that have duplicates
+        job_ids_by_exe_num = {}  # {Exe num: [Job ID]}
+        job_exe_ids_by_exe_num = {}  # {Exe num: [Job Exe ID]}, these are the "good" exes to keep
+        qry = 'SELECT job_id, exe_num, count(*), min(id) FROM job_exe'
+        qry += ' WHERE job_id BETWEEN %d AND %d GROUP BY job_id, exe_num'
+        qry = 'SELECT job_id, exe_num, count, min FROM (%s) c WHERE count > 1' % qry
+        with connection.cursor() as cursor:
+            cursor.execute(qry, [batch_start_job_id, batch_end_job_id])
+            for row in cursor.fetchall():
+                job_id = row[0]
+                exe_num = row[1]
+                job_exe_id = row[3]
+                if exe_num not in job_ids_by_exe_num:
+                    job_ids_by_exe_num[exe_num] = []
+                    job_exe_ids_by_exe_num[exe_num] = []
+                job_ids_by_exe_num[exe_num].append(job_id)
+                job_exe_ids_by_exe_num[exe_num].append(job_exe_id)
+
+        if not job_ids_by_exe_num:
+            logger.info('No duplicates found')
+            return  # No duplicates
+
+        # Find IDs of duplicate job_exes
+        job_exe_ids_to_delete = []
+        for exe_num in job_ids_by_exe_num:
+            job_ids = job_ids_by_exe_num[exe_num]
+            job_exe_ids = job_exe_ids_by_exe_num[exe_num]  # These are the "good" exes to keep
+            job_exe_qry = JobExecution.objects.filter(job_id__in=job_ids, exe_num=exe_num)
+            for job_exe in job_exe_qry.exclude(id__in=job_exe_ids).only('id'):
+                job_exe_ids_to_delete.append(job_exe.id)
+
+        logger.info('Deleting %d duplicates that were found...', len(job_exe_ids_to_delete))
+        TaskUpdate.objects.filter(job_exe_id__in=job_exe_ids_to_delete).delete()
+        JobExecutionOutput.objects.filter(job_exe_id__in=job_exe_ids_to_delete).delete()
+        JobExecutionEnd.objects.filter(job_exe_id__in=job_exe_ids_to_delete).delete()
+        deleted_count = JobExecution.objects.filter(job_exe_id__in=job_exe_ids_to_delete).delete()[0]
+        logger.info('Deleted %d duplicates', deleted_count)
+
+        self._updated_job += job_batch_size
+        percent = (float(self._updated_job) / float(self._total_job)) * 100.00
+        logger.info('Completed %s of %s jobs (%.1f%%)', self._updated_job, self._total_job, percent)
 
     def _perform_update_init(self):
         """Performs any initialization piece of the database update

--- a/scale/scheduler/test/database/test_updater.py
+++ b/scale/scheduler/test/database/test_updater.py
@@ -1,0 +1,60 @@
+from __future__ import unicode_literals
+
+import django
+from django.test import TestCase
+
+from job.models import JobExecution, TaskUpdate
+from job.test import utils as job_test_utils
+from scheduler.database.updater import DatabaseUpdater
+
+
+class TestDatabaseUpdater(TestCase):
+
+    def setUp(self):
+        django.setup()
+
+    def test_update(self):
+        """Tests running the database update"""
+
+        # Create jobs with duplicate job executions
+        job_type = job_test_utils.create_job_type()
+        job_1 = job_test_utils.create_job(job_type=job_type, num_exes=2)
+        job_2 = job_test_utils.create_job(job_type=job_type, num_exes=3)
+        job_3 = job_test_utils.create_job(job_type=job_type, num_exes=2)
+
+        # Job 1
+        job_exe_1 = job_test_utils.create_job_exe(job=job_1, status='COMPLETED', exe_num=1)
+        job_exe_2 = job_test_utils.create_job_exe(job=job_1, status='COMPLETED', exe_num=1)
+        job_exe_3 = job_test_utils.create_job_exe(job=job_1, status='COMPLETED', exe_num=2)
+        job_exe_4 = job_test_utils.create_job_exe(job=job_1, status='COMPLETED', exe_num=2)
+
+        # Job 2
+        job_exe_5 = job_test_utils.create_job_exe(job=job_2, status='COMPLETED', exe_num=1)
+        job_exe_6 = job_test_utils.create_job_exe(job=job_2, status='COMPLETED', exe_num=2)
+        job_exe_7 = job_test_utils.create_job_exe(job=job_2, status='COMPLETED', exe_num=2)
+        job_exe_8 = job_test_utils.create_job_exe(job=job_2, status='COMPLETED', exe_num=3)
+
+        # Job 3
+        job_exe_9 = job_test_utils.create_job_exe(job=job_3, status='COMPLETED', exe_num=1)
+
+        # Create some task updates to make sure they get deleted as well
+        task_updates = []
+        task_updates.append(TaskUpdate(job_exe=job_exe_1, task_id='1234', status='foo'))
+        task_updates.append(TaskUpdate(job_exe=job_exe_1, task_id='1234', status='foo'))
+        task_updates.append(TaskUpdate(job_exe=job_exe_2, task_id='1234', status='foo'))
+        task_updates.append(TaskUpdate(job_exe=job_exe_2, task_id='1234', status='foo'))
+        task_updates.append(TaskUpdate(job_exe=job_exe_3, task_id='1234', status='foo'))
+        task_updates.append(TaskUpdate(job_exe=job_exe_3, task_id='1234', status='foo'))
+        task_updates.append(TaskUpdate(job_exe=job_exe_4, task_id='1234', status='foo'))
+        task_updates.append(TaskUpdate(job_exe=job_exe_4, task_id='1234', status='foo'))
+        TaskUpdate.objects.bulk_create(task_updates)
+
+        # Run update
+        updater = DatabaseUpdater()
+        updater.update()
+
+        expected_job_exe_ids = {job_exe_1.id, job_exe_3.id, job_exe_5.id, job_exe_6.id, job_exe_8.id, job_exe_9.id}
+        actual_job_exe_ids = set()
+        for job_exe in JobExecution.objects.all().only('id'):
+            actual_job_exe_ids.add(job_exe.id)
+        self.assertSetEqual(expected_job_exe_ids, actual_job_exe_ids)


### PR DESCRIPTION
Added additional logic to the database update system task to clean up any duplicate job executions (same job ID and execution number).