### PR TITLE
Issue 1023 - Move product publishing to its own message

### DIFF
--- a/scale/job/apps.py
+++ b/scale/job/apps.py
@@ -32,6 +32,7 @@ class JobConfig(AppConfig):
         from job.messages.job_exe_end import CreateJobExecutionEnd
         from job.messages.pending_jobs import PendingJobs
         from job.messages.process_job_inputs import ProcessJobInputs
+        from job.messages.publish_job import PublishJob
         from job.messages.running_jobs import RunningJobs
         from messaging.messages.factory import add_message_type
 
@@ -41,4 +42,5 @@ class JobConfig(AppConfig):
         add_message_type(CreateJobExecutionEnd)
         add_message_type(PendingJobs)
         add_message_type(ProcessJobInputs)
+        add_message_type(PublishJob)
         add_message_type(RunningJobs)

--- a/scale/job/messages/completed_jobs.py
+++ b/scale/job/messages/completed_jobs.py
@@ -51,6 +51,33 @@ def create_completed_jobs_messages(completed_jobs, when):
     return messages
 
 
+def process_completed_jobs_with_output(job_ids, when):
+    """Processes the given job IDs to determine if any of the jobs have both COMPLETED and received their output.
+    Messages will be created and returned for completed jobs that have their output populated. Caller must have obtained
+    model locks on the given jobs.
+
+    :param job_ids: The job IDs
+    :type job_ids: list
+    :param when: The current time
+    :type when: :class:`datetime.datetime`
+    :return: The list of created messages
+    :rtype: list
+    """
+
+    messages = []
+
+    # Find jobs that are COMPLETED and have output
+    completed_job_ids_with_output = Job.objects.process_job_output(job_ids, when)
+    if completed_job_ids_with_output:
+        logger.info('Found %d COMPLETED job(s) with output', len(completed_job_ids_with_output))
+
+        # Create messages to update recipes
+        from recipe.messages.update_recipes import create_update_recipes_messages_from_jobs
+        messages.extend(create_update_recipes_messages_from_jobs(completed_job_ids_with_output))
+
+    return messages
+
+
 class CompletedJobs(CommandMessage):
     """Command message that sets COMPLETED status for job models
     """
@@ -128,6 +155,7 @@ class CompletedJobs(CommandMessage):
                     # Ignore this job
                     continue
                 jobs_to_complete.append(job_model)
+            job_ids_to_complete = [job.id for job in jobs_to_complete]
 
             # Update jobs to completed
             completed_job_ids = []
@@ -135,15 +163,10 @@ class CompletedJobs(CommandMessage):
                 completed_job_ids = Job.objects.update_jobs_to_completed(jobs_to_complete, self.ended)
                 logger.info('Set %d job(s) to COMPLETED status', len(completed_job_ids))
 
-            # Process job output to find jobs that are both COMPLETED and have output
-            if jobs_to_complete:
-                job_ids = [job.id for job in jobs_to_complete]
-                jobs_with_output = Job.objects.process_job_output(job_ids, when)
-                # Jobs that are COMPLETED and have output should update their recipes
-                if jobs_with_output:
-                    logger.info('Found %d COMPLETED job(s) with output, ready to update recipe(s)',
-                                len(jobs_with_output))
-                    self._create_update_recipes_messages(jobs_with_output)
+            # Create messages for jobs that are both COMPLETED and have output
+            if job_ids_to_complete:
+                msgs = process_completed_jobs_with_output(job_ids_to_complete, when)
+                self.new_messages.extend(msgs)
 
             # TODO: this needs to be improved to be more efficient and not perform batch model locking
             for job_id in completed_job_ids:
@@ -162,16 +185,3 @@ class CompletedJobs(CommandMessage):
                     pass
 
         return True
-
-    def _create_update_recipes_messages(self, job_ids):
-        """Creates messages to update the the recipes for the given jobs that are both COMPLETED and have output
-
-        :param job_ids: The job IDs
-        :type job_ids: list
-        """
-
-        from recipe.messages.update_recipes import create_update_recipes_messages
-        from recipe.models import Recipe
-
-        recipe_ids = Recipe.objects.get_latest_recipe_ids_for_jobs(job_ids)
-        self.new_messages.extend(create_update_recipes_messages(recipe_ids))

--- a/scale/job/messages/failed_jobs.py
+++ b/scale/job/messages/failed_jobs.py
@@ -171,23 +171,13 @@ class FailedJobs(CommandMessage):
 
             # Need to update recipes of failed jobs so that dependent jobs are BLOCKED
             if all_failed_job_ids:
-                self._create_update_recipes_messages(all_failed_job_ids)
+                from recipe.messages.update_recipes import create_update_recipes_messages_from_jobs
+
+                msgs = create_update_recipes_messages_from_jobs(all_failed_job_ids)
+                self.new_messages.extend(msgs)
 
             # Place jobs to retry back onto the queue
             if jobs_to_retry:
                 self.new_messages.extend(create_queued_jobs_messages(jobs_to_retry))
 
         return True
-
-    def _create_update_recipes_messages(self, failed_job_ids):
-        """Creates messages to update the the recipes for the given failed jobs
-
-        :param failed_job_ids: The job IDs
-        :type failed_job_ids: list
-        """
-
-        from recipe.messages.update_recipes import create_update_recipes_messages
-        from recipe.models import Recipe
-
-        recipe_ids = Recipe.objects.get_latest_recipe_ids_for_jobs(failed_job_ids)
-        self.new_messages.extend(create_update_recipes_messages(recipe_ids))

--- a/scale/job/messages/publish_job.py
+++ b/scale/job/messages/publish_job.py
@@ -1,0 +1,72 @@
+"""Defines a command message that publishes a job"""
+from __future__ import unicode_literals
+
+import logging
+
+from django.db import transaction
+from django.utils.timezone import now
+
+from job.models import JobExecution
+from messaging.messages.message import CommandMessage
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_publish_job_message(job_id):
+    """Creates a publish job message
+
+    :param job_id: The job ID
+    :type job_id: int
+    :return: The publish job message
+    :rtype: :class:`job.messages.publish_job.PublishJob`
+    """
+
+    message = PublishJob()
+    message.job_id = job_id
+    return message
+
+
+class PublishJob(CommandMessage):
+    """Command message that publishes a completed job
+    """
+
+    def __init__(self):
+        """Constructor
+        """
+
+        super(PublishJob, self).__init__('publish_job')
+
+        self.job_id = None
+
+    def to_json(self):
+        """See :meth:`messaging.messages.message.CommandMessage.to_json`
+        """
+
+        return {'job_id': self.job_id}
+
+    @staticmethod
+    def from_json(json_dict):
+        """See :meth:`messaging.messages.message.CommandMessage.from_json`
+        """
+
+        message = PublishJob()
+        message.job_id = json_dict['job_id']
+        return message
+
+    def execute(self):
+        """See :meth:`messaging.messages.message.CommandMessage.execute`
+        """
+
+        when_published = now()
+
+        with transaction.atomic():
+            # Retrieve job and job_exe models
+            job_exe = JobExecution.objects.get_latest_execution(self.job_id)
+            job = job_exe.job
+
+            # Publish this job's products
+            from product.models import ProductFile
+            ProductFile.objects.publish_products(job_exe.id, job, when_published)
+
+        return True

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1403,6 +1403,17 @@ class JobExecutionManager(models.Manager):
 
         return results
 
+    def get_latest_execution(self, job_id):
+        """Gets the latest job execution for the given job ID and returns it with the related job model
+
+        :param job_id: The job ID
+        :type job_id: int
+        :returns: The job execution model with related job and job_type models populated
+        :rtype: :class:`job.models.JobExecution`
+        """
+
+        return self.select_related('job').get(job_id=job_id, exe_num=F('job__num_exes'))
+
     # TODO: remove when REST API v5 is removed
     def get_logs(self, job_exe_id):
         """Gets additional details for the given job execution model based on related model attributes.

--- a/scale/job/test/messages/test_completed_jobs.py
+++ b/scale/job/test/messages/test_completed_jobs.py
@@ -93,10 +93,19 @@ class TestCompletedJobs(TransactionTestCase):
         self.assertTrue(result)
 
         jobs = Job.objects.filter(id__in=job_ids).order_by('id')
-        self.assertEqual(len(message.new_messages), 1)
-        update_recipes_msg = message.new_messages[0]
-        self.assertEqual(update_recipes_msg.type, 'update_recipes')
-        self.assertEqual(len(update_recipes_msg._recipe_ids), 1)  # Job 2 was only job both completed and with output
+        self.assertEqual(len(message.new_messages), 2)
+        update_recipes_msg = None
+        publish_job_msg = None
+        for msg in message.new_messages:
+            if msg.type == 'update_recipes':
+                update_recipes_msg = msg
+            elif msg.type == 'publish_job':
+                publish_job_msg = msg
+        self.assertIsNotNone(update_recipes_msg)
+        self.assertIsNotNone(publish_job_msg)
+        # Job 2 was only job both completed and with output
+        self.assertEqual(len(update_recipes_msg._recipe_ids), 1)
+        self.assertEqual(publish_job_msg.job_id, job_2.id)
 
         # Job 1 should be completed
         self.assertEqual(jobs[0].status, 'COMPLETED')
@@ -121,10 +130,19 @@ class TestCompletedJobs(TransactionTestCase):
 
         # Should have the same update_recipes message as before
         jobs = Job.objects.filter(id__in=job_ids).order_by('id')
-        self.assertEqual(len(message.new_messages), 1)
-        update_recipes_msg = message.new_messages[0]
-        self.assertEqual(update_recipes_msg.type, 'update_recipes')
-        self.assertEqual(len(update_recipes_msg._recipe_ids), 1)  # Job 2 was only job both completed and with output
+        self.assertEqual(len(message.new_messages), 2)
+        update_recipes_msg = None
+        publish_job_msg = None
+        for msg in message.new_messages:
+            if msg.type == 'update_recipes':
+                update_recipes_msg = msg
+            elif msg.type == 'publish_job':
+                publish_job_msg = msg
+        self.assertIsNotNone(update_recipes_msg)
+        self.assertIsNotNone(publish_job_msg)
+        # Job 2 was only job both completed and with output
+        self.assertEqual(len(update_recipes_msg._recipe_ids), 1)
+        self.assertEqual(publish_job_msg.job_id, job_2.id)
 
         # Should have the same models as before
         self.assertEqual(jobs[0].status, 'COMPLETED')

--- a/scale/job/test/messages/test_publish_job.py
+++ b/scale/job/test/messages/test_publish_job.py
@@ -1,0 +1,58 @@
+from __future__ import unicode_literals
+
+import django
+from django.test import TransactionTestCase
+
+from job.messages.publish_job import PublishJob
+from job.test import utils as job_test_utils
+from product.test import utils as product_test_utils
+from storage.models import ScaleFile
+
+
+class TestPublishJob(TransactionTestCase):
+
+    def setUp(self):
+        django.setup()
+
+    def test_json(self):
+        """Tests coverting a PublishJob message to and from JSON"""
+
+        job_exe = job_test_utils.create_job_exe(status='COMPLETED')
+        job = job_exe.job
+
+        product_1 = product_test_utils.create_product(job_exe=job_exe)
+        product_2 = product_test_utils.create_product(job_exe=job_exe)
+
+        # Add job to message
+        message = PublishJob()
+        message.job_id = job.id
+
+        # Convert message to JSON and back, and then execute
+        message_json_dict = message.to_json()
+        new_message = PublishJob.from_json(message_json_dict)
+        result = new_message.execute()
+
+        self.assertTrue(result)
+        for scale_file in ScaleFile.objects.filter(id__in=[product_1.id, product_2.id]):
+            self.assertTrue(scale_file.is_published)
+
+    def test_execute(self):
+        """Tests calling CompletedJobs.execute() successfully"""
+
+        job_exe = job_test_utils.create_job_exe(status='COMPLETED')
+        job = job_exe.job
+
+        product_1 = product_test_utils.create_product(job_exe=job_exe)
+        product_2 = product_test_utils.create_product(job_exe=job_exe)
+
+        # Add job to message
+        message = PublishJob()
+        message.job_id = job.id
+
+        # Execute message
+        result = message.execute()
+        self.assertTrue(result)
+
+        # Check that products are published
+        for scale_file in ScaleFile.objects.filter(id__in=[product_1.id, product_2.id]):
+            self.assertTrue(scale_file.is_published)

--- a/scale/recipe/messages/update_recipes.py
+++ b/scale/recipe/messages/update_recipes.py
@@ -47,6 +47,19 @@ def create_update_recipes_messages(recipe_ids):
     return messages
 
 
+def create_update_recipes_messages_from_jobs(job_ids):
+    """Creates messages to update the recipes for the given jobs
+
+    :param job_ids: The job IDs
+    :type job_ids: list
+    :return: The list of messages
+    :rtype: list
+    """
+
+    recipe_ids = Recipe.objects.get_latest_recipe_ids_for_jobs(job_ids)
+    return create_update_recipes_messages(recipe_ids)
+
+
 class UpdateRecipes(CommandMessage):
     """Command message that evaluates and updates recipes
     """


### PR DESCRIPTION
Created a new publish job message that gets sent when a job is both completed and has its output populated from its last execution.