### PR TITLE
Issue 1128 - Canceled Job Bug

### DIFF
--- a/scale/job/messages/failed_jobs.py
+++ b/scale/job/messages/failed_jobs.py
@@ -178,7 +178,7 @@ class FailedJobs(CommandMessage):
 
             # Place jobs to retry back onto the queue
             if jobs_to_retry:
-                self.new_messages.extend(create_queued_jobs_messages(jobs_to_retry))
+                self.new_messages.extend(create_queued_jobs_messages(jobs_to_retry, requeue=True))
 
         # Send messages to update recipe metrics
         from recipe.messages.update_recipe_metrics import create_update_recipe_metrics_messages_from_jobs

--- a/scale/job/messages/process_job_inputs.py
+++ b/scale/job/messages/process_job_inputs.py
@@ -110,6 +110,6 @@ class ProcessJobInputs(CommandMessage):
                 jobs_to_queue.append(QueuedJob(job_model.id, 0))
         if jobs_to_queue:
             logger.info('Processed job inputs, %d job(s) will be queued', len(jobs_to_queue))
-            self.new_messages.extend(create_queued_jobs_messages(jobs_to_queue))
+            self.new_messages.extend(create_queued_jobs_messages(jobs_to_queue, requeue=False))
 
         return True

--- a/scale/job/test/messages/test_failed_jobs.py
+++ b/scale/job/test/messages/test_failed_jobs.py
@@ -67,6 +67,7 @@ class TestFailedJobs(TransactionTestCase):
         self.assertEqual(jobs[0].num_exes, 1)
         self.assertEqual(len(queued_jobs_msg._queued_jobs), 1)
         self.assertEqual(queued_jobs_msg._queued_jobs[0].job_id, job_1.id)
+        self.assertTrue(queued_jobs_msg.requeue)
         # Job 2 should be failed since max_tries is used up
         self.assertEqual(jobs[1].status, 'FAILED')
         self.assertEqual(jobs[1].num_exes, 1)
@@ -136,6 +137,7 @@ class TestFailedJobs(TransactionTestCase):
                 update_recipes_msg = msg
             elif msg.type == 'update_recipe_metrics':
                 update_recipe_metrics_msg = msg
+        self.assertTrue(queued_jobs_msg.requeue)
         self.assertEqual(len(queued_jobs_msg._queued_jobs), 2)  # 2 jobs should have been retried
         self.assertEqual(len(update_recipes_msg._recipe_ids), 2)  # 2 jobs should have been failed
 
@@ -188,6 +190,7 @@ class TestFailedJobs(TransactionTestCase):
             elif msg.type == 'update_recipe_metrics':
                 update_recipe_metrics_msg = msg
         self.assertEqual(queued_jobs_msg.type, 'queued_jobs')
+        self.assertTrue(queued_jobs_msg.requeue)
         # The same 2 jobs should have been retried
         self.assertEqual(len(queued_jobs_msg._queued_jobs), 2)
 

--- a/scale/job/test/messages/test_process_job_inputs.py
+++ b/scale/job/test/messages/test_process_job_inputs.py
@@ -37,6 +37,7 @@ class TestProcessJobInputs(TransactionTestCase):
         jobs = Job.objects.filter(id__in=job_ids).order_by('id')
         self.assertEqual(len(new_message.new_messages), 1)
         self.assertEqual(new_message.new_messages[0].type, 'queued_jobs')
+        self.assertFalse(new_message.new_messages[0].requeue)
         # Jobs should have input_file_size set to 0 (no input files)
         self.assertEqual(jobs[0].input_file_size, 0.0)
         self.assertEqual(jobs[1].input_file_size, 0.0)
@@ -116,6 +117,7 @@ class TestProcessJobInputs(TransactionTestCase):
         # Check for queued jobs message
         self.assertEqual(len(message.new_messages), 1)
         self.assertEqual(message.new_messages[0].type, 'queued_jobs')
+        self.assertFalse(message.new_messages[0].requeue)
 
         # Check jobs for expected input_file_size
         self.assertEqual(jobs[0].input_file_size, 110.0)
@@ -150,6 +152,7 @@ class TestProcessJobInputs(TransactionTestCase):
         # Still should have queued jobs message
         self.assertEqual(len(message.new_messages), 1)
         self.assertEqual(message.new_messages[0].type, 'queued_jobs')
+        self.assertFalse(message.new_messages[0].requeue)
 
         # Make sure job input file models are unchanged
         job_input_files = JobInputFile.objects.filter(job_id=job_1.id)

--- a/scale/job/test/test_models.py
+++ b/scale/job/test/test_models.py
@@ -327,9 +327,10 @@ class TestJobManager(TransactionTestCase):
 
     def test_queue_job_timestamps(self):
         """Tests that job attributes are updated when a job is queued."""
-        job = job_test_utils.create_job(num_exes=1, input={}, started=timezone.now(), ended=timezone.now())
+        job = job_test_utils.create_job(num_exes=1, status='CANCELED', input={}, started=timezone.now(),
+                                        ended=timezone.now())
 
-        Job.objects.update_jobs_to_queued([job], timezone.now())
+        Job.objects.update_jobs_to_queued([job], timezone.now(), requeue=True)
         job = Job.objects.get(pk=job.id)
 
         self.assertEqual(job.status, 'QUEUED')

--- a/scale/queue/messages/queued_jobs.py
+++ b/scale/queue/messages/queued_jobs.py
@@ -21,11 +21,13 @@ QueuedJob = namedtuple('QueuedJob', ['job_id', 'exe_num'])
 logger = logging.getLogger(__name__)
 
 
-def create_queued_jobs_messages(jobs, priority=None):
+def create_queued_jobs_messages(jobs, requeue=False, priority=None):
     """Creates messages to queue the given jobs
 
     :param jobs: The jobs to queue (QueuedJob tuple)
     :type jobs: list
+    :param requeue: Whether this is a re-queue (True) or a first queue (False)
+    :type requeue: bool
     :param priority: Optional priority to set on the queued jobs
     :type priority: int
     :return: The list of messages
@@ -39,10 +41,12 @@ def create_queued_jobs_messages(jobs, priority=None):
         if not message:
             message = QueuedJobs()
             message.priority = priority
+            message.requeue = requeue
         elif not message.can_fit_more():
             messages.append(message)
             message = QueuedJobs()
             message.priority = priority
+            message.requeue = requeue
         message.add_job(job.job_id, job.exe_num)
     if message:
         messages.append(message)
@@ -61,6 +65,7 @@ class QueuedJobs(CommandMessage):
         super(QueuedJobs, self).__init__('queued_jobs')
 
         self.priority = None
+        self.requeue = False
         self._queued_jobs = []
 
     def add_job(self, job_id, exe_num):
@@ -91,7 +96,7 @@ class QueuedJobs(CommandMessage):
         job_list = []
         for queued_job in self._queued_jobs:
             job_list.append({'id': queued_job.job_id, 'exe_num': queued_job.exe_num})
-        cmd_dict = {'jobs': job_list}
+        cmd_dict = {'jobs': job_list, 'requeue': self.requeue}
 
         if self.priority is not None:
             cmd_dict['priority'] = self.priority
@@ -104,6 +109,9 @@ class QueuedJobs(CommandMessage):
         """
 
         message = QueuedJobs()
+
+        if 'requeue' in json_dict:
+            message.requeue = json_dict['requeue']
 
         if 'priority' in json_dict:
             message.priority = json_dict['priority']
@@ -142,7 +150,7 @@ class QueuedJobs(CommandMessage):
 
             # Queue jobs
             if jobs_to_queue:
-                queued_job_ids = Queue.objects.queue_jobs(jobs_to_queue, self.priority)
+                queued_job_ids = Queue.objects.queue_jobs(jobs_to_queue, requeue=self.requeue, priority=self.priority)
                 logger.info('Queued %d job(s)', len(queued_job_ids))
 
         # Send messages to update recipe metrics

--- a/scale/queue/messages/requeue_jobs.py
+++ b/scale/queue/messages/requeue_jobs.py
@@ -125,7 +125,7 @@ class RequeueJobs(CommandMessage):
         job_models = {job.id: job for job in Job.objects.get_basic_jobs(job_ids)}
         for requeue_job in self._requeue_jobs:
             job_model = job_models[requeue_job.job_id]
-            if job_model.can_be_queued() and job_model.has_been_queued() and job_model.num_exes == requeue_job.exe_num:
+            if job_model.can_be_requeued() and job_model.num_exes == requeue_job.exe_num:
                 jobs_to_requeue.append(QueuedJob(job_model.id, job_model.num_exes))
             elif job_model.can_be_uncanceled():
                 job_ids_to_uncancel.append(job_model.id)
@@ -137,7 +137,7 @@ class RequeueJobs(CommandMessage):
             Job.objects.increment_max_tries(job_ids_to_requeue, when)
 
         # Create messages to queue the jobs
-        self.new_messages.extend(create_queued_jobs_messages(jobs_to_requeue, priority=self.priority))
+        self.new_messages.extend(create_queued_jobs_messages(jobs_to_requeue, requeue=True, priority=self.priority))
 
         # Create messages to uncancel jobs
         self.new_messages.extend(create_uncancel_jobs_messages(job_ids_to_uncancel, when))

--- a/scale/queue/messages/requeue_jobs_bulk.py
+++ b/scale/queue/messages/requeue_jobs_bulk.py
@@ -148,7 +148,7 @@ class RequeueJobsBulk(CommandMessage):
         for job in job_qry.defer('output')[:MAX_BATCH_SIZE]:
             batch_count += 1
             last_job_id = job.id
-            if job.can_be_queued() and job.has_been_queued():
+            if job.can_be_requeued():
                 requeue_jobs.append(QueuedJob(job.id, job.num_exes))
         requeue_count = len(requeue_jobs)
 

--- a/scale/queue/test/messages/test_queued_jobs.py
+++ b/scale/queue/test/messages/test_queued_jobs.py
@@ -22,7 +22,8 @@ class TestQueuedJobs(TransactionTestCase):
         job_1 = job_test_utils.create_job(num_exes=0, status='PENDING', input=data.get_dict())
         job_2 = job_test_utils.create_job(num_exes=1, status='FAILED', input=data.get_dict())
         job_3 = job_test_utils.create_job(num_exes=1, status='COMPLETED', input=data.get_dict())
-        job_ids = [job_1.id, job_2.id, job_3.id]
+        job_4 = job_test_utils.create_job(num_exes=0, status='CANCELED', input=data.get_dict())
+        job_ids = [job_1.id, job_2.id, job_3.id, job_4.id]
 
         # Add jobs to message
         message = QueuedJobs()
@@ -33,6 +34,8 @@ class TestQueuedJobs(TransactionTestCase):
             message.add_job(job_2.id, job_2.num_exes - 1)  # Mismatched exe_num
         if message.can_fit_more():
             message.add_job(job_3.id, job_3.num_exes)
+        if message.can_fit_more():
+            message.add_job(job_4.id, job_4.num_exes)
 
         # Convert message to JSON and back, and then execute
         message_json_dict = message.to_json()
@@ -47,6 +50,8 @@ class TestQueuedJobs(TransactionTestCase):
         self.assertEqual(jobs[1].num_exes, 1)
         self.assertEqual(jobs[2].status, 'COMPLETED')
         self.assertEqual(jobs[2].num_exes, 1)
+        self.assertEqual(jobs[3].status, 'CANCELED')
+        self.assertEqual(jobs[3].num_exes, 0)
         # Ensure priority is correctly set
         queue = Queue.objects.get(job_id=job_1.id)
         self.assertEqual(queue.priority, 1)

--- a/scale/queue/test/messages/test_queued_jobs.py
+++ b/scale/queue/test/messages/test_queued_jobs.py
@@ -58,7 +58,7 @@ class TestQueuedJobs(TransactionTestCase):
         job_1 = job_test_utils.create_job(num_exes=0, status='PENDING', input=data.get_dict())
         job_2 = job_test_utils.create_job(num_exes=1, status='FAILED', input=data.get_dict())
         job_3 = job_test_utils.create_job(num_exes=1, status='RUNNING', input=data.get_dict())
-        job_4 = job_test_utils.create_job(num_exes=0, status='CANCELED', input=data.get_dict())
+        job_4 = job_test_utils.create_job(num_exes=1, status='CANCELED', input=data.get_dict())
         job_5 = job_test_utils.create_job(num_exes=1, status='QUEUED', input=data.get_dict())
         job_6 = job_test_utils.create_job(num_exes=1, status='COMPLETED', input=data.get_dict())
         job_7 = job_test_utils.create_job(num_exes=1, status='RUNNING', input=data.get_dict())
@@ -68,6 +68,7 @@ class TestQueuedJobs(TransactionTestCase):
         # Add jobs to message
         message = QueuedJobs()
         message.priority = 101
+        message.requeue = True  # The message is re-queuing so only jobs that have been queued before may be re-queued
         if message.can_fit_more():
             message.add_job(job_1.id, job_1.num_exes)
         if message.can_fit_more():
@@ -90,9 +91,9 @@ class TestQueuedJobs(TransactionTestCase):
         self.assertTrue(result)
 
         jobs = Job.objects.filter(id__in=job_ids).order_by('id')
-        # Job 1 should have been successfully QUEUED
-        self.assertEqual(jobs[0].status, 'QUEUED')
-        self.assertEqual(jobs[0].num_exes, 1)
+        # Job 1 should not have been queued since the message is re-queuing and Job 1 has never been queued
+        self.assertEqual(jobs[0].status, 'PENDING')
+        self.assertEqual(jobs[0].num_exes, 0)
         # Job 2 should have been successfully QUEUED
         self.assertEqual(jobs[1].status, 'QUEUED')
         self.assertEqual(jobs[1].num_exes, 2)
@@ -101,7 +102,7 @@ class TestQueuedJobs(TransactionTestCase):
         self.assertEqual(jobs[2].num_exes, 2)
         # Job 4 should have been successfully QUEUED
         self.assertEqual(jobs[3].status, 'QUEUED')
-        self.assertEqual(jobs[3].num_exes, 1)
+        self.assertEqual(jobs[3].num_exes, 2)
         # Job 5 should have been successfully QUEUED
         self.assertEqual(jobs[4].status, 'QUEUED')
         self.assertEqual(jobs[4].num_exes, 2)
@@ -111,28 +112,30 @@ class TestQueuedJobs(TransactionTestCase):
         # Job 7 should not have been queued since it is an old message
         self.assertEqual(jobs[6].status, 'RUNNING')
         self.assertEqual(jobs[6].num_exes, 1)
-        # Job 8 should not have been queued since it doesn't have any input data
+        # Job 8 should not have been queued since it doesn't have any input data and has never been queued
         self.assertEqual(jobs[7].status, 'CANCELED')
         self.assertEqual(jobs[7].num_exes, 0)
         # Ensure priority is correctly set
-        queue = Queue.objects.get(job_id=job_1.id)
+        queue = Queue.objects.get(job_id=job_2.id)
         self.assertEqual(queue.priority, 101)
 
         # Test executing message again
+        message_json_dict = message.to_json()
+        message = QueuedJobs.from_json(message_json_dict)
         result = message.execute()
         self.assertTrue(result)
 
         self.assertTrue(result)
         # All results should be the same
         jobs = Job.objects.filter(id__in=job_ids).order_by('id')
-        self.assertEqual(jobs[0].status, 'QUEUED')
-        self.assertEqual(jobs[0].num_exes, 1)
+        self.assertEqual(jobs[0].status, 'PENDING')
+        self.assertEqual(jobs[0].num_exes, 0)
         self.assertEqual(jobs[1].status, 'QUEUED')
         self.assertEqual(jobs[1].num_exes, 2)
         self.assertEqual(jobs[2].status, 'QUEUED')
         self.assertEqual(jobs[2].num_exes, 2)
         self.assertEqual(jobs[3].status, 'QUEUED')
-        self.assertEqual(jobs[3].num_exes, 1)
+        self.assertEqual(jobs[3].num_exes, 2)
         self.assertEqual(jobs[4].status, 'QUEUED')
         self.assertEqual(jobs[4].num_exes, 2)
         self.assertEqual(jobs[5].status, 'COMPLETED')

--- a/scale/queue/test/messages/test_requeue_jobs.py
+++ b/scale/queue/test/messages/test_requeue_jobs.py
@@ -46,6 +46,7 @@ class TestRequeueJobs(TestCase):
         message = new_message.new_messages[0]
         self.assertEqual(message.type, 'queued_jobs')
         self.assertListEqual(message._queued_jobs, [QueuedJob(job_1.id, job_1.num_exes)])
+        self.assertTrue(message.requeue)
         self.assertEqual(message.priority, 1)
 
     def test_execute(self):
@@ -95,6 +96,7 @@ class TestRequeueJobs(TestCase):
         self.assertEqual(queued_jobs_msg.type, 'queued_jobs')
         self.assertListEqual(queued_jobs_msg._queued_jobs, [QueuedJob(job_1.id, job_1.num_exes)])
         self.assertEqual(queued_jobs_msg.priority, 101)
+        self.assertTrue(queued_jobs_msg.requeue)
         # Job 5 is only job that should be included in message to uncancel
         uncancel_jobs_msg = message.new_messages[1]
         self.assertEqual(uncancel_jobs_msg.type, 'uncancel_jobs')
@@ -123,6 +125,7 @@ class TestRequeueJobs(TestCase):
         self.assertEqual(queued_jobs_msg.type, 'queued_jobs')
         self.assertListEqual(queued_jobs_msg._queued_jobs, [QueuedJob(job_1.id, job_1.num_exes)])
         self.assertEqual(queued_jobs_msg.priority, 101)
+        self.assertTrue(queued_jobs_msg.requeue)
         # Job 5 is only job that should be included in message to uncancel
         uncancel_jobs_msg = message.new_messages[1]
         self.assertEqual(uncancel_jobs_msg.type, 'uncancel_jobs')

--- a/scale/queue/test/test_models.py
+++ b/scale/queue/test/test_models.py
@@ -15,6 +15,7 @@ import storage.test.utils as storage_test_utils
 import source.test.utils as source_test_utils
 import trigger.test.utils as trigger_test_utils
 from error.models import reset_error_cache
+from job.configuration.data.job_data import JobData
 from job.configuration.results.job_results import JobResults
 from job.models import Job
 from queue.models import JobLoad, Queue, QUEUE_ORDER_FIFO, QUEUE_ORDER_LIFO
@@ -178,7 +179,7 @@ class TestQueueManagerHandleJobCancellation(TransactionTestCase):
         """Tests calling QueueManager.handle_job_cancellation() successfully with a queued job."""
 
         # Queue the job
-        job = job_test_utils.create_job()
+        job = job_test_utils.create_job(input=JobData().get_dict(), num_exes=0, status='PENDING')
         Queue.objects.queue_jobs([job])
 
         # Call method to test

--- a/scale/recipe/handlers/handler.py
+++ b/scale/recipe/handlers/handler.py
@@ -177,7 +177,7 @@ class RecipeHandler(object):
 
         for job_name in self._graph.get_topological_order():
             job = self._jobs_by_name[job_name].job
-            if not job.has_been_queued() and job.can_be_queued():
+            if job.can_be_queued():
                 jobs_to_queue.append(job)
 
         return jobs_to_queue


### PR DESCRIPTION
Fixed the bug by using a flag in the queued_jobs message to distinguish between queuing for the first time and re-queuing. When re-queuing, CANCELED jobs can be QUEUED. When queuing for the first time, CANCELED jobs cannot be QUEUED.