### PR TITLE
Fix batch bugs

### DIFF
--- a/scale/batch/models.py
+++ b/scale/batch/models.py
@@ -656,22 +656,22 @@ class BatchManager(models.Manager):
         errors = []
         warnings = []
 
-        batch = Batch()
-        batch.recipe_type = recipe_type
-        batch.recipe_type_rev = RecipeTypeRevision.objects.get_revision(recipe_type.id, recipe_type.revision_num)
-        batch.definition = convert_definition_to_v6(definition).get_dict()
-        batch.configuration = convert_configuration_to_v6(configuration).get_dict()
-
-        if definition.root_batch_id is not None:
-            # Find latest batch with the root ID
-            try:
-                superseded_batch = Batch.objects.get_batch_from_root(definition.root_batch_id)
-            except Batch.DoesNotExist:
-                raise InvalidDefinition('PREV_BATCH_NOT_FOUND', 'No batch with that root ID exists')
-            batch.root_batch_id = superseded_batch.root_batch_id
-            batch.superseded_batch = superseded_batch
-
         try:
+            batch = Batch()
+            batch.recipe_type = recipe_type
+            batch.recipe_type_rev = RecipeTypeRevision.objects.get_revision(recipe_type.id, recipe_type.revision_num)
+            batch.definition = convert_definition_to_v6(definition).get_dict()
+            batch.configuration = convert_configuration_to_v6(configuration).get_dict()
+
+            if definition.root_batch_id is not None:
+                # Find latest batch with the root ID
+                try:
+                    superseded_batch = Batch.objects.get_batch_from_root(definition.root_batch_id)
+                except Batch.DoesNotExist:
+                    raise InvalidDefinition('PREV_BATCH_NOT_FOUND', 'No batch with that root ID exists')
+                batch.root_batch_id = superseded_batch.root_batch_id
+                batch.superseded_batch = superseded_batch
+
             warnings.extend(definition.validate(batch))
             warnings.extend(configuration.validate(batch))
         except ValidationException as ex:

--- a/scale/scheduler/database/updater.py
+++ b/scale/scheduler/database/updater.py
@@ -97,7 +97,8 @@ class DatabaseUpdater(object):
         qry_2 = 'UPDATE batch b SET is_creation_done = true FROM '
         qry_2 += '(SELECT b.id, j.status FROM batch b JOIN job j ON b.creator_job_id = j.id) s '
         qry_2 += 'WHERE b.id = s.id AND s.status = \'COMPLETED\' AND b.is_creation_done = false'
-        # Populate batch.recipe_type_rev if it hasn't been set yet
+        qry_3 = 'UPDATE batch SET root_batch_id = id WHERE root_batch_id is null'
+
         with connection.cursor() as cursor:
             cursor.execute(qry_1, [])
             count = cursor.rowcount
@@ -107,6 +108,10 @@ class DatabaseUpdater(object):
             count = cursor.rowcount
             if count:
                 logger.info('%d batch(s) updated with correct is_creation_done value', count)
+            cursor.execute(qry_3, [])
+            count = cursor.rowcount
+            if count:
+                logger.info('%d batch(s) updated with correct root_batch_id value', count)
 
         logger.info('Scale is now populating the new batch fields on the job, recipe, and batch models')
         logger.info('Counting the number of batches...')

--- a/scale/scheduler/test/database/test_updater.py
+++ b/scale/scheduler/test/database/test_updater.py
@@ -164,6 +164,7 @@ class TestDatabaseUpdater(TestCase):
         self.assertEqual(batch_1.recipes_estimated, 2)
         recipe_type_rev = RecipeTypeRevision.objects.get_revision(recipe_type.id, recipe_type.revision_num)
         self.assertEqual(batch_1.recipe_type_rev_id, recipe_type_rev.id)
+        self.assertEqual(batch_1.root_batch_id, batch_1.id)
         self.assertEqual(batch_1.get_configuration().priority, 303)
         job_1 = Job.objects.get(id=job_1.id)
         self.assertEqual(job_1.batch_id, batch_1.id)
@@ -184,3 +185,4 @@ class TestDatabaseUpdater(TestCase):
         batch_3 = Batch.objects.get(id=batch_3.id)
         recipe_type_rev = RecipeTypeRevision.objects.get_revision(recipe_type_3.id, 2)
         self.assertEqual(batch_3.recipe_type_rev_id, recipe_type_rev.id)
+        self.assertEqual(batch_3.root_batch_id, batch_3.id)


### PR DESCRIPTION
Fixing a batch bug where the batch validation REST API errors if given an invalid previous batch and updated the database update to ensure old batches have their root batch ID correctly set.