### PR TITLE
Deprecating v5 Source File REST API

### DIFF
--- a/scale/docs/rest/source_file.rst
+++ b/scale/docs/rest/source_file.rst
@@ -6,10 +6,17 @@ Source File Services
 
 These services provide access to information about source files that Scale has ingested.
 
+**DEPRECATED**
+This documentation describes the API **v5** version of Source File services. These services will be removed in API **v6**.
+
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Source File List**                                                                                                    |
 +=========================================================================================================================+
 | Returns a list of all source files                                                                                      |
++-------------------------------------------------------------------------------------------------------------------------+
+| **DEPRECATED**                                                                                                          |
+|                This documentation describes the API **v5** version of the Source File List response.  Starting with API |
+|                **v6** this endpoint will be removed.                                                                    |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /sources/                                                                                                       |
 +-------------------------------------------------------------------------------------------------------------------------+
@@ -153,6 +160,7 @@ These services provide access to information about source files that Scale has i
 |                This table describes the current v4 version of the source file details API, which is now deprecated.     |
 |                The new v5 version of this API does not include the *ingests* and *products* arrays in the response.     |
 |                The new v5 version also does not support the use of *file_name* in the URL (only source ID supported).   |
+|                Starting with API **v6** this endpoint will be removed.                                                  |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /sources/{id}/                                                                                                  |
 |         Where {id} is the unique identifier of an existing model.                                                       |
@@ -334,6 +342,10 @@ These services provide access to information about source files that Scale has i
 | **Source File Ingest List**                                                                                             |
 +=========================================================================================================================+
 | Returns a list of all ingests related to the source file with the given ID.                                             |
++-------------------------------------------------------------------------------------------------------------------------+
+| **DEPRECATED**                                                                                                          |
+|                This documentation describes the API **v5** version of the Source File Ingest List response.  Starting   |
+|                with API **v6** this endpoint will be removed.                                                           |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /sources/{id}/ingests/                                                                                          |
 |         Where {id} is the unique identifier of an existing source file                                                  |
@@ -542,6 +554,10 @@ These services provide access to information about source files that Scale has i
 | Returns a list of all jobs related to the source file with the given ID. Jobs marked as superseded are excluded by      |
 | default.                                                                                                                |
 +-------------------------------------------------------------------------------------------------------------------------+
+| **DEPRECATED**                                                                                                          |
+|                This documentation describes the API **v5** version of the Source File Job List response.  Starting with |
+|                API **v6** this endpoint will be removed.                                                                |
++-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /sources/{id}/jobs/                                                                                             |
 |         Where {id} is the unique identifier of an existing source file                                                  |
 +-------------------------------------------------------------------------------------------------------------------------+
@@ -732,6 +748,10 @@ These services provide access to information about source files that Scale has i
 | **Source File Product List**                                                                                            |
 +=========================================================================================================================+
 | Returns a list of all products that were produced by the given source file ID                                           |
++-------------------------------------------------------------------------------------------------------------------------+
+| **DEPRECATED**                                                                                                          |
+|                This documentation describes the API **v5** version of the Source File Product List response.  Starting  |
+|                with API **v6** this endpoint will be removed.                                                           |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /sources/{id}/products/                                                                                         |
 |         Where {id} is the unique identifier of an existing source file                                                  |
@@ -976,6 +996,10 @@ These services provide access to information about source files that Scale has i
 | **Source File Updates**                                                                                                 |
 +=========================================================================================================================+
 | Returns the source file updates (created, parsed, and deleted sources) that have occurred in the given time range.      |
++-------------------------------------------------------------------------------------------------------------------------+
+| **DEPRECATED**                                                                                                          |
+|                This documentation describes the API **v5** version of the Source File Updates response.  Starting with  |
+|                API **v6** this endpoint will be removed.                                                                |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /sources/updates/                                                                                               |
 +-------------------------------------------------------------------------------------------------------------------------+

--- a/scale/source/test/test_views.py
+++ b/scale/source/test/test_views.py
@@ -14,7 +14,8 @@ import storage.test.utils as storage_test_utils
 import util.rest as rest_util
 
 
-class TestSourcesView(TestCase):
+class TestSourcesViewV5(TestCase):
+    api = 'v5'
 
     def setUp(self):
         django.setup()
@@ -28,7 +29,7 @@ class TestSourcesView(TestCase):
     def test_invalid_started(self):
         """Tests calling the source files view when the started parameter is invalid."""
 
-        url = rest_util.get_url('/sources/?started=hello')
+        url = '/%s/sources/?started=hello' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -36,7 +37,7 @@ class TestSourcesView(TestCase):
     def test_missing_tz_started(self):
         """Tests calling the source files view when the started parameter is missing timezone."""
 
-        url = rest_util.get_url('/sources/?started=1970-01-01T00:00:00')
+        url = '/%s/sources/?started=1970-01-01T00:00:00' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -44,7 +45,7 @@ class TestSourcesView(TestCase):
     def test_invalid_ended(self):
         """Tests calling the source files view when the ended parameter is invalid."""
 
-        url = rest_util.get_url('/sources/?started=1970-01-01T00:00:00Z&ended=hello')
+        url = '/%s/sources/?started=1970-01-01T00:00:00Z&ended=hello' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -52,7 +53,7 @@ class TestSourcesView(TestCase):
     def test_missing_tz_ended(self):
         """Tests calling the source files view when the ended parameter is missing timezone."""
 
-        url = rest_util.get_url('/sources/?started=1970-01-01T00:00:00Z&ended=1970-01-02T00:00:00')
+        url = '/%s/sources/?started=1970-01-01T00:00:00Z&ended=1970-01-02T00:00:00' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -60,7 +61,7 @@ class TestSourcesView(TestCase):
     def test_negative_time_range(self):
         """Tests calling the source files view with a negative time range."""
 
-        url = rest_util.get_url('/sources/?started=1970-01-02T00:00:00Z&ended=1970-01-01T00:00:00')
+        url = '/%s/sources/?started=1970-01-02T00:00:00Z&ended=1970-01-01T00:00:00' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -68,7 +69,7 @@ class TestSourcesView(TestCase):
     def test_invalid_time_field(self):
         """Tests calling the source files view when the time_field parameter is invalid."""
 
-        url = rest_util.get_url('/sources/?started=1970-01-01T00:00:00Z&time_field=hello')
+        url = '/%s/sources/?started=1970-01-01T00:00:00Z&time_field=hello' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -76,7 +77,7 @@ class TestSourcesView(TestCase):
     def test_time_field(self):
         """Tests successfully calling the source files view using the time_field parameter"""
 
-        url = rest_util.get_url('/sources/?started=2016-02-01T00:00:00Z&time_field=data')
+        url = '/%s/sources/?started=2016-02-01T00:00:00Z&time_field=data' % self.api
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -86,7 +87,7 @@ class TestSourcesView(TestCase):
     def test_is_parsed(self):
         """Tests successfully calling the source files view filtered by is_parsed flag."""
 
-        url = rest_util.get_url('/sources/?is_parsed=true')
+        url = '/%s/sources/?is_parsed=true' % self.api
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -97,7 +98,7 @@ class TestSourcesView(TestCase):
     def test_file_name(self):
         """Tests successfully calling the source files view filtered by file name."""
 
-        url = rest_util.get_url('/sources/?file_name=test.txt')
+        url = '/%s/sources/?file_name=test.txt' % self.api
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -108,7 +109,7 @@ class TestSourcesView(TestCase):
     def test_successful(self):
         """Tests successfully calling the source files view."""
 
-        url = rest_util.get_url('/sources/')
+        url = '/%s/sources/' % self.api
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -116,8 +117,9 @@ class TestSourcesView(TestCase):
         self.assertEqual(len(result['results']), 2)
 
 
-class TestSourceDetailsView(TestCase):
-
+class TestSourceDetailsViewV5(TestCase):
+    api = 'v5'
+    
     def setUp(self):
         django.setup()
 
@@ -127,9 +129,7 @@ class TestSourceDetailsView(TestCase):
     def test_id(self):
         """Tests successfully calling the source files view by id"""
 
-        # TODO: this can change to rest_util.get_url() once v5 is default instead of v4
         url = '/v5/sources/%i/' % self.source.id
-        #  url = rest_util.get_url('/sources/%i/' % self.source.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -145,9 +145,7 @@ class TestSourceDetailsView(TestCase):
     def test_missing(self):
         """Tests calling the source files view with an invalid id"""
 
-        # TODO: this can change to rest_util.get_url() once v5 is default instead of v4
         url = '/v5/sources/12345/'
-        #  url = rest_util.get_url('/sources/12345/')
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
 
@@ -242,7 +240,8 @@ class TestSourceDetailsViewV4(TestCase):
                 self.assertIn(product['id'], [self.product1.id, self.product2.id])
 
 
-class TestSourceIngestsView(TestCase):
+class TestSourceIngestsViewV5(TestCase):
+    api = 'v5'
     fixtures = ['ingest_job_types.json']
 
     def setUp(self):
@@ -258,7 +257,7 @@ class TestSourceIngestsView(TestCase):
     def test_invalid_source_id(self):
         """Tests calling the source ingests view when the source ID is invalid."""
 
-        url = rest_util.get_url('/sources/12345678/ingests/')
+        url = '/%s/sources/12345678/ingests/' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
@@ -266,7 +265,7 @@ class TestSourceIngestsView(TestCase):
     def test_successful(self):
         """Tests successfully calling the source ingests view."""
 
-        url = rest_util.get_url('/sources/%s/ingests/' % self.source_file.id)
+        url = '/%s/sources/%s/ingests/' % (self.api, self.source_file.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -284,7 +283,7 @@ class TestSourceIngestsView(TestCase):
     def test_status(self):
         """Tests successfully calling the source ingests view filtered by status."""
 
-        url = rest_util.get_url('/sources/%s/ingests/?status=%s' % (self.source_file.id, self.ingest1.status))
+        url = '/%s/sources/%s/ingests/?status=%s' % (self.api, self.source_file.id, self.ingest1.status)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -295,7 +294,7 @@ class TestSourceIngestsView(TestCase):
     def test_strike_id(self):
         """Tests successfully calling the source ingests view filtered by strike processor."""
 
-        url = rest_util.get_url('/sources/%s/ingests/?strike_id=%d' % (self.source_file.id, self.ingest1.strike.id))
+        url = '/%s/sources/%s/ingests/?strike_id=%d' % (self.api, self.source_file.id, self.ingest1.strike.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -304,8 +303,9 @@ class TestSourceIngestsView(TestCase):
         self.assertEqual(result['results'][0]['strike']['id'], self.ingest1.strike.id)
 
 
-class TestSourceJobsView(TransactionTestCase):
-
+class TestSourceJobsViewV5(TransactionTestCase):
+    api = 'v5'
+    
     def setUp(self):
         django.setup()
 
@@ -329,7 +329,7 @@ class TestSourceJobsView(TransactionTestCase):
     def test_invalid_source_id(self):
         """Tests calling the source jobs view when the source ID is invalid."""
 
-        url = rest_util.get_url('/sources/12345678/jobs/')
+        url = '/%s/sources/12345678/jobs/' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
@@ -337,7 +337,7 @@ class TestSourceJobsView(TransactionTestCase):
     def test_successful(self):
         """Tests successfully calling the source jobs view."""
 
-        url = rest_util.get_url('/sources/%d/jobs/' % self.src_file.id)
+        url = '/%s/sources/%d/jobs/' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -356,7 +356,7 @@ class TestSourceJobsView(TransactionTestCase):
     def test_status(self):
         """Tests successfully calling the source jobs view filtered by status."""
 
-        url = rest_util.get_url('/sources/%d/jobs/?status=RUNNING' % self.src_file.id)
+        url = '/%s/sources/%d/jobs/?status=RUNNING' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -367,7 +367,7 @@ class TestSourceJobsView(TransactionTestCase):
     def test_job_id(self):
         """Tests successfully calling the source jobs view filtered by job identifier."""
 
-        url = rest_util.get_url('/sources/%d/jobs/?job_id=%s' % (self.src_file.id, self.job1.id))
+        url = '/%s/sources/%d/jobs/?job_id=%s' % (self.api, self.src_file.id, self.job1.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -378,7 +378,7 @@ class TestSourceJobsView(TransactionTestCase):
     def test_job_type_id(self):
         """Tests successfully calling the source jobs view filtered by job type identifier."""
 
-        url = rest_util.get_url('/sources/%d/jobs/?job_type_id=%s' % (self.src_file.id, self.job1.job_type.id))
+        url = '/%s/sources/%d/jobs/?job_type_id=%s' % (self.api, self.src_file.id, self.job1.job_type.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -389,7 +389,7 @@ class TestSourceJobsView(TransactionTestCase):
     def test_job_type_name(self):
         """Tests successfully calling the source jobs view filtered by job type name."""
 
-        url = rest_util.get_url('/sources/%d/jobs/?job_type_name=%s' % (self.src_file.id, self.job1.job_type.name))
+        url = '/%s/sources/%d/jobs/?job_type_name=%s' % (self.api, self.src_file.id, self.job1.job_type.name)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -400,8 +400,8 @@ class TestSourceJobsView(TransactionTestCase):
     def test_job_type_category(self):
         """Tests successfully calling the source jobs view filtered by job type category."""
 
-        url = rest_util.get_url('/sources/%d/jobs/?job_type_category=%s')
-        url = url % (self.src_file.id, self.job1.job_type.category)
+        url = '/%s/sources/%d/jobs/?job_type_category=%s'
+        url = url % (self.api, self.src_file.id, self.job1.job_type.category)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -418,7 +418,7 @@ class TestSourceJobsView(TransactionTestCase):
         job_exe = job_test_utils.create_job_exe(job=job)
         product_test_utils.create_file_link(ancestor=self.src_file, job=job, job_exe=job_exe)
 
-        url = rest_util.get_url('/sources/%d/jobs/?error_category=%s' % (self.src_file.id, error.category))
+        url = '/%s/sources/%d/jobs/?error_category=%s' % (self.api, self.src_file.id, error.category)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -430,7 +430,7 @@ class TestSourceJobsView(TransactionTestCase):
     def test_superseded(self):
         """Tests getting superseded jobs from source jobs view."""
 
-        url = rest_util.get_url('/sources/%d/jobs/?include_superseded=true' % self.src_file.id)
+        url = '/%s/sources/%d/jobs/?include_superseded=true' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -443,7 +443,7 @@ class TestSourceJobsView(TransactionTestCase):
         self.job1.batch_id = batch.id
         self.job1.save()
 
-        url = rest_util.get_url('/sources/%d/jobs/?batch_id=%d' % (self.src_file.id, batch.id))
+        url = '/%s/sources/%d/jobs/?batch_id=%d' % (self.api, self.src_file.id, batch.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -465,7 +465,7 @@ class TestSourceJobsView(TransactionTestCase):
         job_exe1c = job_test_utils.create_job_exe(job=job1c)
         product_test_utils.create_file_link(ancestor=self.src_file, job=job1c, job_exe=job_exe1c)
 
-        url = rest_util.get_url('/sources/%d/jobs/?order=job_type__name&order=-job_type__version' % self.src_file.id)
+        url = '/%s/sources/%d/jobs/?order=job_type__name&order=-job_type__version' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -477,8 +477,9 @@ class TestSourceJobsView(TransactionTestCase):
         self.assertEqual(result['results'][3]['job_type']['id'], self.job_type2.id)
 
 
-class TestSourceProductsView(TestCase):
-
+class TestSourceProductsViewV5(TestCase):
+    api = 'v5'
+    
     def setUp(self):
         django.setup()
 
@@ -518,7 +519,7 @@ class TestSourceProductsView(TestCase):
     def test_invalid_source_id(self):
         """Tests calling the source products view when the source ID is invalid."""
 
-        url = rest_util.get_url('/sources/12345678/products/')
+        url = '/%s/sources/12345678/products/' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
@@ -526,7 +527,7 @@ class TestSourceProductsView(TestCase):
     def test_invalid_started(self):
         """Tests calling the source products view when the started parameter is invalid."""
 
-        url = rest_util.get_url('/sources/%d/products/?started=hello' % self.src_file.id)
+        url = '/%s/sources/%d/products/?started=hello' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -534,7 +535,7 @@ class TestSourceProductsView(TestCase):
     def test_missing_tz_started(self):
         """Tests calling the source products view when the started parameter is missing timezone."""
 
-        url = rest_util.get_url('/sources/%d/products/?started=1970-01-01T00:00:00' % self.src_file.id)
+        url = '/%s/sources/%d/products/?started=1970-01-01T00:00:00' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -542,7 +543,7 @@ class TestSourceProductsView(TestCase):
     def test_invalid_ended(self):
         """Tests calling the source products view when the ended parameter is invalid."""
 
-        url = rest_util.get_url('/sources/%d/products/?started=1970-01-01T00:00:00Z&ended=hello' % self.src_file.id)
+        url = '/%s/sources/%d/products/?started=1970-01-01T00:00:00Z&ended=hello' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -550,8 +551,7 @@ class TestSourceProductsView(TestCase):
     def test_missing_tz_ended(self):
         """Tests calling the source products view when the ended parameter is missing timezone."""
 
-        url = '/sources/%d/products/?started=1970-01-01T00:00:00Z&ended=1970-01-02T00:00:00' % self.src_file.id
-        url = rest_util.get_url(url)
+        url = '/%s/sources/%d/products/?started=1970-01-01T00:00:00Z&ended=1970-01-02T00:00:00' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -559,8 +559,7 @@ class TestSourceProductsView(TestCase):
     def test_negative_time_range(self):
         """Tests calling the source products view with a negative time range."""
 
-        url = '/sources/%d/products/?started=1970-01-02T00:00:00Z&ended=1970-01-01T00:00:00' % self.src_file.id
-        url = rest_util.get_url(url)
+        url = '/%s/sources/%d/products/?started=1970-01-02T00:00:00Z&ended=1970-01-01T00:00:00' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -568,7 +567,7 @@ class TestSourceProductsView(TestCase):
     def test_batch_id(self):
         """Tests successfully calling the source products view filtered by batch identifier."""
 
-        url = rest_util.get_url('/sources/%d/products/?batch_id=%s' % (self.src_file.id, self.batch.id))
+        url = '/%s/sources/%d/products/?batch_id=%s' % (self.api, self.src_file.id, self.batch.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -578,7 +577,7 @@ class TestSourceProductsView(TestCase):
     def test_job_type_id(self):
         """Tests successfully calling the source products view filtered by job type identifier."""
 
-        url = rest_util.get_url('/sources/%d/products/?job_type_id=%s' % (self.src_file.id, self.job_type1.id))
+        url = '/%s/sources/%d/products/?job_type_id=%s' % (self.api, self.src_file.id, self.job_type1.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -589,7 +588,7 @@ class TestSourceProductsView(TestCase):
     def test_job_type_name(self):
         """Tests successfully calling the source products view filtered by job type name."""
 
-        url = rest_util.get_url('/sources/%d/products/?job_type_name=%s' % (self.src_file.id,  self.job_type1.name))
+        url = '/%s/sources/%d/products/?job_type_name=%s' % (self.api, self.src_file.id,  self.job_type1.name)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -600,8 +599,7 @@ class TestSourceProductsView(TestCase):
     def test_job_type_category(self):
         """Tests successfully calling the source products view filtered by job type category."""
 
-        url = '/sources/%d/products/?job_type_category=%s' % (self.src_file.id, self.job_type1.category)
-        url = rest_util.get_url(url)
+        url = '/%s/sources/%d/products/?job_type_category=%s' % (self.api, self.src_file.id, self.job_type1.category)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -612,7 +610,7 @@ class TestSourceProductsView(TestCase):
     def test_is_operational(self):
         """Tests successfully calling the source products view filtered by is_operational flag."""
 
-        url = rest_util.get_url('/sources/%d/products/?is_operational=true' % self.src_file.id)
+        url = '/%s/sources/%d/products/?is_operational=true' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -623,7 +621,7 @@ class TestSourceProductsView(TestCase):
     def test_is_published(self):
         """Tests successfully calling the source products view filtered by is_published flag."""
 
-        url = rest_util.get_url('/sources/%d/products/?is_published=false' % self.src_file.id)
+        url = '/%s/sources/%d/products/?is_published=false' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -635,7 +633,7 @@ class TestSourceProductsView(TestCase):
     def test_file_name(self):
         """Tests successfully calling the source products view filtered by file name."""
 
-        url = rest_util.get_url('/sources/%d/products/?file_name=test.txt' % self.src_file.id)
+        url = '/%s/sources/%d/products/?file_name=test.txt' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -646,7 +644,7 @@ class TestSourceProductsView(TestCase):
     def test_successful(self):
         """Tests successfully calling the source products view."""
 
-        url = rest_util.get_url('/sources/%d/products/' % self.src_file.id)
+        url = '/%s/sources/%d/products/' % (self.api, self.src_file.id)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -658,8 +656,9 @@ class TestSourceProductsView(TestCase):
             self.assertEqual(entry['countries'][0], self.country.iso3)
 
 
-class TestSourceUpdatesView(TestCase):
-
+class TestSourceUpdatesViewV5(TestCase):
+    api = 'v5'
+    
     def setUp(self):
         django.setup()
 
@@ -672,7 +671,7 @@ class TestSourceUpdatesView(TestCase):
     def test_invalid_started(self):
         """Tests calling the source file updates view when the started parameter is invalid."""
 
-        url = rest_util.get_url('/sources/updates/?started=hello')
+        url = '/%s/sources/updates/?started=hello' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -680,7 +679,7 @@ class TestSourceUpdatesView(TestCase):
     def test_missing_tz_started(self):
         """Tests calling the source file updates view when the started parameter is missing timezone."""
 
-        url = rest_util.get_url('/sources/updates/?started=1970-01-01T00:00:00')
+        url = '/%s/sources/updates/?started=1970-01-01T00:00:00' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -688,7 +687,7 @@ class TestSourceUpdatesView(TestCase):
     def test_invalid_ended(self):
         """Tests calling the source file updates view when the ended parameter is invalid."""
 
-        url = rest_util.get_url('/sources/updates/?started=1970-01-01T00:00:00Z&ended=hello')
+        url = '/%s/sources/updates/?started=1970-01-01T00:00:00Z&ended=hello' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -696,7 +695,7 @@ class TestSourceUpdatesView(TestCase):
     def test_missing_tz_ended(self):
         """Tests calling the source file updates view when the ended parameter is missing timezone."""
 
-        url = rest_util.get_url('/sources/updates/?started=1970-01-01T00:00:00Z&ended=1970-01-02T00:00:00')
+        url = '/%s/sources/updates/?started=1970-01-01T00:00:00Z&ended=1970-01-02T00:00:00' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -704,7 +703,7 @@ class TestSourceUpdatesView(TestCase):
     def test_negative_time_range(self):
         """Tests calling the source file updates view with a negative time range."""
 
-        url = rest_util.get_url('/sources/updates/?started=1970-01-02T00:00:00Z&ended=1970-01-01T00:00:00')
+        url = '/%s/sources/updates/?started=1970-01-02T00:00:00Z&ended=1970-01-01T00:00:00' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -712,7 +711,7 @@ class TestSourceUpdatesView(TestCase):
     def test_invalid_time_field(self):
         """Tests calling the source file updates view when the time_field parameter is invalid."""
 
-        url = rest_util.get_url('/sources/updates/?started=1970-01-01T00:00:00Z&time_field=hello')
+        url = '/%s/sources/updates/?started=1970-01-01T00:00:00Z&time_field=hello' % self.api
         response = self.client.generic('GET', url)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
@@ -720,7 +719,7 @@ class TestSourceUpdatesView(TestCase):
     def test_time_field(self):
         """Tests successfully calling the source file updates view using the time_field parameter"""
 
-        url = rest_util.get_url('/sources/updates/?started=2016-02-01T00:00:00Z&time_field=data')
+        url = '/%s/sources/updates/?started=2016-02-01T00:00:00Z&time_field=data' % self.api
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -730,7 +729,7 @@ class TestSourceUpdatesView(TestCase):
     def test_is_parsed(self):
         """Tests successfully calling the source files view filtered by is_parsed flag."""
 
-        url = rest_util.get_url('/sources/updates/?is_parsed=true')
+        url = '/%s/sources/updates/?is_parsed=true' % self.api
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -741,7 +740,7 @@ class TestSourceUpdatesView(TestCase):
     def test_file_name(self):
         """Tests successfully calling the source file updates view filtered by file name."""
 
-        url = rest_util.get_url('/sources/updates/?file_name=test.txt')
+        url = '/%s/sources/updates/?file_name=test.txt' % self.api
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -752,7 +751,7 @@ class TestSourceUpdatesView(TestCase):
     def test_successful(self):
         """Tests successfully calling the source file updates view."""
 
-        url = rest_util.get_url('/sources/updates/')
+        url = '/%s/sources/updates/' % self.api
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 

--- a/scale/source/views.py
+++ b/scale/source/views.py
@@ -28,6 +28,22 @@ class SourcesView(ListAPIView):
     serializer_class = SourceFileSerializer
 
     def list(self, request):
+        """Determine api version and call specific method
+
+        :param request: the HTTP POST request
+        :type request: :class:`rest_framework.request.Request`
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+
+        if request.version == 'v4':
+            return self.list_impl(request)
+        elif request.version == 'v5':
+            return self.list_impl(request)
+
+        raise Http404()
+        
+    def list_impl(self, request):
         """Retrieves the source files for a given time range and returns it in JSON form
 
         :param request: the HTTP GET request
@@ -62,7 +78,8 @@ class SourceDetailsView(RetrieveAPIView):
         """Override the serializer for legacy API calls."""
         if self.request.version == 'v4':
             return SourceFileDetailsSerializerV4
-        return SourceFileDetailsSerializer
+        elif self.request.version == 'v5':
+            return SourceFileDetailsSerializer
 
     def retrieve(self, request, source_id=None, file_name=None):
         """Retrieves the details for a source file and return them in JSON form
@@ -79,14 +96,16 @@ class SourceDetailsView(RetrieveAPIView):
 
         if request.version == 'v4':
             return self.retrieve_v4(request, source_id, file_name)
-
-        try:
-            source = SourceFile.objects.get_details(source_id)
-        except ScaleFile.DoesNotExist:
-            raise Http404
-
-        serializer = self.get_serializer(source)
-        return Response(serializer.data)
+        elif request.version == 'v5':
+            try:
+                source = SourceFile.objects.get_details(source_id)
+            except ScaleFile.DoesNotExist:
+                raise Http404
+    
+            serializer = self.get_serializer(source)
+            return Response(serializer.data)
+        
+        raise Http404()
 
     # TODO: remove when REST API v4 is removed
     def retrieve_v4(self, request, source_id=None, file_name=None):
@@ -126,6 +145,24 @@ class SourceIngestsView(ListAPIView):
     serializer_class = IngestSerializer
 
     def list(self, request, source_id=None):
+        """Determine api version and call specific method
+        
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :param source_id: The id of the source
+        :type source_id: int encoded as a string
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+        
+        if request.version == 'v4':
+            return self.list_impl(request, source_id)
+        elif request.version == 'v5':
+            return self.list_impl(request, source_id)
+
+        raise Http404()
+
+    def list_impl(self, request, source_id=None):
         """Retrieves the ingests for a given source file ID and returns them in JSON form
 
         :param request: the HTTP GET request
@@ -163,8 +200,26 @@ class SourceJobsView(ListAPIView):
     """This view is the endpoint for retrieving a list of all jobs related to a source file."""
     queryset = Job.objects.all()
     serializer_class = JobSerializer
-
+    
     def list(self, request, source_id=None):
+        """Determine api version and call specific method
+        
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :param source_id: The id of the source
+        :type source_id: int encoded as a string
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+        
+        if request.version == 'v4':
+            return self.list_impl(request, source_id)
+        elif request.version == 'v5':
+            return self.list_impl(request, source_id)
+
+        raise Http404()
+        
+    def list_impl(self, request, source_id=None):
         """Retrieves the jobs for a given source file ID and returns them in JSON form
 
         :param request: the HTTP GET request
@@ -213,6 +268,24 @@ class SourceProductsView(ListAPIView):
     serializer_class = ProductFileSerializer
 
     def list(self, request, source_id=None):
+        """Determine api version and call specific method
+        
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :param source_id: The id of the source
+        :type source_id: int encoded as a string
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+        
+        if request.version == 'v4':
+            return self.list_impl(request, source_id)
+        elif request.version == 'v5':
+            return self.list_impl(request, source_id)
+
+        raise Http404()
+        
+    def list_impl(self, request, source_id=None):
         """Retrieves the products for a given source file ID and returns them in JSON form
 
         :param request: the HTTP GET request
@@ -269,6 +342,22 @@ class SourceUpdatesView(ListAPIView):
     serializer_class = SourceFileUpdateSerializer
 
     def list(self, request):
+        """Determine api version and call specific method
+        
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+        
+        if request.version == 'v4':
+            return self.list_impl(request)
+        elif request.version == 'v5':
+            return self.list_impl(request)
+
+        raise Http404()
+        
+    def list_impl(self, request):
         """Retrieves the source file updates for a given time range and returns it in JSON form
 
         :param request: the HTTP GET request


### PR DESCRIPTION
Updating v5 docs to deprecate Source File endpoints and disabling it in v6 endpoints.