### PR TITLE
Fix for displaying recipe counts for new batches in v5 API

### DIFF
--- a/scale/batch/test/test_views.py
+++ b/scale/batch/test/test_views.py
@@ -496,7 +496,7 @@ class TestBatchDetailsViewV5(TestCase):
         definition.root_batch_id = prev_batch.root_batch_id
         definition.job_names = ['job_a', 'job_b']
         definition.all_jobs = True
-        new_batch = batch_test_utils.create_batch(recipe_type=recipe_type, definition=definition)
+        new_batch = batch_test_utils.create_batch(recipe_type=recipe_type, definition=definition, recipes_total=10)
 
         url = '/v5/batches/%d/' % new_batch.id
         response = self.client.get(url)
@@ -506,6 +506,8 @@ class TestBatchDetailsViewV5(TestCase):
         self.assertEqual(result['id'], new_batch.id)
         self.assertEqual(result['title'], new_batch.title)
         self.assertEqual(result['description'], new_batch.description)
+        self.assertEqual(result['created_count'], 10)
+        self.assertEqual(result['total_count'], 10)
         self.assertDictEqual(result['definition'], {'version': '1.0', 'job_names': ['job_a', 'job_b'],
                                                     'all_jobs': True})
 

--- a/scale/batch/views.py
+++ b/scale/batch/views.py
@@ -285,6 +285,11 @@ class BatchDetailsView(RetrieveUpdateAPIView):
         except Batch.DoesNotExist:
             raise Http404()
 
+        # Populate old count fields from new count field
+        if batch.recipes_total:
+            batch.created_count = batch.recipes_total
+            batch.total_count = batch.recipes_total
+
         serializer = self.get_serializer(batch)
         return Response(serializer.data)
 


### PR DESCRIPTION
This is a bug fix for displaying recipe counts for a new batch when using the v5 batch details API.