### PR TITLE
Issue 1105 - Create v6 job configuration

### DIFF
--- a/scale/data/data/json/data_v6.py
+++ b/scale/data/data/json/data_v6.py
@@ -95,7 +95,7 @@ class DataV6(object):
             if do_validate:
                 validate(self._data, DATA_SCHEMA)
         except ValidationError as ex:
-            raise InvalidData('INVALID_DATA', 'Invalid interface: %s' % unicode(ex))
+            raise InvalidData('INVALID_DATA', 'Invalid data: %s' % unicode(ex))
 
     def get_data(self):
         """Returns the data represented by this JSON

--- a/scale/job/configuration/configuration.py
+++ b/scale/job/configuration/configuration.py
@@ -1,0 +1,81 @@
+"""Defines the class that represents a job configuration"""
+from __future__ import unicode_literals
+
+from job.configuration.exceptions import InvalidJobConfiguration
+
+
+DEFAULT_PRIORITY = 100
+
+
+class JobConfiguration(object):
+    """Represents the configuration for running a job"""
+
+    def __init__(self):
+        """Constructor
+        """
+
+        # Jobs can be configured to have a main (default) workspace for all output files, as well as have a specific
+        # workspace for each output name
+        self.main_output_workspace = None
+        self.output_workspaces = {}  # {Output name: Workspace name}
+
+        self.priority = DEFAULT_PRIORITY
+
+        self.mounts = {}  # {Name: MountConfig}
+        self.settings = {}  # {Name: Value}
+
+    def add_mount(self, mount_config):
+        """Adds the given mount configuration
+
+        :param mount_config: The mount configuration to add
+        :type mount_config: :class:`job.configuration.mount.MountConfig`
+
+        :raises :class:`job.configuration.exceptions.InvalidJobConfiguration`: If the mount is a duplicate
+        """
+
+        if mount_config.name in self.mounts:
+            raise InvalidJobConfiguration('Duplicate mount \'%s\'' % mount_config.name)
+
+        self.mounts[mount_config.name] = mount_config
+
+    def add_setting(self, setting_name, setting_value):
+        """Adds the given setting value
+
+        :param setting_name: The setting name
+        :type setting_name: string
+        :param setting_value: The setting value
+        :type setting_value: string
+
+        :raises :class:`job.configuration.exceptions.InvalidJobConfiguration`: If the setting is a duplicate or invalid
+        """
+
+        if setting_name in self.settings:
+            raise InvalidJobConfiguration('Duplicate setting \'%s\'' % setting_name)
+        if not setting_value:
+            raise InvalidJobConfiguration('The value for setting \'%s\' must be a non-empty string' % setting_name)
+
+        self.settings[setting_name] = setting_value
+
+    # TODO: implement validating against a Seed manifest
+    def validate(self, interface):
+        """Validates the configuration against the given Seed manifest
+
+        :param interface: The interface dict for the job type
+        :type interface: dict
+        :returns: A list of warnings discovered during validation
+        :rtype: list
+
+        :raises :class:`job.configuration.exceptions.InvalidJobConfiguration`: If the configuration is invalid
+        """
+
+        warnings = []
+
+        for mount_config in self.mounts.values():
+            warnings.extend(mount_config.validate())
+
+        # TODO: ensure output workspaces are valid
+        # TODO: do warnings for ignored mounts and settings not defined in Seed
+        # TODO: do warnings for mounts, settings, and output workspaces in Seed, but not defined here
+        # TODO: strip out secret settings? how does this work now?
+
+        return warnings

--- a/scale/job/configuration/configuration.py
+++ b/scale/job/configuration/configuration.py
@@ -16,7 +16,7 @@ class JobConfiguration(object):
 
         # Jobs can be configured to have a main (default) workspace for all output files, as well as have a specific
         # workspace for each output name
-        self.main_output_workspace = None
+        self.default_output_workspace = None
         self.output_workspaces = {}  # {Output name: Workspace name}
 
         self.priority = DEFAULT_PRIORITY
@@ -37,6 +37,22 @@ class JobConfiguration(object):
             raise InvalidJobConfiguration('Duplicate mount \'%s\'' % mount_config.name)
 
         self.mounts[mount_config.name] = mount_config
+
+    def add_output_workspace(self, output, workspace):
+        """Adds the given output_workspace
+
+        :param output: The output name
+        :type output: string
+        :param workspace: The workspace name
+        :type workspace: string
+
+        :raises :class:`job.configuration.exceptions.InvalidJobConfiguration`: If the output is a duplicate
+        """
+
+        if output in self.output_workspaces:
+            raise InvalidJobConfiguration('Duplicate output workspace \'%s\'' % output)
+
+        self.output_workspaces[output] = workspace
 
     def add_setting(self, setting_name, setting_value):
         """Adds the given setting value
@@ -73,9 +89,11 @@ class JobConfiguration(object):
         for mount_config in self.mounts.values():
             warnings.extend(mount_config.validate())
 
-        # TODO: ensure output workspaces are valid
+        # TODO: ensure output workspaces are valid (exist)
+        # TODO: ensure priority is positive
         # TODO: do warnings for ignored mounts and settings not defined in Seed
         # TODO: do warnings for mounts, settings, and output workspaces in Seed, but not defined here
+        # TODO: do warnings for ro output workspaces
         # TODO: strip out secret settings? how does this work now?
 
         return warnings

--- a/scale/job/configuration/exceptions.py
+++ b/scale/job/configuration/exceptions.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from error.exceptions import ScaleError
+from util.exceptions import ValidationException
 
 
 class InvalidExecutionConfiguration(Exception):

--- a/scale/job/configuration/json/job/job_config_v6.py
+++ b/scale/job/configuration/json/job/job_config_v6.py
@@ -1,0 +1,245 @@
+"""Manages the v6 job configuration schema"""
+from __future__ import unicode_literals
+
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+from job.configuration.configuration import DEFAULT_PRIORITY, JobConfiguration
+from job.configuration.exceptions import InvalidJobConfiguration
+from job.configuration.json.job.job_config import JobConfiguration as JobConfigurationV2
+from job.configuration.mount import HostMountConfig, VolumeMountConfig
+from job.configuration.volume import HOST_TYPE, VOLUME_TYPE
+
+
+SCHEMA_VERSION = '6'
+
+
+JOB_CONFIG_SCHEMA = {
+    'type': 'object',
+    'required': ['mounts', 'output_workspaces', 'priority', 'settings'],
+    'additionalProperties': False,
+    'properties': {
+        'version': {
+            'description': 'Version of the job configuration schema',
+            'type': 'string',
+        },
+        'mounts': {
+            'description': 'Defines volumes to use for the job\'s mounts',
+            'type': 'object',
+            'additionalProperties': {
+                '$ref': '#/definitions/mount'
+            },
+        },
+        'output_workspaces': {
+            'description': 'Defines workspaces to use for the job\'s output files',
+            'type': 'object',
+            'required': ['default', 'outputs'],
+            'additionalProperties': False,
+            'properties': {
+                'default': {
+                    'description': 'Defines the job\'s default output workspace',
+                    'type': 'string',
+                },
+                'outputs': {
+                    'description': 'Defines a workspace for each given output name',
+                    'type': 'object',
+                    'additionalProperties': {
+                        'type': 'string',
+                    },
+                },
+            },
+        },
+        'priority': {
+            'description': 'Defines the job\'s priority',
+            'type': 'integer',
+            'minimum': 1,
+        },
+        'settings': {
+            'description': 'Defines values to use for the job\'s settings',
+            'type': 'object',
+            'additionalProperties': {
+                'type': 'string',
+            },
+        },
+    },
+    'definitions': {
+        'mount': {
+            'oneOf': [{
+                'type': 'object',
+                'description': 'A configuration for a host mount',
+                'required': ['type', 'host_path'],
+                'additionalProperties': False,
+                'properties': {
+                    'type': {
+                        'enum': ['host'],
+                    },
+                    'host_path': {
+                        'type': 'string',
+                    },
+                },
+            }, {
+                'type': 'object',
+                'description': 'A configuration for a volume mount',
+                'required': ['type', 'driver', 'driver_opts'],
+                'additionalProperties': False,
+                'properties': {
+                    'type': {
+                        'enum': ['volume'],
+                    },
+                    'driver': {
+                        'type': 'string',
+                    },
+                    'driver_opts': {
+                        'type': 'object',
+                        'additionalProperties': {
+                            'type': 'string',
+                        },
+                    },
+                },
+            }],
+        },
+    },
+}
+
+
+def convert_config_to_v6_json(config):
+    """Returns the v6 job configuration JSON for the given data
+
+    :param config: The job configuration
+    :type config: :class:`job.configuration.configuration.JobConfiguration`
+    :returns: The v6 job configuration JSON
+    :rtype: :class:`job.configuration.json.job.job_config_v6.JobConfigurationV6`
+    """
+
+    mounts_dict = {}
+    for mount_config in config.mounts.values():
+        if mount_config.mount_type == HOST_TYPE:
+            mounts_dict[mount_config.name] = {'type': 'host', 'host_path': mount_config.host_path}
+        elif mount_config.mount_type == VOLUME_TYPE:
+            vol_dict = {'type': 'volume', 'driver_opts': mount_config.driver_opts}
+            if mount_config.driver:
+                vol_dict['driver'] = mount_config.driver
+            mounts_dict[mount_config.name] = vol_dict
+
+    workspace_dict = {'outputs': config.output_workspaces}
+    if config.default_output_workspace:
+        workspace_dict['default'] = config.default_output_workspace
+
+    config_dict = {'version': SCHEMA_VERSION, 'mounts': mounts_dict, 'output_workspaces': workspace_dict,
+                   'priority': config.priority, 'settings': config.settings}
+
+    return JobConfigurationV6(config=config_dict, do_validate=False)
+
+
+class JobConfigurationV6(object):
+    """Represents a v6 job configuration JSON"""
+
+    def __init__(self, config=None, do_validate=False):
+        """Creates a v6 job configuration JSON object from the given dictionary
+
+        :param config: The job configuration JSON dict
+        :type config: dict
+        :param do_validate: Whether to perform validation on the JSON schema
+        :type do_validate: bool
+
+        :raises :class:`job.configuration.exceptions.InvalidJobConfiguration`: If the given configuration is invalid
+        """
+
+        if not config:
+            config = {}
+        self._config = config
+
+        if 'version' not in self._config:
+            self._config['version'] = SCHEMA_VERSION
+
+        if self._config['version'] != SCHEMA_VERSION:
+            self._convert_from_v2(do_validate)
+
+        self._populate_default_values()
+
+        try:
+            if do_validate:
+                validate(self._config, JOB_CONFIG_SCHEMA)
+        except ValidationError as ex:
+            raise InvalidJobConfiguration('Invalid configuration: %s' % unicode(ex))
+
+    def get_configuration(self):
+        """Returns the job configuration represented by this JSON
+
+        :returns: The job configuration
+        :rtype: :class:`job.configuration.configuration.JobConfiguration`:
+        """
+
+        config = JobConfiguration()
+
+        for name, mount_dict in self._config['mounts'].items():
+            if mount_dict['type'] == 'host':
+                config.add_mount(HostMountConfig(name, mount_dict['host_path']))
+            elif mount_dict['type'] == 'volume':
+                config.add_mount(VolumeMountConfig(name, mount_dict['driver'], mount_dict['driver_opts']))
+
+        default_workspace = self._config['output_workspaces']['default']
+        if default_workspace:
+            config.default_output_workspace = default_workspace
+        for output, workspace in self._config['output_workspaces']['outputs'].items():
+            config.add_output_workspace(output, workspace)
+
+        config.priority = self._config['priority']
+
+        for name, value in self._config['settings'].items():
+            config.add_setting(name, value)
+
+        return config
+
+    def get_dict(self):
+        """Returns the internal dictionary
+
+        :returns: The internal dictionary
+        :rtype: dict
+        """
+
+        return self._config
+
+    def _convert_from_v2(self, do_validate):
+        """Converts the JSON dict from v2 to the current version
+
+        :param do_validate: Whether to perform validation on the JSON schema
+        :type do_validate: bool
+
+        :raises :class:`job.configuration.exceptions.InvalidJobConfiguration`: If the given configuration is invalid
+        """
+
+        v2_json_dict = JobConfigurationV2(self._config).get_dict()
+
+        # Only the version needs changed when going from v2 to v6
+        if 'version' in v2_json_dict:
+            del v2_json_dict['version']
+        v2_json_dict['version'] = SCHEMA_VERSION
+
+        self._data = v2_json_dict
+
+    def _populate_default_values(self):
+        """Populates any missing required values with defaults
+        """
+
+        if 'mounts' not in self._config:
+            self._config['mounts'] = {}
+        for mount_dict in self._config['mounts'].values():
+            if mount_dict['type'] == 'volume':
+                if 'driver' not in mount_dict:
+                    mount_dict['driver'] = ''
+                if 'driver_opts' not in mount_dict:
+                    mount_dict['driver_opts'] = {}
+
+        if 'output_workspaces' not in self._config:
+            self._config['output_workspaces'] = {}
+        if 'default' not in self._config['output_workspaces']:
+            self._config['output_workspaces']['default'] = ''
+        if 'outputs' not in self._config['output_workspaces']:
+            self._config['output_workspaces']['outputs'] = {}
+
+        if 'priority' not in self._config:
+            self._config['priority'] = DEFAULT_PRIORITY
+
+        if 'settings' not in self._config:
+            self._config['settings'] = {}

--- a/scale/job/configuration/mount.py
+++ b/scale/job/configuration/mount.py
@@ -84,5 +84,5 @@ class VolumeMountConfig(MountConfig):
 
         super(VolumeMountConfig, self).__init__(name, VOLUME_TYPE)
 
-        self.driver = driver
-        self.driver_opts = driver_opts
+        self.driver = driver if driver else None
+        self.driver_opts = driver_opts if driver_opts else {}

--- a/scale/job/configuration/mount.py
+++ b/scale/job/configuration/mount.py
@@ -1,0 +1,88 @@
+"""Defines the configuration for a mount that will be mounted into a job's container"""
+from __future__ import unicode_literals
+
+import os
+from abc import ABCMeta
+
+from job.configuration.exceptions import InvalidJobConfiguration
+from job.configuration.volume import HOST_TYPE, VOLUME_TYPE
+
+
+class MountConfig(object):
+    """Defines the configuration for a job's mount
+    """
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, name, mount_type):
+        """Creates a mount configuration
+
+        :param name: The name of the mount
+        :type name: string
+        :param mount_type: The type of the mount
+        :type mount_type: string
+        """
+
+        self.name = name
+        self.mount_type = mount_type
+
+    def validate(self):
+        """Validates this mount configuration
+
+        :returns: A list of warnings discovered during validation
+        :rtype: list
+
+        :raises :class:`job.configuration.exceptions.InvalidJobConfiguration`: If the configuration is invalid
+        """
+
+        return []
+
+
+class HostMountConfig(MountConfig):
+    """Defines the configuration for a host mount
+    """
+
+    def __init__(self, name, host_path):
+        """Creates a host mount configuration
+
+        :param name: The name of the mount
+        :type name: string
+        :param host_path: The path on the host to be mounted into the container
+        :type host_path: string
+        """
+
+        super(HostMountConfig, self).__init__(name, HOST_TYPE)
+
+        self.host_path = host_path
+
+    def validate(self):
+        """See :meth:`job.configuration.mount.MountConfig.validate`
+        """
+
+        warnings = super(HostMountConfig, self).validate()
+
+        if not os.path.isabs(self.host_path):
+            raise InvalidJobConfiguration('Host mount %s must use an absolute host path' % self.name)
+
+        return warnings
+
+
+class VolumeMountConfig(MountConfig):
+    """Defines the configuration for a volume mount
+    """
+
+    def __init__(self, name, driver=None, driver_opts=None):
+        """Creates a volume mount configuration
+
+        :param name: The name of the volume
+        :type name: string
+        :param driver: The volume driver to use
+        :type driver: string
+        :param driver_opts: The driver options to use
+        :type driver_opts: dict
+        """
+
+        super(VolumeMountConfig, self).__init__(name, VOLUME_TYPE)
+
+        self.driver = driver
+        self.driver_opts = driver_opts

--- a/scale/job/configuration/volume.py
+++ b/scale/job/configuration/volume.py
@@ -3,9 +3,13 @@ from __future__ import unicode_literals
 
 from job.configuration.docker_param import DockerParameter
 
+# TODO: This class should be moved to the storage app and merged with the workspace brokers
 MODE_RO = 'ro'
 MODE_RW = 'rw'
 
+# TODO: This class could be split into two subclasses, one for host volumes and one for regular volumes
+HOST_TYPE = 'host'
+VOLUME_TYPE = 'volume'
 
 class Volume(object):
     """Defines a Docker volume that will be mounted into a container

--- a/scale/job/test/configuration/json/job/test_job_config_v6.py
+++ b/scale/job/test/configuration/json/job/test_job_config_v6.py
@@ -1,0 +1,65 @@
+from __future__ import unicode_literals
+
+import django
+from django.test import TestCase
+
+from job.configuration.configuration import JobConfiguration
+from job.configuration.exceptions import InvalidJobConfiguration
+from job.configuration.json.job.job_config_v6 import convert_config_to_v6_json, JobConfigurationV6
+from job.configuration.mount import HostMountConfig, VolumeMountConfig
+
+
+class TestJobConfigurationV6(TestCase):
+
+    def setUp(self):
+        django.setup()
+
+    def test_convert_config_to_v6_json(self):
+        """Tests calling convert_config_to_v6_json()"""
+
+        # Try configuration with nothing set
+        config = JobConfiguration()
+        json = convert_config_to_v6_json(config)
+        JobConfigurationV6(config=json.get_dict(), do_validate=True)  # Revalidate
+
+        # Try configuration with a variety of values
+        config = JobConfiguration()
+        config.add_mount(HostMountConfig('mount_1', '/the/host/path'))
+        config.add_mount(VolumeMountConfig('mount_2', 'driver', {'opt_1': 'foo', 'opt_2': 'bar'}))
+        config.default_output_workspace = 'workspace_1'
+        config.add_output_workspace('output_2', 'workspace_2')
+        config.priority = 999
+        config.add_setting('setting_1', 'Hello')
+        config.add_setting('setting_2', 'Scale!')
+        json = convert_config_to_v6_json(config)
+        JobConfigurationV6(config=json.get_dict(), do_validate=True)  # Revalidate
+        self.assertSetEqual(set(json.get_dict()['mounts'].keys()), {'mount_1', 'mount_2'})
+        self.assertEqual(json.get_dict()['priority'], 999)
+        self.assertSetEqual(set(json.get_dict()['settings'].keys()), {'setting_1', 'setting_2'})
+
+    def test_init_validation(self):
+        """Tests the validation done in __init__"""
+
+        # Try minimal acceptable configuration
+        JobConfigurationV6(do_validate=True)
+
+        # Invalid version
+        config_dict = {'version': 'BAD'}
+        with self.assertRaises(InvalidJobConfiguration) as context:
+            JobConfigurationV6(config_dict, do_validate=True)
+        #self.assertEqual(context.exception.error.name, 'INVALID_VERSION')
+
+        # Valid v6 configuration
+        config_dict = {'version': '6', 'mounts': {'mount_1': {'type': 'host', 'host_path': '/the/host/path'},
+                                                  'mount_2': {'type': 'volume', 'driver': 'driver',
+                                                              'driver_opts': {'opt_1': 'foo', 'opt_2': 'bar'}}},
+                       'output_workspaces': {'default': 'workspace_1', 'outputs': {'output': 'workspace_2'}},
+                       'priority': 999, 'settings': {'setting_1': '1234', 'setting_2': '5678'}}
+        JobConfigurationV6(config=config_dict, do_validate=True)
+
+        # Conversion from valid v2 configuration
+        config_dict = {'version': '2.0', 'mounts': {'mount_1': {'type': 'host', 'host_path': '/the/host/path'},
+                                                    'mount_2': {'type': 'volume', 'driver': 'driver',
+                                                                'driver_opts': {'opt_1': 'foo', 'opt_2': 'bar'}}},
+                       'settings': {'setting_1': '1234', 'setting_2': '5678'}}
+        JobConfigurationV6(config=config_dict, do_validate=True)


### PR DESCRIPTION
Created a new v6 job configuration. It is not yet connected to the configurator logic and it doesn't have v6 REST API docs yet. Both of these things will be implemented in the Seed integration branch.

The v6 job configuration has priority and output workspaces added to it in addition to the previous mounts and settings.