### PR TITLE
Issue 1166 - Update batch metrics

### DIFF
--- a/scale/batch/models.py
+++ b/scale/batch/models.py
@@ -608,32 +608,38 @@ class BatchManager(models.Manager):
         if not batch_ids:
             return
 
-        # Update recipe metrics for batch
-        qry = 'UPDATE batch b SET recipes_total = s.recipes_total, recipes_completed = s.recipes_completed '
-        qry += 'FROM (SELECT r.batch_id, COUNT(r.id) AS recipes_total, '
-        qry += 'COUNT(r.id) FILTER(WHERE r.is_completed) AS recipes_completed '
-        qry += 'FROM recipe r WHERE r.batch_id IN %s GROUP BY r.batch_id) s '
-        qry += 'WHERE b.id = s.batch_id'
-        with connection.cursor() as cursor:
-            cursor.execute(qry, [tuple(batch_ids)])
-
-        # Update job metrics for batch
-        qry = 'UPDATE batch b SET jobs_total = s.jobs_total, jobs_pending = s.jobs_pending, '
-        qry += 'jobs_blocked = s.jobs_blocked, jobs_queued = s.jobs_queued, jobs_running = s.jobs_running, '
-        qry += 'jobs_failed = s.jobs_failed, jobs_completed = s.jobs_completed, jobs_canceled = s.jobs_canceled, '
-        qry += 'last_modified = %s FROM (SELECT r.batch_id, COUNT(j.id) AS jobs_total, '
-        qry += 'COUNT(j.id) FILTER(WHERE status = \'PENDING\') AS jobs_pending, '
-        qry += 'COUNT(j.id) FILTER(WHERE status = \'BLOCKED\') AS jobs_blocked, '
-        qry += 'COUNT(j.id) FILTER(WHERE status = \'QUEUED\') AS jobs_queued, '
-        qry += 'COUNT(j.id) FILTER(WHERE status = \'RUNNING\') AS jobs_running, '
-        qry += 'COUNT(j.id) FILTER(WHERE status = \'FAILED\') AS jobs_failed, '
-        qry += 'COUNT(j.id) FILTER(WHERE status = \'COMPLETED\') AS jobs_completed, '
-        qry += 'COUNT(j.id) FILTER(WHERE status = \'CANCELED\') AS jobs_canceled '
-        qry += 'FROM recipe_node rj JOIN job j ON rj.job_id = j.id JOIN recipe r ON rj.recipe_id = r.id '
-        qry += 'WHERE r.batch_id IN %s GROUP BY r.batch_id) s '
+        qry = 'UPDATE batch b SET recipes_total = s.recipes_total, recipes_completed = s.recipes_completed, '
+        qry += 'jobs_total = s.jobs_total, jobs_pending = s.jobs_pending, jobs_blocked = s.jobs_blocked, '
+        qry += 'jobs_queued = s.jobs_queued, jobs_running = s.jobs_running, jobs_failed = s.jobs_failed, '
+        qry += 'jobs_completed = s.jobs_completed, jobs_canceled = s.jobs_canceled, last_modified = %s '
+        qry += 'FROM (SELECT r.batch_id, COUNT(r.id) + SUM(r.sub_recipes_total) AS recipes_total, '
+        qry += 'COUNT(r.id) FILTER(WHERE r.is_completed) + SUM(r.sub_recipes_completed) AS recipes_completed, '
+        qry += 'SUM(r.jobs_total) AS jobs_total, SUM(r.jobs_pending) AS jobs_pending, '
+        qry += 'SUM(r.jobs_blocked) AS jobs_blocked, SUM(r.jobs_queued) AS jobs_queued, '
+        qry += 'SUM(r.jobs_running) AS jobs_running, SUM(r.jobs_failed) AS jobs_failed, '
+        qry += 'SUM(r.jobs_completed) AS jobs_completed, SUM(r.jobs_canceled) AS jobs_canceled '
+        qry += 'FROM recipe r WHERE r.batch_id IN %s AND r.recipe_id IS NULL GROUP BY r.batch_id) s '
         qry += 'WHERE b.id = s.batch_id'
         with connection.cursor() as cursor:
             cursor.execute(qry, [now(), tuple(batch_ids)])
+
+        # Update job metrics for batch
+        # qry = 'UPDATE batch b SET jobs_total = s.jobs_total, jobs_pending = s.jobs_pending, '
+        # qry += 'jobs_blocked = s.jobs_blocked, jobs_queued = s.jobs_queued, jobs_running = s.jobs_running, '
+        # qry += 'jobs_failed = s.jobs_failed, jobs_completed = s.jobs_completed, jobs_canceled = s.jobs_canceled, '
+        # qry += 'last_modified = %s FROM (SELECT r.batch_id, COUNT(j.id) AS jobs_total, '
+        # qry += 'COUNT(j.id) FILTER(WHERE status = \'PENDING\') AS jobs_pending, '
+        # qry += 'COUNT(j.id) FILTER(WHERE status = \'BLOCKED\') AS jobs_blocked, '
+        # qry += 'COUNT(j.id) FILTER(WHERE status = \'QUEUED\') AS jobs_queued, '
+        # qry += 'COUNT(j.id) FILTER(WHERE status = \'RUNNING\') AS jobs_running, '
+        # qry += 'COUNT(j.id) FILTER(WHERE status = \'FAILED\') AS jobs_failed, '
+        # qry += 'COUNT(j.id) FILTER(WHERE status = \'COMPLETED\') AS jobs_completed, '
+        # qry += 'COUNT(j.id) FILTER(WHERE status = \'CANCELED\') AS jobs_canceled '
+        # qry += 'FROM recipe_node rn JOIN job j ON rn.job_id = j.id JOIN recipe r ON rn.recipe_id = r.id '
+        # qry += 'WHERE r.batch_id IN %s GROUP BY r.batch_id) s '
+        # qry += 'WHERE b.id = s.batch_id'
+        # with connection.cursor() as cursor:
+        #     cursor.execute(qry, [now(), tuple(batch_ids)])
 
         BatchMetrics.objects.update_batch_metrics_per_job(batch_ids)
 
@@ -778,11 +784,12 @@ class Batch(models.Model):
     :type jobs_completed: :class:`django.db.models.IntegerField`
     :keyword jobs_canceled: The count of all CANCELED jobs within the batch
     :type jobs_canceled: :class:`django.db.models.IntegerField`
-    :keyword recipes_estimated: The estimated count for all recipes that will be created for the batch
+    :keyword recipes_estimated: The estimated count for all recipes (including sub-recipes) that will be created for the
+        batch
     :type recipes_estimated: :class:`django.db.models.IntegerField`
-    :keyword recipes_total: The total count for all recipes within the batch
+    :keyword recipes_total: The total count for all recipes (including sub-recipes) within the batch
     :type recipes_total: :class:`django.db.models.IntegerField`
-    :keyword recipes_completed: The count for all completed recipes within the batch
+    :keyword recipes_completed: The count for all completed recipes (including sub-recipes) within the batch
     :type recipes_completed: :class:`django.db.models.IntegerField`
 
     :keyword created: When the batch was created
@@ -964,7 +971,7 @@ class BatchMetricsManager(models.Manager):
         qry += 'min_job_duration = s.min_job_duration, avg_job_duration = s.avg_job_duration, '
         qry += 'max_job_duration = s.max_job_duration, min_seed_duration = s.min_seed_duration, '
         qry += 'avg_seed_duration = s.avg_seed_duration, max_seed_duration = s.max_seed_duration, last_modified = %s '
-        qry += 'FROM (SELECT r.batch_id, rj.node_name, COUNT(j.id) AS jobs_total, '
+        qry += 'FROM (SELECT r.batch_id, rn.node_name, COUNT(j.id) AS jobs_total, '
         qry += 'COUNT(j.id) FILTER(WHERE j.status = \'PENDING\') AS jobs_pending, '
         qry += 'COUNT(j.id) FILTER(WHERE j.status = \'BLOCKED\') AS jobs_blocked, '
         qry += 'COUNT(j.id) FILTER(WHERE j.status = \'QUEUED\') AS jobs_queued, '
@@ -978,9 +985,9 @@ class BatchMetricsManager(models.Manager):
         qry += 'MIN(je.seed_ended - je.seed_started) FILTER(WHERE j.status = \'COMPLETED\') AS min_seed_duration, '
         qry += 'AVG(je.seed_ended - je.seed_started) FILTER(WHERE j.status = \'COMPLETED\') AS avg_seed_duration, '
         qry += 'MAX(je.seed_ended - je.seed_started) FILTER(WHERE j.status = \'COMPLETED\') AS max_seed_duration '
-        qry += 'FROM recipe_node rj JOIN job j ON rj.job_id = j.id JOIN recipe r ON rj.recipe_id = r.id '
+        qry += 'FROM recipe_node rn JOIN job j ON rn.job_id = j.id JOIN recipe r ON rn.recipe_id = r.id '
         qry += 'LEFT OUTER JOIN job_exe_end je ON je.job_id = j.id AND je.exe_num = j.num_exes '
-        qry += 'WHERE r.batch_id IN %s GROUP BY r.batch_id, rj.node_name) s '
+        qry += 'WHERE r.batch_id IN %s AND r.recipe_id IS NULL GROUP BY r.batch_id, rn.node_name) s '
         qry += 'WHERE bm.batch_id = s.batch_id AND bm.job_name = s.node_name'
         with connection.cursor() as cursor:
             cursor.execute(qry, [now(), tuple(batch_ids)])

--- a/scale/batch/models.py
+++ b/scale/batch/models.py
@@ -623,24 +623,6 @@ class BatchManager(models.Manager):
         with connection.cursor() as cursor:
             cursor.execute(qry, [now(), tuple(batch_ids)])
 
-        # Update job metrics for batch
-        # qry = 'UPDATE batch b SET jobs_total = s.jobs_total, jobs_pending = s.jobs_pending, '
-        # qry += 'jobs_blocked = s.jobs_blocked, jobs_queued = s.jobs_queued, jobs_running = s.jobs_running, '
-        # qry += 'jobs_failed = s.jobs_failed, jobs_completed = s.jobs_completed, jobs_canceled = s.jobs_canceled, '
-        # qry += 'last_modified = %s FROM (SELECT r.batch_id, COUNT(j.id) AS jobs_total, '
-        # qry += 'COUNT(j.id) FILTER(WHERE status = \'PENDING\') AS jobs_pending, '
-        # qry += 'COUNT(j.id) FILTER(WHERE status = \'BLOCKED\') AS jobs_blocked, '
-        # qry += 'COUNT(j.id) FILTER(WHERE status = \'QUEUED\') AS jobs_queued, '
-        # qry += 'COUNT(j.id) FILTER(WHERE status = \'RUNNING\') AS jobs_running, '
-        # qry += 'COUNT(j.id) FILTER(WHERE status = \'FAILED\') AS jobs_failed, '
-        # qry += 'COUNT(j.id) FILTER(WHERE status = \'COMPLETED\') AS jobs_completed, '
-        # qry += 'COUNT(j.id) FILTER(WHERE status = \'CANCELED\') AS jobs_canceled '
-        # qry += 'FROM recipe_node rn JOIN job j ON rn.job_id = j.id JOIN recipe r ON rn.recipe_id = r.id '
-        # qry += 'WHERE r.batch_id IN %s GROUP BY r.batch_id) s '
-        # qry += 'WHERE b.id = s.batch_id'
-        # with connection.cursor() as cursor:
-        #     cursor.execute(qry, [now(), tuple(batch_ids)])
-
         BatchMetrics.objects.update_batch_metrics_per_job(batch_ids)
 
     def validate_batch_v6(self, recipe_type, definition, configuration=None):

--- a/scale/batch/test/messages/test_update_batch_metrics.py
+++ b/scale/batch/test/messages/test_update_batch_metrics.py
@@ -10,7 +10,9 @@ from batch.messages.update_batch_metrics import UpdateBatchMetrics
 from batch.models import Batch, BatchMetrics
 from batch.test import utils as batch_test_utils
 from job.execution.tasks.json.results.task_results import TaskResults
+from job.models import Job
 from job.test import utils as job_test_utils
+from recipe.models import Recipe, RecipeNode
 from recipe.test import utils as recipe_test_utils
 from util.parse import datetime_to_string
 
@@ -46,6 +48,9 @@ class TestUpdateBatchMetrics(TestCase):
         recipe_test_utils.create_recipe_job(recipe=recipe_2, job=job_6)
         recipe_test_utils.create_recipe_job(recipe=recipe_2, job=job_7)
         recipe_test_utils.create_recipe_job(recipe=recipe_2, job=job_8)
+
+        # Generate recipe metrics
+        Recipe.objects.update_recipe_metrics([recipe_1.id, recipe_2.id])
 
         # Add batch to message
         message = UpdateBatchMetrics()
@@ -221,6 +226,9 @@ class TestUpdateBatchMetrics(TestCase):
         recipe_test_utils.create_recipe_job(recipe=recipe_3, job=job_26, job_name='c')
         recipe_test_utils.create_recipe_job(recipe=recipe_3, job=job_27, job_name='c')
 
+        # Generate recipe metrics
+        Recipe.objects.update_recipe_metrics([recipe_1.id, recipe_2.id, recipe_3.id])
+
         # Add batch to message
         message = UpdateBatchMetrics()
         if message.can_fit_more():
@@ -387,4 +395,125 @@ class TestUpdateBatchMetrics(TestCase):
         result = message.execute()
         self.assertTrue(result)
 
-        # TODO: check results again
+    def test_execute_with_sub_recipes(self):
+        """Tests calling UpdateBatchMetrics.execute() successfully with sub-recipes"""
+
+        batch = batch_test_utils.create_batch()
+        recipe_1 = recipe_test_utils.create_recipe(batch=batch)
+        recipe_2 = recipe_test_utils.create_recipe(batch=batch)
+        # Recipe 1 jobs
+        job_1 = job_test_utils.create_job(status='FAILED', save=False)
+        job_2 = job_test_utils.create_job(status='CANCELED', save=False)
+        job_3 = job_test_utils.create_job(status='BLOCKED', save=False)
+        job_4 = job_test_utils.create_job(status='BLOCKED', save=False)
+        job_5 = job_test_utils.create_job(status='COMPLETED', save=False)
+        # Recipe 2 jobs
+        job_6 = job_test_utils.create_job(status='COMPLETED', save=False)
+        job_7 = job_test_utils.create_job(status='COMPLETED', save=False)
+        job_8 = job_test_utils.create_job(status='RUNNING', save=False)
+        job_9 = job_test_utils.create_job(status='QUEUED', save=False)
+        job_10 = job_test_utils.create_job(status='PENDING', save=False)
+        job_11 = job_test_utils.create_job(status='PENDING', save=False)
+        job_12 = job_test_utils.create_job(status='PENDING', save=False)
+        job_13 = job_test_utils.create_job(status='CANCELED', save=False)
+        job_14 = job_test_utils.create_job(status='BLOCKED', save=False)
+        Job.objects.bulk_create([job_1, job_2, job_3, job_4, job_5, job_6, job_7, job_8, job_9, job_10, job_11, job_12,
+                                 job_13, job_14])
+
+        # Recipe 1 sub-recipes
+        sub_recipe_1 = recipe_test_utils.create_recipe(save=False)
+        sub_recipe_1.recipe = recipe_1
+        sub_recipe_1.jobs_total = 26
+        sub_recipe_1.jobs_pending = 3
+        sub_recipe_1.jobs_blocked = 4
+        sub_recipe_1.jobs_queued = 5
+        sub_recipe_1.jobs_running = 1
+        sub_recipe_1.jobs_failed = 2
+        sub_recipe_1.jobs_completed = 3
+        sub_recipe_1.jobs_canceled = 8
+        sub_recipe_1.is_completed = False
+        sub_recipe_2 = recipe_test_utils.create_recipe(save=False)
+        sub_recipe_2.recipe = recipe_1
+        sub_recipe_2.jobs_total = 30
+        sub_recipe_2.jobs_completed = 30
+        sub_recipe_2.is_completed = True
+        # Recipe 2 sub-recipes
+        sub_recipe_3 = recipe_test_utils.create_recipe(save=False)
+        sub_recipe_3.recipe = recipe_2
+        sub_recipe_3.jobs_total = 21
+        sub_recipe_3.jobs_pending = 2
+        sub_recipe_3.jobs_blocked = 5
+        sub_recipe_3.jobs_queued = 0
+        sub_recipe_3.jobs_running = 3
+        sub_recipe_3.jobs_failed = 2
+        sub_recipe_3.jobs_completed = 8
+        sub_recipe_3.jobs_canceled = 1
+        sub_recipe_3.is_completed = False
+        sub_recipe_4 = recipe_test_utils.create_recipe(save=False)
+        sub_recipe_4.recipe = recipe_2
+        sub_recipe_4.jobs_total = 7
+        sub_recipe_4.jobs_completed = 7
+        sub_recipe_4.is_completed = True
+        sub_recipe_5 = recipe_test_utils.create_recipe(save=False)
+        sub_recipe_5.recipe = recipe_2
+        sub_recipe_5.jobs_total = 12
+        sub_recipe_5.jobs_completed = 12
+        sub_recipe_5.is_completed = True
+        Recipe.objects.bulk_create([sub_recipe_1, sub_recipe_2, sub_recipe_3, sub_recipe_4, sub_recipe_5])
+        # Recipe 1 nodes
+        recipe_node_1 = recipe_test_utils.create_recipe_node(recipe=recipe_1, job=job_1)
+        recipe_node_2 = recipe_test_utils.create_recipe_node(recipe=recipe_1, job=job_2)
+        recipe_node_3 = recipe_test_utils.create_recipe_node(recipe=recipe_1, job=job_3)
+        recipe_node_4 = recipe_test_utils.create_recipe_node(recipe=recipe_1, job=job_4)
+        recipe_node_5 = recipe_test_utils.create_recipe_node(recipe=recipe_1, job=job_5)
+        recipe_node_6 = recipe_test_utils.create_recipe_node(recipe=recipe_1, sub_recipe=sub_recipe_1)
+        recipe_node_7 = recipe_test_utils.create_recipe_node(recipe=recipe_1, sub_recipe=sub_recipe_2)
+        # Recipe 2 nodes
+        recipe_node_8 = recipe_test_utils.create_recipe_node(recipe=recipe_2, job=job_6)
+        recipe_node_9 = recipe_test_utils.create_recipe_node(recipe=recipe_2, job=job_7)
+        recipe_node_10 = recipe_test_utils.create_recipe_node(recipe=recipe_2, job=job_8)
+        recipe_node_11 = recipe_test_utils.create_recipe_node(recipe=recipe_2, job=job_9)
+        recipe_node_12 = recipe_test_utils.create_recipe_node(recipe=recipe_2, job=job_10)
+        recipe_node_13 = recipe_test_utils.create_recipe_node(recipe=recipe_2, job=job_11)
+        recipe_node_14 = recipe_test_utils.create_recipe_node(recipe=recipe_2, job=job_12)
+        recipe_node_15 = recipe_test_utils.create_recipe_node(recipe=recipe_2, job=job_13)
+        recipe_node_16 = recipe_test_utils.create_recipe_node(recipe=recipe_2, job=job_14)
+        recipe_node_17 = recipe_test_utils.create_recipe_node(recipe=recipe_2, sub_recipe=sub_recipe_3)
+        recipe_node_18 = recipe_test_utils.create_recipe_node(recipe=recipe_2, sub_recipe=sub_recipe_4)
+        recipe_node_19 = recipe_test_utils.create_recipe_node(recipe=recipe_2, sub_recipe=sub_recipe_5)
+        RecipeNode.objects.bulk_create([recipe_node_1, recipe_node_2, recipe_node_3, recipe_node_4, recipe_node_5,
+                                        recipe_node_6, recipe_node_7, recipe_node_8, recipe_node_9, recipe_node_10,
+                                        recipe_node_11, recipe_node_12, recipe_node_13, recipe_node_14, recipe_node_15,
+                                        recipe_node_16, recipe_node_17, recipe_node_18, recipe_node_19])
+
+        # Generate recipe metrics
+        Recipe.objects.update_recipe_metrics([sub_recipe_1.id, sub_recipe_2.id, sub_recipe_3.id, sub_recipe_4.id,
+                                              sub_recipe_5.id])
+        Recipe.objects.update_recipe_metrics([recipe_1.id, recipe_2.id])
+
+        # Add batch to message
+        message = UpdateBatchMetrics()
+        if message.can_fit_more():
+            message.add_batch(batch.id)
+
+        # Execute message
+        result = message.execute()
+        self.assertTrue(result)
+
+        batch = Batch.objects.get(id=batch.id)
+        self.assertEqual(batch.jobs_total, 110)
+        self.assertEqual(batch.jobs_pending, 8)
+        self.assertEqual(batch.jobs_blocked, 12)
+        self.assertEqual(batch.jobs_queued, 6)
+        self.assertEqual(batch.jobs_running, 5)
+        self.assertEqual(batch.jobs_failed, 5)
+        self.assertEqual(batch.jobs_completed, 63)
+        self.assertEqual(batch.jobs_canceled, 11)
+        self.assertEqual(batch.recipes_total, 7)
+        self.assertEqual(batch.recipes_completed, 3)
+
+        # Test executing message again
+        message_json_dict = message.to_json()
+        message = UpdateBatchMetrics.from_json(message_json_dict)
+        result = message.execute()
+        self.assertTrue(result)

--- a/scale/docs/rest/v6/batch.rst
+++ b/scale/docs/rest/v6/batch.rst
@@ -170,11 +170,12 @@ Response: 200 OK
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
 | jobs_canceled           | Integer           | The count of CANCELED jobs within this batch's recipes                        |
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
-| recipes_estimated       | Integer           | The estimated count of recipes that will be created for this batch            |
+| recipes_estimated       | Integer           | The estimated count of recipes (including sub-recipes) that will be created   |
+|                         |                   | for this batch                                                                |
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
-| recipes_total           | Integer           | The total count of recipes within this batch                                  |
+| recipes_total           | Integer           | The total count of recipes (including sub-recipes) within this batch          |
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
-| recipes_completed       | Integer           | The count of completed recipes within this batch                              |
+| recipes_completed       | Integer           | The count of completed recipes (including sub-recipes) within this batch      |
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
 | created                 | ISO-8601 Datetime | When the batch was initially created                                          |
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
@@ -685,11 +686,12 @@ Response: 200 OK
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
 | jobs_canceled           | Integer           | The count of CANCELED jobs within this batch's recipes                        |
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
-| recipes_estimated       | Integer           | The estimated count of recipes that will be created for this batch            |
+| recipes_estimated       | Integer           | The estimated count of recipes (including sub-recipes) that will be created   |
+|                         |                   | for this batch                                                                |
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
-| recipes_total           | Integer           | The total count of recipes within this batch                                  |
+| recipes_total           | Integer           | The total count of recipes (including sub-recipes) within this batch          |
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
-| recipes_completed       | Integer           | The count of completed recipes within this batch                              |
+| recipes_completed       | Integer           | The count of completed recipes (including sub-recipes) within this batch      |
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
 | created                 | ISO-8601 Datetime | When the batch was initially created                                          |
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
@@ -703,12 +705,12 @@ Response: 200 OK
 | configuration           | JSON Object       | The configuration of the batch                                                |
 |                         |                   | See :ref:`rest_v6_batch_json_configuration`                                   |
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
-| job_metrics             | JSON Object       | The metrics for each recipe job in the batch. Each recipe job name maps to    |
-|                         |                   | the metrics for that job. The job count metrics (e.g. jobs_total) are similar |
-|                         |                   | to the top level batch metrics. The duration metrics (e.g. min_seed_duration) |
-|                         |                   | detail the minimum, average, and maximum durations for completing the Seed    |
-|                         |                   | run and completing the overall Scale job. The durations are provided in the   |
-|                         |                   | ISO-8601 duration format.                                                     |
+| job_metrics             | JSON Object       | The metrics for each top level recipe job (not in a sub-recipe) in the batch. |
+|                         |                   | Each recipe job name maps to the metrics for that job. The job count metrics  |
+|                         |                   | (e.g. jobs_total) are similar to the top level batch metrics. The duration    |
+|                         |                   | metrics (e.g. min_seed_duration) detail the minimum, average, and maximum     |
+|                         |                   | durations for completing the Seed run and completing the overall Scale job.   |
+|                         |                   | The durations are provided in the ISO-8601 duration format.                   |
 +-------------------------+-------------------+-------------------------------------------------------------------------------+
 
 .. _rest_v6_batch_edit:


### PR DESCRIPTION
I updated the batch metrics generation to handle sub-recipes.

Recipe metrics generation already correctly sends batch metrics update messages only for top level recipes, so I didn't have to implement that.