### PR TITLE
Issue 1234 - Fix Seed error bugs

### DIFF
--- a/scale/error/models.py
+++ b/scale/error/models.py
@@ -179,11 +179,12 @@ class ErrorManager(models.Manager):
         """
 
         error_names = [error.name for error in error_models]
-        error_ids = {error.name: error.id for error in self.filter(job_type_name=job_type_name, name__in=error_names)}
+        existing_errors = {err.name: err for err in self.filter(job_type_name=job_type_name, name__in=error_names)}
         for error_model in error_models:
-            if error_model.name in error_ids:
+            if error_model.name in existing_errors:
                 # Error already exists, grab ID so save() will perform an update
-                error_model.id = error_ids[error_model.name]
+                error_model.id = existing_errors[error_model.name].id
+                error_model.created = existing_errors[error_model.name].created # Keep created value unchanged
             error_model.save()
 
     # TODO - this is for creating errors for legacy job types, remove when legacy job types are removed

--- a/scale/error/test/test_models.py
+++ b/scale/error/test/test_models.py
@@ -1,16 +1,37 @@
 import django
 from django.test import TestCase
 
-from error.handlers import DatabaseLogHandler
+from error.models import Error
 
 
-class TestGetDatabaseModel(TestCase):
+class TestErrorManager(TestCase):
 
     def setUp(self):
         django.setup()
-        self.obj_under_test = DatabaseLogHandler()
 
-    def test_get_model(self):
-        model = self.obj_under_test.get_model('error.models.LogEntry')
-        if model is None:
-            self.fail("Failed to get the model")
+    def test_save_job_error_models(self):
+        """Tests successfully calling save_job_error_models()"""
+
+        job_type_name = 'job_type_1_for_error_test'
+        error_model_1 = Error()
+        error_model_1.name = 'error_1'
+        error_model_1.job_type_name = job_type_name
+        error_model_1.title = 'Error 1'
+        error_model_1.description = 'This is a description'
+        error_model_1.category = 'ALGORITHM'
+        error_model_2 = Error()
+        error_model_2.name = 'error_2'
+        error_model_2.job_type_name = job_type_name
+
+        # Test saving models for the first time
+        Error.objects.save_job_error_models(job_type_name, [error_model_1, error_model_2])
+        self.assertEqual(Error.objects.filter(job_type_name=job_type_name).count(), 2)
+
+        # Make some changes
+        error_model_1.description = 'New description'
+        error_model_2.category = 'DATA'
+
+        # Test updating models
+        Error.objects.save_job_error_models(job_type_name, [error_model_1, error_model_2])
+        self.assertEqual(Error.objects.get(name='error_1').description, 'New description')
+        self.assertEqual(Error.objects.get(name='error_2').category, 'DATA')

--- a/scale/job/error/error.py
+++ b/scale/job/error/error.py
@@ -47,5 +47,5 @@ class JobError(object):
         error_model.title = self.title
         error_model.description = self.description
         error_model.category = self.category
-        
+
         return error_model

--- a/scale/job/test/error/test_error.py
+++ b/scale/job/test/error/test_error.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from job.error.error import JobError
 
 
-class TestJobErrorModel(TestCase):
+class TestJobError(TestCase):
     """Tests functions in the job error module."""
 
     def setUp(self):
@@ -16,12 +16,13 @@ class TestJobErrorModel(TestCase):
     def test_create_error_model(self):
         """Validate that a complete Error model is created using JobError
         """
+
         job_type_name = 'test-job'
         name = 'bad-data'
         title = 'Bad Data'
         description = 'Error received when bad data is detected'
         category = 'DATA'
-        
+
         error = JobError(job_type_name, name, title, description, category)
         model = error.create_model()
         self.assertEqual(model.name, name)

--- a/scale/job/test/error/test_mapping.py
+++ b/scale/job/test/error/test_mapping.py
@@ -1,0 +1,41 @@
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+import django
+from django.test import TestCase
+
+from error.models import Error
+from job.error.error import JobError
+from job.error.mapping import JobErrorMapping
+
+
+class TestJobErrorMapping(TestCase):
+    """Tests the JobErrorMapping class"""
+
+    def setUp(self):
+        django.setup()
+
+    def test_save_models(self):
+        """Tests calling JobErrorMapping.save_models() successfully"""
+
+        job_type_name = 'test-job'
+        mapping = JobErrorMapping(job_type_name)
+
+        error_1 = JobError(job_type_name, 'mapped_error_1', title='Title', description='Description',
+                           category='ALGORITHM')
+        error_2 = JobError(job_type_name, 'mapped_error_2', category='DATA')
+        mapping.add_mapping(1, error_1)
+        mapping.add_mapping(2, error_2)
+
+        # Make sure error models are created successfully
+        mapping.save_models()
+        self.assertEqual(Error.objects.filter(job_type_name=job_type_name).count(), 2)
+
+        # Make some changes
+        error_1.description = 'New description'
+        error_2.category = 'ALGORITHM'
+
+        # Make sure error models are updated successfully
+        mapping.save_models()
+        self.assertEqual(Error.objects.get(name='mapped_error_1').description, 'New description')
+        self.assertEqual(Error.objects.get(name='mapped_error_2').category, 'ALGORITHM')


### PR DESCRIPTION
(1) and (2) seem to be fluke issues when we deployed to the dev DB. On both the prod DB and a clean DB, the 0005 error migration appears to generate the correct SQL commands.

Fixed the bug where updating an existing Seed error failed due to a null created time. Now the previous created time is queried and set on the model when updating.