### PR TITLE
roll back logstash for now...

### DIFF
--- a/dockerfiles/logstash/Dockerfile
+++ b/dockerfiles/logstash/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=logstash:5.6-alpine
+ARG IMAGE=logstash:2.4-alpine
 FROM $IMAGE
 MAINTAINER Scale Developers "https://github.com/ngageoint/scale"
 

--- a/dockerfiles/logstash/logstash.conf-template
+++ b/dockerfiles/logstash/logstash.conf-template
@@ -17,14 +17,18 @@ filter {
   if [@metadata][DEBUG] != 'true' {
     ruby {
       init => "@ordernum = 0"
-      code => "@ordernum += 1; tag_items = event.get('program').split('|'); event.set('scale_order_num', @ordernum); event.set('scale_task', tag_items[0].sub(%r{^docker/}, '')); event.set('scale_job_exe', event.get('scale_task').sub(%r{_[^_]*$}, '')); event.set('scale_node', event.get('logsource')); event.set('stream', event.get('severity') == 3 ? 'stderr' : 'stdout'); event.set('job_type', tag_items[1])"
+      code => "@ordernum += 1; tag_items = event['program'].split('|'); event['scale_order_num'] = @ordernum; event['scale_task'] = tag_items[0].sub(%r{^docker/}, ''); event['scale_job_exe'] = event['scale_task'].sub(%r{_[^_]*$}, ''); event['scale_node'] = event['logsource']; event['stream'] = event['severity'] == 3 ? 'stderr' : 'stdout'; event['job_type'] = tag_items[1]"
+#     line change needed when we upgrade logstash 
+#     code => "@ordernum += 1; tag_items = event.get('program').split('|'); event.set('scale_order_num', @ordernum); event.set('scale_task', tag_items[0].sub(%r{^docker/}, '')); event.set('scale_job_exe', event.get('scale_task').sub(%r{_[^_]*$}, '')); event.set('scale_node', event.get('logsource')); event.set('stream', event.get('severity') == 3 ? 'stderr' : 'stdout'); event.set('job_type', tag_items[1])"
       remove_field => ["host", "priority", "timestamp8601", "logsource", "program", "pid", "severity", "facility", "timestamp", "facility_label", "severity_label", "job_type"]
     }
   }
   else {
     ruby {
       init => "@ordernum = 0"
-      code => "@ordernum += 1; tag_items = event.get('program').split('|'); event.set('scale_order_num', @ordernum); event.set('scale_task', tag_items[0].sub(%r{^docker/}, '')); event.set('scale_job_exe', event.get('scale_task').sub(%r{_[^_]*$}, '')); event.set('scale_node', event.get('logsource')); event.set('stream', event.get('severity') == 3 ? 'stderr' : 'stdout'); event.set('job_type', tag_items[1])"
+      code => "@ordernum += 1; tag_items = event['program'].split('|'); event['scale_order_num'] = @ordernum; event['scale_task'] = tag_items[0].sub(%r{^docker/}, ''); event['scale_job_exe'] = event['scale_task'].sub(%r{_[^_]*$}, ''); event['scale_node'] = event['logsource']; event['stream'] = event['severity'] == 3 ? 'stderr' : 'stdout'; event['job_type'] = tag_items[1]"
+#     line change needed when we upgrade logstash 
+#     code => "@ordernum += 1; tag_items = event.get('program').split('|'); event.set('scale_order_num', @ordernum); event.set('scale_task', tag_items[0].sub(%r{^docker/}, '')); event.set('scale_job_exe', event.get('scale_task').sub(%r{_[^_]*$}, '')); event.set('scale_node', event.get('logsource')); event.set('stream', event.get('severity') == 3 ? 'stderr' : 'stdout'); event.set('job_type', tag_items[1])"
     }
   }
 

--- a/dockerfiles/logstash/supervisord.conf
+++ b/dockerfiles/logstash/supervisord.conf
@@ -9,7 +9,9 @@ stdout_logfile_maxbytes=0
 auto_start=true
 
 [program:logstash]
-command=sh -c 'sleep 5 && logstash $LOGSTASH_ARGS -f /opt/logstash/logstash.conf -r; kill 1'
+#for logstsash 5
+#command=sh -c 'sleep 5 && logstash $LOGSTASH_ARGS -f /opt/logstash/logstash.conf -r; kill 1'
+command=sh -c 'sleep 5 && logstash $LOGSTASH_ARGS -f /opt/logstash/logstash.conf --allow-env --auto-reload; kill 1'
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
fixes #1277 
roll back logstash to 2.4 for now, to avoid different logstash templates on different indices that may occur when upgrading elasticsearch. 