### PR TITLE
Issue 1307 - Fixed submitting Seed manifest without tags

### DIFF
--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -4030,7 +4030,8 @@ class JobTypeTagManager(models.Manager):
             job_type_tag.tag = tag
             job_type_tags.append(job_type_tag)
 
-        self.bulk_create(job_type_tags)
+        if job_type_tags:
+            self.bulk_create(job_type_tags)
 
         return job_type_tags
 

--- a/scale/job/seed/manifest.py
+++ b/scale/job/seed/manifest.py
@@ -122,7 +122,7 @@ class SeedManifest(object):
         :rtype: [str]
         """
 
-        return self.get_job()['tags']
+        return self.get_job().get('tags', [])
 
     def get_job(self):
         """Gets the Job object within the Seed manifest

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -1802,7 +1802,33 @@ class TestJobTypesPostViewV6(TestCase):
         self.assertEqual(results['revision_num'], 1)
         self.assertIsNone(results['max_scheduled'])
         self.assertEqual(results['configuration']['settings'], good_setting)
-        
+
+    def test_add_seed_job_type_minimum_manifest(self):
+        """Tests adding a Seed image with a minimum Seed manifest"""
+
+        url = '/%s/job-types/' % self.api
+        manifest = copy.deepcopy(job_test_utils.MINIMUM_MANIFEST)
+        manifest['job']['name'] = 'my-new-job'
+
+        json_data = {
+            'icon_code': 'BEEF',
+            'docker_image': 'my-new-job-1.0.0-seed:1.0.0',
+            'manifest': manifest
+        }
+
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        self.assertTrue('/%s/job-types/my-new-job/1.0.0/' % self.api in response['location'])
+
+        job_type = JobType.objects.filter(name='my-new-job').first()
+
+        results = json.loads(response.content)
+        self.assertEqual(results['id'], job_type.id)
+        self.assertEqual(results['version'], job_type.version)
+        self.assertEqual(results['title'], job_type.title)
+        self.assertEqual(results['revision_num'], job_type.revision_num)
+        self.assertEqual(results['revision_num'], 1)
+
     def test_add_seed_version_job_type(self):
         """Tests adding a new version of a seed image."""
         

--- a/scale/job/test/utils.py
+++ b/scale/job/test/utils.py
@@ -155,6 +155,22 @@ COMPLETE_MANIFEST = {
       }
     }
 
+MINIMUM_MANIFEST = {
+    'seedVersion': '1.0.0',
+    'job': {
+        'name': 'my-job',
+        'jobVersion': '1.0.0',
+        'packageVersion': '1.0.0',
+        'title': 'My first job',
+        'description': 'Reads an HDF5 file and outputs two png images, a CSV and manifest containing cell_count',
+        'maintainer': {
+            'name': 'John Doe',
+            'email': 'jdoe@example.com'
+        },
+        'timeout': 3600
+    }
+}
+
 
 class MockTriggerRuleConfiguration(JobTriggerRuleConfiguration):
     """Mock trigger rule configuration for testing


### PR DESCRIPTION
I fixed the bug so that minimum Seed manifests are correctly accepted by the v6 REST API.

If approved, please immediately merge and delete branch.