### PR TITLE
Output capture filters out special metadata files

### DIFF
--- a/scale/job/seed/types.py
+++ b/scale/job/seed/types.py
@@ -83,7 +83,7 @@ class SeedOutputFiles(SeedFiles):
         path_pattern = os.path.join(SCALE_JOB_EXE_OUTPUT_PATH, self.pattern)
         results = glob.glob(path_pattern)
 
-        logger.debug('Results found in post-step pattern match for output %s: %s' % (self.name, results))
+        logger.info('Results found in post-step pattern match for output %s: %s' % (self.name, results))
 
         # Remove any metadata.json and special json files from results
         purged_results = []

--- a/scale/job/seed/types.py
+++ b/scale/job/seed/types.py
@@ -7,6 +7,9 @@ import os
 from job.configuration.results.exceptions import OutputCaptureError
 from job.execution.container import SCALE_JOB_EXE_OUTPUT_PATH
 from job.seed.metadata import METADATA_SUFFIX
+from job.seed.results.outputs_json import SEED_OUPUTS_JSON_FILENAME
+
+LEGACY_RESULTS_MANIFEST = 'results_manifest.json'
 
 logger = logging.getLogger(__name__)
 
@@ -81,8 +84,15 @@ class SeedOutputFiles(SeedFiles):
 
         logger.debug('Results found in post-step pattern match for output %s: %s' % (self.name, results))
 
-        # Remove any metadata.json files from results
-        results = [x for x in results if METADATA_SUFFIX not in x]
+        special_files = [METADATA_SUFFIX, SEED_OUPUTS_JSON_FILENAME, LEGACY_RESULTS_MANIFEST]
+        # Remove any metadata.json and special json files from results
+        purged_results = []
+        for x in results:
+            for file_name in special_files:
+                if file_name in x:
+                    break
+            else:
+                purged_results.append(x)
 
         # Handle required validation
         if self.required and len(results) == 0:

--- a/scale/job/seed/types.py
+++ b/scale/job/seed/types.py
@@ -10,6 +10,7 @@ from job.seed.metadata import METADATA_SUFFIX
 from job.seed.results.outputs_json import SEED_OUPUTS_JSON_FILENAME
 
 LEGACY_RESULTS_MANIFEST = 'results_manifest.json'
+SPECIAL_FILES = [METADATA_SUFFIX, SEED_OUPUTS_JSON_FILENAME, LEGACY_RESULTS_MANIFEST]
 
 logger = logging.getLogger(__name__)
 
@@ -84,15 +85,15 @@ class SeedOutputFiles(SeedFiles):
 
         logger.debug('Results found in post-step pattern match for output %s: %s' % (self.name, results))
 
-        special_files = [METADATA_SUFFIX, SEED_OUPUTS_JSON_FILENAME, LEGACY_RESULTS_MANIFEST]
         # Remove any metadata.json and special json files from results
         purged_results = []
         for x in results:
-            for file_name in special_files:
+            for file_name in SPECIAL_FILES:
                 if file_name in x:
                     break
             else:
                 purged_results.append(x)
+        results = purged_results
 
         # Handle required validation
         if self.required and len(results) == 0:

--- a/scale/job/test/execution/configuration/test_configurators.py
+++ b/scale/job/test/execution/configuration/test_configurators.py
@@ -521,7 +521,8 @@ class TestScheduledExecutionConfigurator(TestCase):
                                           'SCALE_DB_HOST': 'TEST_HOST', 'SCALE_DB_PORT': 'TEST_PORT',
                                           'SCALE_JOB_ID': unicode(job.id), 'SCALE_EXE_NUM': unicode(job.num_exes),
                                           'SCALE_RECIPE_ID': unicode(recipe.id), 'SCALE_BATCH_ID': unicode(batch.id),
-                                          'SCALE_BROKER_URL': 'mock://broker-url'
+                                          'SCALE_BROKER_URL': 'mock://broker-url',
+                                          'SYSTEM_LOGGING_LEVEL': 'INFO'
                              },
                              'workspaces': {input_workspace.name: {'mode': 'ro', 'volume_name': input_wksp_vol_name}},
                              'mounts': {input_mnt_name: input_vol_name, output_mnt_name: output_vol_name},
@@ -548,6 +549,7 @@ class TestScheduledExecutionConfigurator(TestCase):
                                                {'flag': 'env', 'value': 'SCALE_EXE_NUM=%s' % unicode(job.num_exes)},
                                                {'flag': 'env', 'value': 'SCALE_RECIPE_ID=%s' % unicode(recipe.id)},
                                                {'flag': 'env', 'value': 'SCALE_BATCH_ID=%s' % unicode(batch.id)},
+                                               {'flag': 'env', 'value': 'SYSTEM_LOGGING_LEVEL=INFO'},
                                                {'flag': 'volume', 'value': '%s:%s:rw' %
                                                                            (output_vol_name, SCALE_JOB_EXE_OUTPUT_PATH)},
                                                {'flag': 'volume',
@@ -568,7 +570,8 @@ class TestScheduledExecutionConfigurator(TestCase):
                                           'SCALE_DB_HOST': 'TEST_HOST', 'SCALE_DB_PORT': 'TEST_PORT',
                                           'SCALE_JOB_ID': unicode(job.id), 'SCALE_EXE_NUM': unicode(job.num_exes),
                                           'SCALE_RECIPE_ID': unicode(recipe.id), 'SCALE_BATCH_ID': unicode(batch.id),
-                                          'SCALE_BROKER_URL': 'mock://broker-url'
+                                          'SCALE_BROKER_URL': 'mock://broker-url',
+                                          'SYSTEM_LOGGING_LEVEL': 'INFO'
                              },
                              'workspaces': {input_workspace.name: {'mode': 'rw', 'volume_name': input_wksp_vol_name},
                                             output_workspace.name: {'mode': 'rw', 'volume_name': output_wksp_vol_name}},
@@ -598,6 +601,7 @@ class TestScheduledExecutionConfigurator(TestCase):
                                                {'flag': 'env', 'value': 'SCALE_EXE_NUM=%s' % unicode(job.num_exes)},
                                                {'flag': 'env', 'value': 'SCALE_RECIPE_ID=%s' % unicode(recipe.id)},
                                                {'flag': 'env', 'value': 'SCALE_BATCH_ID=%s' % unicode(batch.id)},
+                                               {'flag': 'env', 'value': 'SYSTEM_LOGGING_LEVEL=INFO'},
                                                {'flag': 'volume', 'value': '%s:%s:ro' %
                                                                            (output_vol_name, SCALE_JOB_EXE_OUTPUT_PATH)},
                                                {'flag': 'volume',

--- a/scale/job/test/seed/test_types.py
+++ b/scale/job/test/seed/test_types.py
@@ -48,6 +48,19 @@ class TestSeedOutputsFiles(TestCase):
         files = seed_output_file.get_files()
 
         self.assertEqual(['outputs1.txt', 'outputs2.txt'], files)
+        
+    @patch('glob.glob', return_value=['something.json', 'seed.outputs.json', 'results_manifest.json'])
+    def test_get_files_single_output_file_with_metadata_files_to_exclude(self, glob):
+        seed_output_file = SeedOutputFiles({
+                'name': 'OUTPUT_FILES',
+                'pattern': '*.json',
+                'multiple': False,
+                'required': True
+            })
+
+        files = seed_output_file.get_files()
+
+        self.assertEqual(['something.json'], files)
 
 
 class TestSeedOutputsJson(TestCase):


### PR DESCRIPTION
- Pass `SYSTEM_LOGGING_LEVEL` to pre and post tasks
- Filter out special metadata files (`results_manifest.json`, `seed.outputs.json` and files ending in `.metadata.json`) from files returned by glob pattern matches
- Made file pattern matches log on info level 