### PR TITLE
#1210 - Recipe purge

### DIFF
--- a/scale/job/messages/spawn_delete_files_job.py
+++ b/scale/job/messages/spawn_delete_files_job.py
@@ -87,6 +87,7 @@ class SpawnDeleteFilesJob(CommandMessage):
 
             inputs = Data()
             inputs.add_value(JsonValue('job_id', str(self.job_id)))
+            inputs.add_value(JsonValue('trigger_id', str(self.trigger_id)))
             inputs.add_value(JsonValue('purge', str(self.purge)))
             inputs.add_value(JsonValue('files', json.dumps(files)))
             inputs.add_value(JsonValue('workspaces', json.dumps(workspaces)))

--- a/scale/job/test/messages/test_spawn_delete_files_job.py
+++ b/scale/job/test/messages/test_spawn_delete_files_job.py
@@ -27,7 +27,7 @@ class TestSpawnDeleteFilesJob(TransactionTestCase):
         self.prod2 = storage_test_utils.create_file(file_type='PRODUCT', workspace=self.wp1, job_exe=self.job_exe)
         self.prod3 = storage_test_utils.create_file(file_type='PRODUCT', workspace=self.wp2, job_exe=self.job_exe)
         self.event = trigger_test_utils.create_trigger_event()
-    
+
     def test_json(self):
         """Tests coverting a SpawnDeleteFilesJob message to and from JSON"""
 

--- a/scale/recipe/apps.py
+++ b/scale/recipe/apps.py
@@ -18,6 +18,7 @@ class RecipeConfig(AppConfig):
         from messaging.messages.factory import add_message_type
         from recipe.messages.create_recipes import CreateRecipes
         from recipe.messages.process_recipe_input import ProcessRecipeInput
+        from recipe.messages.purge_recipe import PurgeRecipe
         from recipe.messages.reprocess_recipes import ReprocessRecipes
         from recipe.messages.supersede_recipe_nodes import SupersedeRecipeNodes
         from recipe.messages.update_recipe_metrics import UpdateRecipeMetrics
@@ -25,6 +26,7 @@ class RecipeConfig(AppConfig):
 
         add_message_type(CreateRecipes)
         add_message_type(ProcessRecipeInput)
+        add_message_type(PurgeRecipe)
         add_message_type(ReprocessRecipes)
         add_message_type(SupersedeRecipeNodes)
         add_message_type(UpdateRecipeMetrics)

--- a/scale/recipe/instance/node.py
+++ b/scale/recipe/instance/node.py
@@ -24,6 +24,7 @@ class NodeInstance(object):
         self.parents = {}  # {Name: Node}
         self.children = {}  # {Name: Node}
         self.blocks_child_jobs = False  # Whether this node blocks child jobs from running
+        self.is_original = False # Whether this node is the original version (not superseded)
 
     def add_dependency(self, node):
         """Adds a dependency that this node has on the given node
@@ -55,18 +56,21 @@ class JobNodeInstance(NodeInstance):
     """Represents a job within a recipe
     """
 
-    def __init__(self, definition, job):
+    def __init__(self, definition, job, is_original):
         """Constructor
 
         :param definition: The definition of this node in the recipe
         :type definition: :class:`recipe.definition.node.JobNodeDefinition`
         :param job: The job model
         :type job: :class:`job.models.Job`
+        :param is_original: The bool designator to determine if job is original
+        :type is_original: bool
         """
 
         super(JobNodeInstance, self).__init__(definition)
 
         self.job = job
+        self.is_original = is_original
 
     def get_jobs_to_update(self, pending_job_ids, blocked_job_ids):
         """See :meth:`recipe.instance.node.NodeInstance.get_jobs_to_update`
@@ -92,18 +96,21 @@ class RecipeNodeInstance(NodeInstance):
     """Represents a recipe within a recipe
     """
 
-    def __init__(self, definition, recipe):
+    def __init__(self, definition, recipe, is_original):
         """Constructor
 
         :param definition: The definition of this node in the recipe
         :type definition: :class:`recipe.definition.node.RecipeNodeDefinition`
         :param recipe: The recipe model
         :type recipe: :class:`recipe.models.Recipe`
+        :param is_original: The bool designator to determine if recipe is original
+        :type is_original: bool
         """
 
         super(RecipeNodeInstance, self).__init__(definition)
 
         self.recipe = recipe
+        self.is_original = is_original
 
     def get_jobs_to_update(self, pending_job_ids, blocked_job_ids):
         """See :meth:`recipe.instance.node.NodeInstance.get_jobs_to_update`

--- a/scale/recipe/instance/recipe.py
+++ b/scale/recipe/instance/recipe.py
@@ -61,7 +61,7 @@ class RecipeInstance(object):
         leaf_job_ids = []
         leaf_recipe_ids = []
 
-        for node in self.graph:
+        for _, node in self.graph.items():
             if node.is_original:
                 if node.node_type == JobNodeDefinition.NODE_TYPE:
                     leaf_job_ids.append(node.job.id)

--- a/scale/recipe/instance/recipe.py
+++ b/scale/recipe/instance/recipe.py
@@ -58,14 +58,6 @@ class RecipeInstance(object):
         :rtype: dict
         """
 
-        leaf_job_ids = []
-        leaf_recipe_ids = []
+        leaf_nodes = {n.name: n for n in self.graph.values() if n.is_original and not n.children}  # {Name: Node}
 
-        for _, node in self.graph.items():
-            if node.is_original:
-                if node.node_type == JobNodeDefinition.NODE_TYPE:
-                    leaf_job_ids.append(node.job.id)
-                elif node.node_type == RecipeNodeDefinition.NODE_TYPE:
-                    leaf_recipe_ids.append(node.recipe.id)
-
-        return {'jobs': leaf_job_ids, 'recipes': leaf_recipe_ids}
+        return leaf_nodes

--- a/scale/recipe/instance/recipe.py
+++ b/scale/recipe/instance/recipe.py
@@ -51,5 +51,21 @@ class RecipeInstance(object):
 
         return {'BLOCKED': blocked_job_ids, 'PENDING': pending_job_ids}
 
-    # Function to find leaf recipes and jobs 
-    # returns leaf nodes 
+    def get_original_leaf_nodes(self):
+        """Returns a mapping of non-superseded job and recipe IDs
+
+        :returns: A dict with node mapping of recipe leafs
+        :rtype: dict
+        """
+
+        leaf_job_ids = []
+        leaf_recipe_ids = []
+
+        for node in self.graph:
+            if node.is_original:
+                if node.node_type == JobNodeDefinition.NODE_TYPE:
+                    leaf_job_ids.append(node.job.id)
+                elif node.node_type == RecipeNodeDefinition.NODE_TYPE:
+                    leaf_recipe_ids.append(node.recipe.id)
+
+        return {'jobs': leaf_job_ids, 'recipes': leaf_recipe_ids}

--- a/scale/recipe/instance/recipe.py
+++ b/scale/recipe/instance/recipe.py
@@ -28,9 +28,9 @@ class RecipeInstance(object):
             node_definition = self._definition.graph[node_name]
             recipe_node_model = recipe_node_dict[node_name]
             if node_definition.node_type == JobNodeDefinition.NODE_TYPE:
-                node = JobNodeInstance(node_definition, recipe_node_model.job)
+                node = JobNodeInstance(node_definition, recipe_node_model.job, recipe_node_model.is_original)
             elif node_definition.node_type == RecipeNodeDefinition.NODE_TYPE:
-                node = RecipeNodeInstance(node_definition, recipe_node_model.sub_recipe)
+                node = RecipeNodeInstance(node_definition, recipe_node_model.sub_recipe, recipe_node_model.is_original)
             self.graph[node.name] = node
             for parent_name in node_definition.parents.keys():
                 node.add_dependency(self.graph[parent_name])
@@ -50,3 +50,6 @@ class RecipeInstance(object):
             node.get_jobs_to_update(pending_job_ids, blocked_job_ids)
 
         return {'BLOCKED': blocked_job_ids, 'PENDING': pending_job_ids}
+
+    # Function to find leaf recipes and jobs 
+    # returns leaf nodes 

--- a/scale/recipe/messages/purge_recipe.py
+++ b/scale/recipe/messages/purge_recipe.py
@@ -17,9 +17,9 @@ def create_purge_recipe_message(recipe_id, trigger_id):
 
     :param recipe_id: The recipe ID
     :type purge_job_ids: int
-    :param trigger_id: The trigger event id for the purge operation
+    :param trigger_id: The trigger event ID for the purge operation
     :type trigger_id: int
-    :return: The list of messages
+    :return: The purge recipe message
     :rtype: :class:`recipe.messages.purge_recipe.PurgeRecipe`
     """
 

--- a/scale/recipe/messages/purge_recipe.py
+++ b/scale/recipe/messages/purge_recipe.py
@@ -1,0 +1,118 @@
+"""Defines a command message that purges a recipe"""
+from __future__ import unicode_literals
+
+import logging
+
+from recipe.models import Recipe, RecipeNode
+from messaging.messages.message import CommandMessage
+from util.parse import datetime_to_string, parse_datetime
+
+# This is the maximum number of job models that can fit in one message. This maximum ensures that every message of this
+# type is less than 25 KiB long.
+MAX_NUM = 100
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_purge_recipe_message(recipe_id, when):
+    """Creates messages to remove the given recipe by ID
+
+    :param recipe_id: The recipe ID
+    :type purge_job_ids: int
+    :param when: The current time
+    :type when: :class:`datetime.datetime`
+    :return: The list of messages
+    :rtype: :class:`recipe.messages.purge_recipe.PurgeRecipe`
+    """
+
+    message = PurgeRecipe()
+    message.recipe_id = recipe_id
+    message.when = when
+
+    return message
+
+
+class PurgeRecipe(CommandMessage):
+    """Command message that purges recipe components
+    """
+
+    def __init__(self):
+        """Constructor
+        """
+
+        super(PurgeRecipe, self).__init__('purge_recipe')
+
+        self.recipe_id = None
+        self.when = None
+
+    def to_json(self):
+        """See :meth:`messaging.messages.message.CommandMessage.to_json`
+        """
+
+        return {'recipe_id': self.recipe_id, 'when': datetime_to_string(self.when)}
+
+    @staticmethod
+    def from_json(json_dict):
+        """See :meth:`messaging.messages.message.CommandMessage.from_json`
+        """
+
+        when = parse_datetime(json_dict['when'])
+
+        message = PurgeRecipe()
+        message.recipe_id = json_dict['recipe_ID']
+        message.when = when
+
+        return message
+
+    def execute(self):
+        """See :meth:`messaging.messages.message.CommandMessage.execute`
+        """
+
+        """
+        Create a purge_recipe message that takes a single recipe ID:
+
+        - message should retrieve the recipe instance and determine the current, original leaf nodes (is_original == True),
+            delete_job_files messages (with purge) for original leaf jobs and send purge_recipe messages for original leaf recipes
+
+        - if there are no original nodes left in the recipe, delete BatchRecipe, RecipeNode (matched on sub_recipe or recipe),
+            RecipeInputFile, and Recipe model for this recipe ID
+
+        - if this recipe had a higher-level recipe containing it (had an is_original == True RecipeNode model matched on sub_recipe),
+            send a purge_recipe message for the higher-level recipe
+
+        - if the recipe did not have a higher-level recipe (is top-level) but has superseded another recipe, send a purge_recipe message for the superseded recipe
+
+        - Update the purge_jobs message to send a purge_recipe message if the job had an is_original == True RecipeNode model attached to it.
+            This way when a job is purged, it will alert its original recipe which can then purge that job's parents.
+
+        RecipeNode = Links a recipe with a node within that recipe. Nodes within a recipe may represent either a job or another
+            recipe. The same node may exist in multiple recipes due to superseding. For an original node and recipe combination,
+            the is_original flag is True. When recipe B supersedes recipe A, the non-superseded nodes from recipe A that are
+            being copied to recipe B will have models with is_original set to False.
+        """
+
+        recipe = Recipe.objects.get(id=self.recipe_id)
+        original_recipe_nodes = RecipeNode.objects.filter(recipe=recipe, is_original=True)
+        
+        # Kick off PurgeRecipe for parent recipes
+        parent_recipe_nodes = RecipeNode.objects.filter(sub_recipe=recipe, is_original=True)
+        if parent_recipe_nodes:
+            for parent_recipe in parent_recipe_nodes:
+                messages.append(create_purge_recipe_message(parent_recipe.recipe.id))
+        
+        elif recipe.is_superseeded:
+
+
+
+        # Determine if recipe is original
+        for recipe_node in recipe_nodes:
+            if recipe_node.is_original == True and recipe_node.sub_recipe:
+                # Kick off a purge_recipe for sub-recipes
+                messages.append(create_purge_recipe_message(recipe_node.recipe.id))
+
+                
+            else:
+                
+            pass
+        return True

--- a/scale/recipe/messages/purge_recipe.py
+++ b/scale/recipe/messages/purge_recipe.py
@@ -3,23 +3,23 @@ from __future__ import unicode_literals
 
 import logging
 
-from recipe.models import Recipe, RecipeNode
+from batch.models import BatchRecipe
+from job.messages.spawn_delete_files_job import create_spawn_delete_files_job
+from recipe.models import Recipe, RecipeInputFile, RecipeNode
 from messaging.messages.message import CommandMessage
 from util.parse import datetime_to_string, parse_datetime
-
-# This is the maximum number of job models that can fit in one message. This maximum ensures that every message of this
-# type is less than 25 KiB long.
-MAX_NUM = 100
 
 
 logger = logging.getLogger(__name__)
 
 
-def create_purge_recipe_message(recipe_id, when):
+def create_purge_recipe_message(recipe_id, trigger_id, when):
     """Creates messages to remove the given recipe by ID
 
     :param recipe_id: The recipe ID
     :type purge_job_ids: int
+    :param trigger_id: The trigger event id for the purge operation
+    :type trigger_id: int
     :param when: The current time
     :type when: :class:`datetime.datetime`
     :return: The list of messages
@@ -28,6 +28,7 @@ def create_purge_recipe_message(recipe_id, when):
 
     message = PurgeRecipe()
     message.recipe_id = recipe_id
+    message.trigger_id = trigger_id
     message.when = when
 
     return message
@@ -44,13 +45,14 @@ class PurgeRecipe(CommandMessage):
         super(PurgeRecipe, self).__init__('purge_recipe')
 
         self.recipe_id = None
+        self.trigger_id = None
         self.when = None
 
     def to_json(self):
         """See :meth:`messaging.messages.message.CommandMessage.to_json`
         """
 
-        return {'recipe_id': self.recipe_id, 'when': datetime_to_string(self.when)}
+        return {'recipe_id': self.recipe_id, 'trigger_id': self.trigger_id, 'when': datetime_to_string(self.when)}
 
     @staticmethod
     def from_json(json_dict):
@@ -60,7 +62,8 @@ class PurgeRecipe(CommandMessage):
         when = parse_datetime(json_dict['when'])
 
         message = PurgeRecipe()
-        message.recipe_id = json_dict['recipe_ID']
+        message.recipe_id = json_dict['recipe_id']
+        message.trigger_id = json_dict['trigger_id']
         message.when = when
 
         return message
@@ -93,26 +96,38 @@ class PurgeRecipe(CommandMessage):
         """
 
         recipe = Recipe.objects.get(id=self.recipe_id)
-        original_recipe_nodes = RecipeNode.objects.filter(recipe=recipe, is_original=True)
-        
-        # Kick off PurgeRecipe for parent recipes
-        parent_recipe_nodes = RecipeNode.objects.filter(sub_recipe=recipe, is_original=True)
-        if parent_recipe_nodes:
-            for parent_recipe in parent_recipe_nodes:
-                messages.append(create_purge_recipe_message(parent_recipe.recipe.id))
-        
-        elif recipe.is_superseeded:
+        recipe_nodes = RecipeNode.objects.filter(recipe=recipe)
 
-
-
-        # Determine if recipe is original
         for recipe_node in recipe_nodes:
             if recipe_node.is_original == True and recipe_node.sub_recipe:
                 # Kick off a purge_recipe for sub-recipes
-                messages.append(create_purge_recipe_message(recipe_node.recipe.id))
-
-                
-            else:
-                
+                self.new_messages.append(create_purge_recipe_message(recipe_id=recipe_node.recipe,
+                                                                     trigger_id=self.trigger_id,
+                                                                     when=self.when))
+            # Kick off a delete files job for the node job
+            self.new_messages.append(create_spawn_delete_files_job(job_id=recipe_node.job,
+                                                                   trigger_id=self.trigger_id,
+                                                                   purge=True))
+            # Kick off a purge recipe for the ???
+            self.new_messages.append(create_purge_recipe_message(recipe_id=recipe_node.recipe,
+                                                                 trigger_id=self.trigger_id,
+                                                                 when=self.when))
             pass
+
+        # Delete BatchRecipe, RecipeNode, RecipeInputFile, and Recipe
+        BatchRecipe.objects.filter(recipe=recipe).delete()
+        RecipeNode.objects.filter(recipe=recipe).delete()
+        RecipeInputFile.objects.filter(recipe=recipe).delete()
+        recipe.delete()
+
+        parent_recipe_nodes = RecipeNode.objects.filter(sub_recipe=recipe, is_original=True)
+
+        if parent_recipe_nodes:
+            for parent_recipe in parent_recipe_nodes:
+                # Kick off PurgeRecipe for parent recipes
+                messages.append(create_purge_recipe_message(recipe_id=recipe_node.recipe,
+                                                            trigger_id=self.trigger_id,
+                                                            when=self.when))
+        elif recipe.is_superseded:
+
         return True

--- a/scale/recipe/messages/purge_recipe.py
+++ b/scale/recipe/messages/purge_recipe.py
@@ -69,13 +69,13 @@ class PurgeRecipe(CommandMessage):
         recipe_nodes = recipe_inst.get_original_leaf_nodes()  # {'jobs': [j.id, j.id, ..], 'recipes': [r.id, r.id, ..]}
         parent_recipes = RecipeNode.objects.filter(sub_recipe=recipe, is_original=True)
 
-        # Kick off a delete files job for the node job
+        # Kick off a delete files job node jobs
         for job_id in recipe_nodes['jobs']:
             self.new_messages.append(create_spawn_delete_files_job(job_id=job_id,
                                                                    trigger_id=self.trigger_id,
                                                                    purge=True))
 
-        # Kick off a purge_recipe for node recipes
+        # Kick off a purge_recipe for node recipes (sub-recipes)
         for recipe_id in recipe_nodes['recipes']:
             self.new_messages.append(create_purge_recipe_message(recipe_id=recipe_id,
                                                                  trigger_id=self.trigger_id))
@@ -86,7 +86,7 @@ class PurgeRecipe(CommandMessage):
                 self.new_messages.append(create_purge_recipe_message(recipe_id=parent_recipe.recipe.id,
                                                                      trigger_id=self.trigger_id))
                 RecipeNode.objects.filter(sub_recipe=recipe).delete()
-                
+
         # Kick off purge_recipe for a superseded recipe
         elif recipe.superseded_recipe:
             self.new_messages.append(create_purge_recipe_message(recipe_id=recipe.superseded_recipe.id,

--- a/scale/recipe/messages/purge_recipe.py
+++ b/scale/recipe/messages/purge_recipe.py
@@ -7,21 +7,18 @@ from batch.models import BatchRecipe
 from job.messages.spawn_delete_files_job import create_spawn_delete_files_job
 from recipe.models import Recipe, RecipeInputFile, RecipeNode
 from messaging.messages.message import CommandMessage
-from util.parse import datetime_to_string, parse_datetime
 
 
 logger = logging.getLogger(__name__)
 
 
-def create_purge_recipe_message(recipe_id, trigger_id, when):
+def create_purge_recipe_message(recipe_id, trigger_id):
     """Creates messages to remove the given recipe by ID
 
     :param recipe_id: The recipe ID
     :type purge_job_ids: int
     :param trigger_id: The trigger event id for the purge operation
     :type trigger_id: int
-    :param when: The current time
-    :type when: :class:`datetime.datetime`
     :return: The list of messages
     :rtype: :class:`recipe.messages.purge_recipe.PurgeRecipe`
     """
@@ -29,7 +26,6 @@ def create_purge_recipe_message(recipe_id, trigger_id, when):
     message = PurgeRecipe()
     message.recipe_id = recipe_id
     message.trigger_id = trigger_id
-    message.when = when
 
     return message
 
@@ -46,25 +42,21 @@ class PurgeRecipe(CommandMessage):
 
         self.recipe_id = None
         self.trigger_id = None
-        self.when = None
 
     def to_json(self):
         """See :meth:`messaging.messages.message.CommandMessage.to_json`
         """
 
-        return {'recipe_id': self.recipe_id, 'trigger_id': self.trigger_id, 'when': datetime_to_string(self.when)}
+        return {'recipe_id': self.recipe_id, 'trigger_id': self.trigger_id}
 
     @staticmethod
     def from_json(json_dict):
         """See :meth:`messaging.messages.message.CommandMessage.from_json`
         """
 
-        when = parse_datetime(json_dict['when'])
-
         message = PurgeRecipe()
         message.recipe_id = json_dict['recipe_id']
         message.trigger_id = json_dict['trigger_id']
-        message.when = when
 
         return message
 
@@ -72,62 +64,36 @@ class PurgeRecipe(CommandMessage):
         """See :meth:`messaging.messages.message.CommandMessage.execute`
         """
 
-        """
-        Create a purge_recipe message that takes a single recipe ID:
-
-        - message should retrieve the recipe instance and determine the current, original leaf nodes (is_original == True),
-            delete_job_files messages (with purge) for original leaf jobs and send purge_recipe messages for original leaf recipes
-
-        - if there are no original nodes left in the recipe, delete BatchRecipe, RecipeNode (matched on sub_recipe or recipe),
-            RecipeInputFile, and Recipe model for this recipe ID
-
-        - if this recipe had a higher-level recipe containing it (had an is_original == True RecipeNode model matched on sub_recipe),
-            send a purge_recipe message for the higher-level recipe
-
-        - if the recipe did not have a higher-level recipe (is top-level) but has superseded another recipe, send a purge_recipe message for the superseded recipe
-
-        - Update the purge_jobs message to send a purge_recipe message if the job had an is_original == True RecipeNode model attached to it.
-            This way when a job is purged, it will alert its original recipe which can then purge that job's parents.
-
-        RecipeNode = Links a recipe with a node within that recipe. Nodes within a recipe may represent either a job or another
-            recipe. The same node may exist in multiple recipes due to superseding. For an original node and recipe combination,
-            the is_original flag is True. When recipe B supersedes recipe A, the non-superseded nodes from recipe A that are
-            being copied to recipe B will have models with is_original set to False.
-
-        Use recipe.get_recipe_instance to get the instance to traverse the recipe graph9
-        """
-
         recipe = Recipe.objects.get(id=self.recipe_id)
-        recipe_nodes = RecipeNode.objects.filter(recipe=recipe)
+        recipe_inst = Recipe.objects.get_recipe_instance(self.recipe_id)
+        recipe_nodes = recipe_inst.get_original_leaf_nodes()  # {'jobs': [j.id, j.id, ..], 'recipes': [r.id, r.id, ..]}
+        parent_recipes = RecipeNode.objects.filter(sub_recipe=recipe, is_original=True)
 
-        for recipe_node in recipe_nodes:
-            if recipe_node.is_original == True and recipe_node.sub_recipe:
-                # Kick off a purge_recipe for sub-recipes
-                self.new_messages.append(create_purge_recipe_message(recipe_id=recipe_node.sub_recipe,
-                                                                     trigger_id=self.trigger_id,
-                                                                     when=self.when))
-            # Kick off a delete files job for the node job
-            self.new_messages.append(create_spawn_delete_files_job(job_id=recipe_node.job,
+        # Kick off a delete files job for the node job
+        for job_id in recipe_nodes['jobs']:
+            self.new_messages.append(create_spawn_delete_files_job(job_id=job_id,
                                                                    trigger_id=self.trigger_id,
                                                                    purge=True))
+
+        # Kick off a purge_recipe for node recipes
+        for recipe_id in recipe_nodes['recipes']:
+            self.new_messages.append(create_purge_recipe_message(recipe_id=recipe_id,
+                                                                 trigger_id=self.trigger_id))
+
+        # Purge parent recipes
+        if parent_recipes:
+            for recipe_node in parent_recipes:
+                self.new_messages.append(create_purge_recipe_message(recipe_id=recipe_node.recipe,
+                                                                     trigger_id=self.trigger_id))
+        # Purge the superseded recipe if exists
+        elif recipe.superseded_recipe:
+            self.new_messages.append(create_purge_recipe_message(recipe_id=recipe.superseded_recipe.id,
+                                                                 trigger_id=self.trigger_id))
 
         # Delete BatchRecipe, RecipeNode, RecipeInputFile, and Recipe
         BatchRecipe.objects.filter(recipe=recipe).delete()
         RecipeNode.objects.filter(recipe=recipe).delete()
         RecipeInputFile.objects.filter(recipe=recipe).delete()
         recipe.delete()
-
-
-        # -------------
-        parent_recipe_nodes = RecipeNode.objects.filter(sub_recipe=recipe, is_original=True)
-
-        if parent_recipe_nodes:
-            for parent_recipe in parent_recipe_nodes:
-                # Kick off PurgeRecipe for parent recipes
-                self.new_messages.append(create_purge_recipe_message(recipe_id=recipe_node.recipe,
-                                                            trigger_id=self.trigger_id,
-                                                            when=self.when))
-        elif recipe.is_superseded:
-            pass
 
         return True

--- a/scale/recipe/test/instance/test_recipe.py
+++ b/scale/recipe/test/instance/test_recipe.py
@@ -79,3 +79,73 @@ class TestRecipe(TestCase):
         results = recipe_instance.get_jobs_to_update()
         self.assertSetEqual(set(results['BLOCKED']), {job_d.id, job_h.id})
         self.assertSetEqual(set(results['PENDING']), {job_e.id})
+
+    def test_get_original_leaf_nodes(self):
+        """Tests calling Recipe.get_original_leaf_nodes()"""
+
+        job_type = job_test_utils.create_job_type()
+        sub_recipe_type = recipe_test_utils.create_recipe_type()
+
+        definition = RecipeDefinition(Interface())
+        definition.add_job_node('A', job_type.name, job_type.version, job_type.revision_num)
+        definition.add_recipe_node('B', sub_recipe_type.name, sub_recipe_type.revision_num)
+        definition.add_job_node('C', job_type.name, job_type.version, job_type.revision_num)
+        definition.add_job_node('D', job_type.name, job_type.version, job_type.revision_num)
+        definition.add_job_node('E', job_type.name, job_type.version, job_type.revision_num)
+        definition.add_job_node('F', job_type.name, job_type.version, job_type.revision_num)
+        definition.add_recipe_node('G', sub_recipe_type.name, sub_recipe_type.revision_num)
+        definition.add_job_node('H', job_type.name, job_type.version, job_type.revision_num)
+        definition.add_dependency('A', 'C')
+        definition.add_dependency('A', 'E')
+        definition.add_dependency('A', 'H')
+        definition.add_dependency('B', 'E')
+        definition.add_dependency('B', 'G')
+        definition.add_dependency('C', 'D')
+        definition.add_dependency('E', 'F')
+        definition.add_dependency('G', 'H')
+
+        job_a = job_test_utils.create_job(job_type=job_type, status='COMPLETED', save=False, is_superseded=True)
+        job_c = job_test_utils.create_job(job_type=job_type, status='CANCELED', num_exes=0, save=False)
+        job_d = job_test_utils.create_job(job_type=job_type, status='PENDING', num_exes=0, save=False)
+        job_e = job_test_utils.create_job(job_type=job_type, status='BLOCKED', num_exes=0, save=False)
+        job_f = job_test_utils.create_job(job_type=job_type, status='PENDING', num_exes=0, save=False)
+        job_h = job_test_utils.create_job(job_type=job_type, status='PENDING', num_exes=0, save=False)
+        Job.objects.bulk_create([job_a, job_c, job_d, job_e, job_f, job_h])
+
+        recipe_b = recipe_test_utils.create_recipe(recipe_type=sub_recipe_type, save=False)
+        recipe_b.jobs_completed = 3
+        recipe_b.jobs_running = 2
+        recipe_b.jobs_total = 5
+        recipe_g = recipe_test_utils.create_recipe(recipe_type=sub_recipe_type, save=False)
+        recipe_g.jobs_completed = 2
+        recipe_g.jobs_failed = 1
+        recipe_g.jobs_total = 3
+        Recipe.objects.bulk_create([recipe_b, recipe_g])
+
+        definition_json_dict = convert_recipe_definition_to_v6_json(definition).get_dict()
+        recipe_type = recipe_test_utils.create_recipe_type(definition=definition_json_dict)
+        recipe = recipe_test_utils.create_recipe(recipe_type=recipe_type)
+        recipe_node_a = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='A', job=job_a, save=False,
+                                                             is_original=False)
+        recipe_node_c = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='C', job=job_c, save=False,
+                                                             is_original=False)
+        recipe_node_d = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='D', job=job_d, save=False,
+                                                             is_original=False)
+        recipe_node_e = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='E', job=job_e, save=False)
+        recipe_node_f = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='F', job=job_f, save=False)
+        recipe_node_h = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='H', job=job_h, save=False)
+
+        recipe_node_g = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='G', sub_recipe=recipe_g,
+                                                             save=False, is_original=False)
+        recipe_node_b = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='B', sub_recipe=recipe_b,
+                                                             save=False)
+        RecipeNode.objects.bulk_create([recipe_node_a, recipe_node_b, recipe_node_c, recipe_node_d, recipe_node_e,
+                                        recipe_node_f, recipe_node_g, recipe_node_h])
+
+        original_jobs = [recipe_node_e.job.id, recipe_node_f.job.id, recipe_node_h.job.id]
+        original_recipes = [recipe_node_b.sub_recipe.id]
+
+        recipe_instance = Recipe.objects.get_recipe_instance(recipe.id)
+        results = recipe_instance.get_original_leaf_nodes()
+        self.assertListEqual(results['jobs'], original_jobs)
+        self.assertListEqual(results['recipes'], original_recipes)

--- a/scale/recipe/test/messages/test_purge_recipe.py
+++ b/scale/recipe/test/messages/test_purge_recipe.py
@@ -1,0 +1,223 @@
+from __future__ import unicode_literals
+
+import django
+from django.test import TransactionTestCase
+
+from batch.test import utils as batch_test_utils
+from job.models import Job
+from job.test import utils as job_test_utils
+from recipe.messages.purge_recipe import create_purge_recipe_message, PurgeRecipe
+from recipe.models import Recipe, RecipeNode
+from recipe.test import utils as recipe_test_utils
+from storage.test import utils as storage_test_utils
+from trigger.test import utils as trigger_test_utils
+
+
+class TestPurgeRecipe(TransactionTestCase):
+
+    def setUp(self):
+        django.setup()
+
+        self.trigger = trigger_test_utils.create_trigger_event()
+        
+        self.workspace = storage_test_utils.create_workspace()
+        self.file_1 = storage_test_utils.create_file()
+        self.file_2 = storage_test_utils.create_file()
+
+        interface_1 = {
+            'version': '1.0',
+            'command': 'my_command',
+            'command_arguments': 'args',
+            'input_data': [{
+                'name': 'Test Input 1',
+                'type': 'file',
+                'media_types': ['text/plain'],
+            }],
+            'output_data': [{
+                'name': 'Test Output 1',
+                'type': 'files',
+                'media_type': 'image/png',
+            }]}
+        self.job_type_1 = job_test_utils.create_job_type(interface=interface_1)
+
+        interface_2 = {
+            'version': '1.0',
+            'command': 'my_command',
+            'command_arguments': 'args',
+            'input_data': [{
+                'name': 'Test Input 2',
+                'type': 'files',
+                'media_types': ['image/png', 'image/tiff'],
+            }],
+            'output_data': [{
+                'name': 'Test Output 2',
+                'type': 'file',
+            }]}
+        self.job_type_2 = job_test_utils.create_job_type(interface=interface_2)
+
+        definition = {
+            'version': '1.0',
+            'input_data': [{
+                'name': 'Recipe Input',
+                'type': 'file',
+                'media_types': ['text/plain'],
+            }],
+            'jobs': [{
+                'name': 'Job 1',
+                'job_type': {
+                    'name': self.job_type_1.name,
+                    'version': self.job_type_1.version,
+                },
+                'recipe_inputs': [{
+                    'recipe_input': 'Recipe Input',
+                    'job_input': 'Test Input 1',
+                }]
+            }, {
+                'name': 'Job 2',
+                'job_type': {
+                    'name': self.job_type_2.name,
+                    'version': self.job_type_2.version,
+                },
+                'dependencies': [{
+                    'name': 'Job 1',
+                    'connections': [{
+                        'output': 'Test Output 1',
+                        'input': 'Test Input 2',
+                    }]
+                }]
+            }]
+        }
+        self.recipe_type = recipe_test_utils.create_recipe_type(definition=definition)
+
+        self.input_1 = {
+            'version': '1.0',
+            'input_data': [{
+                'name': 'Recipe Input',
+                'file_id': self.file_1.id,
+            }],
+            'workspace_id': self.workspace.id,
+        }
+        self.recipe_1 = recipe_test_utils.create_recipe(recipe_type=self.recipe_type)
+        self.job_1_1 = job_test_utils.create_job(job_type=self.job_type_1, status='COMPLETED')
+        recipe_test_utils.create_recipe_job(recipe=self.recipe_1, job_name='Job 1', job=self.job_1_1)
+        self.job_1_2 = job_test_utils.create_job(job_type=self.job_type_2, status='COMPLETED')
+        recipe_test_utils.create_recipe_job(recipe=self.recipe_1, job_name='Job 2', job=self.job_1_2)
+
+        self.input_2 = {
+            'version': '1.0',
+            'input_data': [{
+                'name': 'Recipe Input',
+                'file_id': self.file_2.id,
+            }],
+            'workspace_id': self.workspace.id,
+        }
+        self.recipe_2 = recipe_test_utils.create_recipe(recipe_type=self.recipe_type, input=self.input_2)
+        self.job_2_1 = job_test_utils.create_job(job_type=self.job_type_1, status='COMPLETED')
+        recipe_test_utils.create_recipe_job(recipe=self.recipe_2, job_name='Job 1', job=self.job_2_1)
+        self.job_2_2 = job_test_utils.create_job(job_type=self.job_type_2, status='COMPLETED')
+        recipe_test_utils.create_recipe_job(recipe=self.recipe_2, job_name='Job 2', job=self.job_2_2)
+
+        self.old_recipe_ids = [self.recipe_1.id, self.recipe_2.id]
+        self.old_job_ids = [self.job_1_1.id, self.job_1_2.id, self.job_2_1.id, self.job_2_2.id]
+        self.old_job_1_ids = [self.job_1_1.id, self.job_2_1.id]
+        self.old_job_2_ids = [self.job_1_2.id, self.job_2_2.id]
+
+    def test_json(self):
+        """Tests coverting a ReprocessRecipes message to and from JSON"""
+
+        # Create message
+        message = create_purge_recipe_message(recipe_id=self.recipe_1.id, trigger_id=self.trigger.id)
+
+        # Convert message to JSON and back, and then execute
+        message_json_dict = message.to_json()
+        new_message = PurgeRecipe.from_json(message_json_dict)
+        result = new_message.execute()
+
+        self.assertTrue(result)
+
+    def test_execute(self):
+        """Tests calling PurgeRecipe.execute() successfully"""
+
+        batch = batch_test_utils.create_batch()
+        event = trigger_test_utils.create_trigger_event()
+
+        # Create message
+        message = create_purge_recipe_message(recipe_id=self.recipe_1.id, trigger_id=self.trigger_1.id)
+
+        # Execute message
+        result = message.execute()
+        self.assertTrue(result)
+
+        print len(message.new_messages)
+        print result
+
+        # # Make sure new recipes supersede the old ones
+        # for recipe in Recipe.objects.filter(id__in=self.old_recipe_ids):
+        #     self.assertTrue(recipe.is_superseded)
+        # new_recipe_1 = Recipe.objects.get(superseded_recipe_id=self.recipe_1.id)
+        # self.assertEqual(new_recipe_1.batch_id, batch.id)
+        # self.assertEqual(new_recipe_1.event_id, event.id)
+        # self.assertEqual(new_recipe_1.root_superseded_recipe_id, self.recipe_1.id)
+        # self.assertDictEqual(new_recipe_1.input, self.recipe_1.input)
+        # new_recipe_2 = Recipe.objects.get(superseded_recipe_id=self.recipe_2.id)
+        # self.assertEqual(new_recipe_2.batch_id, batch.id)
+        # self.assertEqual(new_recipe_2.event_id, event.id)
+        # self.assertEqual(new_recipe_2.root_superseded_recipe_id, self.recipe_2.id)
+        # self.assertDictEqual(new_recipe_2.input, self.recipe_2.input)
+        # # Make sure identical jobs (Job 1) are NOT superseded
+        # for job in Job.objects.filter(id__in=self.old_job_1_ids):
+        #     self.assertFalse(job.is_superseded)
+        # # Make sure old jobs (Job 2) are superseded
+        # for job in Job.objects.filter(id__in=self.old_job_2_ids):
+        #     self.assertTrue(job.is_superseded)
+        # # Make sure identical jobs (Job 1) were copied to new recipes
+        # recipe_job_1 = RecipeNode.objects.get(recipe=new_recipe_1.id)
+        # self.assertEqual(recipe_job_1.node_name, 'Job 1')
+        # self.assertEqual(recipe_job_1.job_id, self.job_1_1.id)
+        # recipe_job_2 = RecipeNode.objects.get(recipe=new_recipe_2.id)
+        # self.assertEqual(recipe_job_2.node_name, 'Job 1')
+        # self.assertEqual(recipe_job_2.job_id, self.job_2_1.id)
+        # # Should be three messages, two for processing new recipe input and one for canceling superseded jobs
+        # self.assertEqual(len(message.new_messages), 3)
+        # found_process_recipe_input_1 = False
+        # found_process_recipe_input_2 = False
+        # found_cancel_jobs = False
+        # for msg in message.new_messages:
+        #     if msg.type == 'process_recipe_input':
+        #         if msg.recipe_id == new_recipe_1.id:
+        #             found_process_recipe_input_1 = True
+        #         elif msg.recipe_id == new_recipe_2.id:
+        #             found_process_recipe_input_2 = True
+        #     elif msg.type == 'cancel_jobs':
+        #         found_cancel_jobs = True
+        #         self.assertSetEqual(set(msg._job_ids), set(self.old_job_2_ids))
+        # self.assertTrue(found_process_recipe_input_1)
+        # self.assertTrue(found_process_recipe_input_2)
+        # self.assertTrue(found_cancel_jobs)
+
+        # # Test executing message again
+        # message_json_dict = message.to_json()
+        # message = ReprocessRecipes.from_json(message_json_dict)
+        # result = message.execute()
+        # self.assertTrue(result)
+
+        # # Make sure we don't reprocess twice
+        # for new_recipe in Recipe.objects.filter(id__in=[new_recipe_1.id, new_recipe_2.id]):
+        #     self.assertFalse(new_recipe.is_superseded)
+        # # Should get same messages
+        # self.assertEqual(len(message.new_messages), 3)
+        # found_process_recipe_input_1 = False
+        # found_process_recipe_input_2 = False
+        # found_cancel_jobs = False
+        # for msg in message.new_messages:
+        #     if msg.type == 'process_recipe_input':
+        #         if msg.recipe_id == new_recipe_1.id:
+        #             found_process_recipe_input_1 = True
+        #         elif msg.recipe_id == new_recipe_2.id:
+        #             found_process_recipe_input_2 = True
+        #     elif msg.type == 'cancel_jobs':
+        #         found_cancel_jobs = True
+        #         self.assertSetEqual(set(msg._job_ids), set(self.old_job_2_ids))
+        # self.assertTrue(found_process_recipe_input_1)
+        # self.assertTrue(found_process_recipe_input_2)
+        # self.assertTrue(found_cancel_jobs)

--- a/scale/recipe/test/messages/test_purge_recipe.py
+++ b/scale/recipe/test/messages/test_purge_recipe.py
@@ -137,12 +137,6 @@ class TestPurgeRecipe(TransactionTestCase):
 
         self.assertTrue(result)
 
-# Create 2 jobs, assert 2 new_messages wth msg.type == 'create_spawn_delete_files_job'
-# TODO: Assert msg.type == 'create_purge_recipe_message' for node recipe.id
-# TODO: Assert msg.type == 'create_purge_recipe_message' for parent recipe.id
-# Assert msg.type == 'create_purge_recipe_message' for superseded recipe.id
-# TODO: BatchRecipe models have been deleted 
-
     def test_execute_with_jobs(self):
         """Tests calling PurgeRecipe.execute() successfully"""
 
@@ -188,7 +182,6 @@ class TestPurgeRecipe(TransactionTestCase):
         self.assertEqual(Recipe.objects.filter(id=recipe.id).count(), 0)
         self.assertEqual(RecipeNode.objects.filter(recipe=recipe).count(), 0)
 
-    # logic is okay, make tests good
     def test_execute_with_parent_recipe(self):
         """Tests calling PurgeRecipe.execute() successfully"""
 
@@ -214,7 +207,6 @@ class TestPurgeRecipe(TransactionTestCase):
         self.assertEqual(Recipe.objects.filter(id=recipe.id).count(), 0)
         self.assertEqual(RecipeNode.objects.filter(recipe=recipe).count(), 0)
 
-    # logic is okay, make tests good
     def test_execute_with_sub_recipe(self):
         """Tests calling PurgeRecipe.execute() successfully"""
 

--- a/scale/recipe/test/utils.py
+++ b/scale/recipe/test/utils.py
@@ -211,7 +211,7 @@ def create_recipe_job(recipe=None, job_name=None, job=None):
     return recipe_job
 
 
-def create_recipe_node(recipe=None, node_name=None, job=None, sub_recipe=None, save=False):
+def create_recipe_node(recipe=None, node_name=None, job=None, sub_recipe=None, save=False, is_original=True):
     """Creates a recipe_node model for unit testing
 
     :param recipe: The recipe containing the node
@@ -224,6 +224,8 @@ def create_recipe_node(recipe=None, node_name=None, job=None, sub_recipe=None, s
     :type sub_recipe: :class:'recipe.models.Recipe'
     :param save: Whether to save the model
     :type save: bool
+    :param is_original: Whether the recipe node is original
+    :type is_original: bool
     :returns: The recipe_node model
     :rtype: :class:`recipe.models.RecipeNode`
     """
@@ -240,6 +242,7 @@ def create_recipe_node(recipe=None, node_name=None, job=None, sub_recipe=None, s
     recipe_node = RecipeNode()
     recipe_node.recipe = recipe
     recipe_node.node_name = node_name
+    recipe_node.is_original = is_original
     if job:
         recipe_node.job = job
     else:

--- a/scale/storage/fixtures/delete_files_job_type.json
+++ b/scale/storage/fixtures/delete_files_job_type.json
@@ -48,6 +48,11 @@
                                     "required": true 
                                 },
                                 {
+                                    "name": "trigger_id",
+                                    "type": "string", 
+                                    "required": true 
+                                },
+                                {
                                     "name": "purge",
                                     "type": "string", 
                                     "required": true 
@@ -113,6 +118,11 @@
                                 },
                                 {
                                     "name": "job_id",
+                                    "type": "string", 
+                                    "required": true 
+                                },
+                                {
+                                    "name": "trigger_id",
                                     "type": "string", 
                                     "required": true 
                                 },

--- a/scale/storage/management/commands/scale_delete_files.py
+++ b/scale/storage/management/commands/scale_delete_files.py
@@ -39,6 +39,7 @@ class Command(BaseCommand):
         files_list = json.loads(os.environ.get('FILES'))
         workspaces_list = json.loads(os.environ.get('WORKSPACES'))
         job_id = int(os.environ.get('JOB_ID'))
+        trigger_id = int(os.environ.get('TRIGGER_ID'))
         purge = os.environ.get('PURGE', 'true').lower() in ('yes', 'true', 't', '1')
 
         workspaces = self._configure_workspaces(workspaces_list)
@@ -51,7 +52,7 @@ class Command(BaseCommand):
             delete_files_job.delete_files(files=[f for f in files if f.workspace == wrkspc_name],
                                           broker=wrkspc['broker'], volume_path=wrkspc['volume_path'])
 
-        messages = create_delete_files_messages(files=files, purge=purge, job_id=job_id)
+        messages = create_delete_files_messages(files=files, purge=purge, job_id=job_id, trigger_id=trigger_id)
         CommandMessageManager().send_messages(messages)
 
         logger.info('Command completed: scale_delete_files')

--- a/scale/storage/test/management/commands/test_scale_delete_files.py
+++ b/scale/storage/test/management/commands/test_scale_delete_files.py
@@ -5,11 +5,12 @@ import os
 
 import django
 from django.test import TestCase
-from mock import call, patch
+from mock import patch
 
 from job.test import utils as job_test_utils
 from storage.configuration.json.workspace_config_v6 import WorkspaceConfigurationV6
 from storage.test import utils as storage_test_utils
+import trigger.test.utils as trigger_test_utils
 
 
 class TestCallScaleDeleteFiles(TestCase):
@@ -18,6 +19,7 @@ class TestCallScaleDeleteFiles(TestCase):
         django.setup()
 
         self.job_1 = job_test_utils.create_job()
+        self.trigger_1 = trigger_test_utils.create_trigger_event()
         self.job_exe_1 = job_test_utils.create_job_exe(job=self.job_1)
         self.file_1 = storage_test_utils.create_file(job_exe=self.job_exe_1)
         self.workspace = storage_test_utils.create_workspace()
@@ -37,7 +39,7 @@ class TestCallScaleDeleteFiles(TestCase):
         os.environ['WORKSPACES'] = json.dumps([{"workspace_1": config.get_dict()}])
         os.environ['PURGE'] = str(False)
         os.environ['JOB_ID'] = str(self.job_1.id)
-
+        os.environ['TRIGGER_ID'] = str(self.trigger_1.id)
 
         with self.assertRaises(SystemExit):
             django.core.management.call_command('scale_delete_files')

--- a/scale/storage/test/messages/test_delete_files.py
+++ b/scale/storage/test/messages/test_delete_files.py
@@ -4,12 +4,12 @@ import os
 
 import django
 from django.test import TestCase
-from mock import call, patch
 
 from job.test import utils as job_test_utils
 from storage.messages.delete_files import create_delete_files_messages, DeleteFiles
 from storage.models import ScaleFile
 from storage.test import utils as storage_test_utils
+import trigger.test.utils as trigger_test_utils
 
 
 class TestDeleteFiles(TestCase):
@@ -126,6 +126,8 @@ class TestDeleteFiles(TestCase):
         job = job_test_utils.create_job()
         job_exe = job_test_utils.create_job_exe(job=job)
 
+        trigger = trigger_test_utils.create_trigger_event()
+
         file_path_1 = os.path.join('my_dir', 'my_file.txt')
         file_path_2 = os.path.join('my_dir', 'my_file1.json')
         file_path_3 = os.path.join('my_dir', 'my_file2.json')
@@ -139,4 +141,4 @@ class TestDeleteFiles(TestCase):
         files = [file_1, file_2, file_3, file_4]
 
         # No exception is success
-        create_delete_files_messages(files=files, job_id=job.id, purge=True)
+        create_delete_files_messages(files=files, job_id=job.id, trigger_id=trigger.id, purge=True)


### PR DESCRIPTION
- Added `get_original_leaf_nodes` to `RecipeInstance`
- Added `trigger_id` passing to the rest of the purge stack
- Modified 'purge_jobs' to so that if the job had an is_original == True `RecipeNode` model attached to it it will pass a message for `purge_recipe`
- Added logic for purging recipes and their contents.  Expected behavior is: 
  - message should retrieve the recipe instance and determine the current, original leaf nodes (is_original == True), send delete_job_files messages (with purge) for original leaf jobs and send purge_recipe messages for original leaf recipes
  - if there are no original nodes left in the recipe, delete `BatchRecipe`, `RecipeNode` (matched on sub_recipe or recipe), `RecipeInputFile`, and `Recipe` model for this recipe ID
  - if this recipe had a higher-level recipe containing it (had an is_original == True `RecipeNode` model matched on sub_recipe), send a purge_recipe message for the higher-level recipe
  - if the recipe did not have a higher-level recipe (is top-level) but has superseded another recipe, send a purge_recipe message for the superseded recipe

**I will update the command messages wiki after approval but before merge**