### PR TITLE
#1342 - Fix purge workflow to only purge the given source file

### DIFF
--- a/scale/job/messages/spawn_delete_files_job.py
+++ b/scale/job/messages/spawn_delete_files_job.py
@@ -16,7 +16,7 @@ from storage.models import ScaleFile
 logger = logging.getLogger(__name__)
 
 
-def create_spawn_delete_files_job(job_id, trigger_id, purge):
+def create_spawn_delete_files_job(job_id, trigger_id, source_file_id, purge):
     """Creates a spawn delete files job message
 
     :param job_id: The job ID whose files will be deleted
@@ -25,6 +25,8 @@ def create_spawn_delete_files_job(job_id, trigger_id, purge):
     :type trigger_id: int
     :param purge: Boolean value to determine if files should be purged from workspace
     :type purge: bool
+    :param source_file_id: The source file id for the original file being purged
+    :type source_file_id: int
     :return: The spawn delete files job message
     :rtype: :class:`job.messages.spawn_delete_files_job.SpawnDeleteFilesJob`
     """
@@ -32,6 +34,7 @@ def create_spawn_delete_files_job(job_id, trigger_id, purge):
     message = SpawnDeleteFilesJob()
     message.job_id = job_id
     message.trigger_id = trigger_id
+    message.source_file_id = source_file_id
     message.purge = purge
 
     return message
@@ -49,13 +52,18 @@ class SpawnDeleteFilesJob(CommandMessage):
 
         self.job_id = None
         self.trigger_id = None
+        self.source_file_id = None
         self.purge = False
 
     def to_json(self):
         """See :meth:`messaging.messages.message.CommandMessage.to_json`
         """
 
-        return {'job_id': self.job_id, 'trigger_id': self.trigger_id, 'purge': str(self.purge)}
+        return {'job_id': self.job_id,
+                'trigger_id': self.trigger_id,
+                'source_file_id': self.source_file_id,
+                'purge': str(self.purge)
+               }
 
     @staticmethod
     def from_json(json_dict):
@@ -65,6 +73,7 @@ class SpawnDeleteFilesJob(CommandMessage):
         message = SpawnDeleteFilesJob()
         message.job_id = json_dict['job_id']
         message.trigger_id = json_dict['trigger_id']
+        message.source_file_id = json_dict['source_file_id']
         message.purge = bool(json_dict['purge'])
         return message
 
@@ -89,6 +98,7 @@ class SpawnDeleteFilesJob(CommandMessage):
             inputs = Data()
             inputs.add_value(JsonValue('job_id', str(self.job_id)))
             inputs.add_value(JsonValue('trigger_id', str(self.trigger_id)))
+            inputs.add_value(JsonValue('source_file_id', str(self.source_file_id)))
             inputs.add_value(JsonValue('purge', str(self.purge)))
             inputs.add_value(JsonValue('files', json.dumps(files)))
             inputs.add_value(JsonValue('workspaces', json.dumps(workspaces)))

--- a/scale/job/test/messages/test_purge_jobs.py
+++ b/scale/job/test/messages/test_purge_jobs.py
@@ -67,6 +67,7 @@ class TestPurgeJobs(TransactionTestCase):
         # Add job to message
         message = PurgeJobs()
         message._purge_job_ids = [job.id]
+        message.source_file_id = input_file.id
         message.status_change = timezone.now()
 
         # Execute message
@@ -79,27 +80,6 @@ class TestPurgeJobs(TransactionTestCase):
         for msg in msgs:
             self.assertEqual(msg.source_file_id, input_file.id)
 
-    def test_execute_with_product_input_file(self):
-        """Tests calling PurgeJobs.execute() successfully"""
-
-        input_file = storage_test_utils.create_file(file_type='PRODUCT')
-        job_exe = job_test_utils.create_job_exe(status='COMPLETED')
-        job = job_exe.job
-        job_test_utils.create_input_file(job=job, input_file=input_file)
-
-        # Add job to message
-        message = PurgeJobs()
-        message._purge_job_ids = [job.id]
-        message.status_change = timezone.now()
-
-        # Execute message
-        result = message.execute()
-        self.assertTrue(result)
-
-        # Check that a new message to purge source file was created
-        msgs = [msg for msg in message.new_messages if msg.type == 'purge_source_file']
-        self.assertEqual(len(msgs), 0)
-
     def test_execute_with_recipe(self):
         """Tests calling PurgeJobs.execute() successfully"""
 
@@ -107,10 +87,12 @@ class TestPurgeJobs(TransactionTestCase):
         job_exe = job_test_utils.create_job_exe(status='COMPLETED')
         job = job_exe.job
         recipe_test_utils.create_recipe_node(recipe=recipe, node_name='A', job=job, save=True)
+        input_file = storage_test_utils.create_file(file_type='SOURCE')
 
         # Add job to message
         message = PurgeJobs()
         message._purge_job_ids = [job.id]
+        message.source_file_id = input_file.id
         message.status_change = timezone.now()
 
         # Execute message

--- a/scale/job/test/messages/test_spawn_delete_files_job.py
+++ b/scale/job/test/messages/test_spawn_delete_files_job.py
@@ -27,12 +27,14 @@ class TestSpawnDeleteFilesJob(TransactionTestCase):
         self.prod2 = storage_test_utils.create_file(file_type='PRODUCT', workspace=self.wp1, job_exe=self.job_exe)
         self.prod3 = storage_test_utils.create_file(file_type='PRODUCT', workspace=self.wp2, job_exe=self.job_exe)
         self.event = trigger_test_utils.create_trigger_event()
+        self.file_1 = storage_test_utils.create_file(file_type='SOURCE')
 
     def test_json(self):
         """Tests coverting a SpawnDeleteFilesJob message to and from JSON"""
 
         # Make the message
-        message = create_spawn_delete_files_job(job_id=self.job.pk, trigger_id=self.event.id, purge=True)
+        message = create_spawn_delete_files_job(job_id=self.job.pk, trigger_id=self.event.id,
+                                                source_file_id=self.file_1.id, purge=True)
 
         # Convert message to JSON and back, and then execute
         message_json_dict = message.to_json()
@@ -53,7 +55,8 @@ class TestSpawnDeleteFilesJob(TransactionTestCase):
         job_type_id = JobType.objects.values_list('id', flat=True).get(name='scale-delete-files')
 
         # Make the message
-        message = create_spawn_delete_files_job(job_id=self.job.pk, trigger_id=self.event.id, purge=True)
+        message = create_spawn_delete_files_job(job_id=self.job.pk, trigger_id=self.event.id,
+                                                source_file_id=self.file_1.id, purge=True)
 
         # Capture message that creates job
         result = message.execute()
@@ -71,7 +74,8 @@ class TestSpawnDeleteFilesJob(TransactionTestCase):
         job_type_id = JobType.objects.values_list('id', flat=True).get(name='scale-delete-files')
         job_id = 1234574223462
         # Make the message
-        message = create_spawn_delete_files_job(job_id=job_id, trigger_id=self.event.id, purge=True)
+        message = create_spawn_delete_files_job(job_id=job_id, trigger_id=self.event.id,
+                                                source_file_id=self.file_1.id, purge=True)
 
         # Capture message that creates job
         result = message.execute()

--- a/scale/recipe/test/messages/test_purge_recipe.py
+++ b/scale/recipe/test/messages/test_purge_recipe.py
@@ -125,7 +125,8 @@ class TestPurgeRecipe(TransactionTestCase):
         """Tests coverting a PurgeRecipe message to and from JSON"""
 
         # Create message
-        message = create_purge_recipe_message(recipe_id=self.recipe_1.id, trigger_id=self.trigger.id)
+        message = create_purge_recipe_message(recipe_id=self.recipe_1.id, trigger_id=self.trigger.id,
+                                              source_file_id=self.file_1.id)
 
         # Convert message to JSON and back, and then execute
         message_json_dict = message.to_json()
@@ -138,7 +139,8 @@ class TestPurgeRecipe(TransactionTestCase):
         """Tests calling PurgeRecipe.execute() successfully"""
 
         # Create message
-        message = create_purge_recipe_message(recipe_id=self.recipe_1.id, trigger_id=self.trigger.id)
+        message = create_purge_recipe_message(recipe_id=self.recipe_1.id, trigger_id=self.trigger.id,
+                                              source_file_id=self.file_1.id)
 
         # Execute message
         result = message.execute()
@@ -159,7 +161,8 @@ class TestPurgeRecipe(TransactionTestCase):
         recipe_test_utils.create_recipe_node(recipe=recipe, node_name='A', save=True)
 
         # Create message
-        message = create_purge_recipe_message(recipe_id=recipe.id, trigger_id=self.trigger.id)
+        message = create_purge_recipe_message(recipe_id=recipe.id, trigger_id=self.trigger.id,
+                                              source_file_id=self.file_1.id)
 
         # Execute message
         result = message.execute()
@@ -184,7 +187,8 @@ class TestPurgeRecipe(TransactionTestCase):
         recipe_test_utils.create_recipe_node(recipe=parent_recipe, node_name='A', sub_recipe=recipe, save=True)
 
         # Create message
-        message = create_purge_recipe_message(recipe_id=recipe.id, trigger_id=self.trigger.id)
+        message = create_purge_recipe_message(recipe_id=recipe.id, trigger_id=self.trigger.id,
+                                              source_file_id=self.file_1.id)
 
         # Execute message
         result = message.execute()
@@ -224,7 +228,8 @@ class TestPurgeRecipe(TransactionTestCase):
         RecipeNode.objects.bulk_create([recipe_node_a])
 
         # Create message
-        message = create_purge_recipe_message(recipe_id=recipe.id, trigger_id=self.trigger.id)
+        message = create_purge_recipe_message(recipe_id=recipe.id, trigger_id=self.trigger.id,
+                                              source_file_id=self.file_1.id)
 
         # Execute message
         result = message.execute()
@@ -244,7 +249,8 @@ class TestPurgeRecipe(TransactionTestCase):
         recipe = recipe_test_utils.create_recipe(recipe_type=recipe_type)
 
         # Create message
-        message = create_purge_recipe_message(recipe_id=recipe.id, trigger_id=self.trigger.id)
+        message = create_purge_recipe_message(recipe_id=recipe.id, trigger_id=self.trigger.id,
+                                              source_file_id=self.file_1.id)
 
         # Execute message
         result = message.execute()

--- a/scale/source/messages/purge_source_file.py
+++ b/scale/source/messages/purge_source_file.py
@@ -76,13 +76,15 @@ class PurgeSourceFile(CommandMessage):
             from job.messages.spawn_delete_files_job import create_spawn_delete_files_job
             self.new_messages.append(create_spawn_delete_files_job(job_id=job_input.job.id,
                                                                    trigger_id=self.trigger_id,
+                                                                   source_file_id=self.source_file_id,
                                                                    purge=True))
 
         # Kick off purge_recipe for recipes that are not superseded and have the given source_file as input
         for recipe_input in recipe_inputs:
             from recipe.messages.purge_recipe import create_purge_recipe_message
             self.new_messages.append(create_purge_recipe_message(recipe_id=recipe_input.recipe.id,
-                                                                 trigger_id=self.trigger_id))
+                                                                 trigger_id=self.trigger_id,
+                                                                 source_file_id=self.source_file_id))
 
         # Delete Ingest and ScaleFile
         if not job_inputs and not recipe_inputs:

--- a/scale/storage/fixtures/delete_files_job_type.json
+++ b/scale/storage/fixtures/delete_files_job_type.json
@@ -53,6 +53,11 @@
                                     "required": true 
                                 },
                                 {
+                                    "name": "source_file_id",
+                                    "type": "string",
+                                    "required": true
+                                },
+                                {
                                     "name": "purge",
                                     "type": "string", 
                                     "required": true 
@@ -125,6 +130,11 @@
                                     "name": "trigger_id",
                                     "type": "string", 
                                     "required": true 
+                                },
+                                {
+                                    "name": "source_file_id",
+                                    "type": "string",
+                                    "required": true
                                 },
                                 {
                                     "name": "purge",

--- a/scale/storage/management/commands/scale_delete_files.py
+++ b/scale/storage/management/commands/scale_delete_files.py
@@ -40,6 +40,7 @@ class Command(BaseCommand):
         workspaces_list = json.loads(os.environ.get('WORKSPACES'))
         job_id = int(os.environ.get('JOB_ID'))
         trigger_id = int(os.environ.get('TRIGGER_ID'))
+        source_file_id = int(os.environ.get('SOURCE_FILE_ID'))
         purge = os.environ.get('PURGE', 'true').lower() in ('yes', 'true', 't', '1')
 
         workspaces = self._configure_workspaces(workspaces_list)
@@ -52,7 +53,8 @@ class Command(BaseCommand):
             delete_files_job.delete_files(files=[f for f in files if f.workspace == wrkspc_name],
                                           broker=wrkspc['broker'], volume_path=wrkspc['volume_path'])
 
-        messages = create_delete_files_messages(files=files, purge=purge, job_id=job_id, trigger_id=trigger_id)
+        messages = create_delete_files_messages(files=files, job_id=job_id, trigger_id=trigger_id,
+                                                source_file_id=source_file_id, purge=purge)
         CommandMessageManager().send_messages(messages)
 
         logger.info('Command completed: scale_delete_files')

--- a/scale/storage/messages/delete_files.py
+++ b/scale/storage/messages/delete_files.py
@@ -18,7 +18,7 @@ MAX_NUM = 100
 logger = logging.getLogger(__name__)
 
 
-def create_delete_files_messages(files, job_id, trigger_id, purge):
+def create_delete_files_messages(files, job_id, trigger_id, source_file_id, purge):
     """Creates messages to delete the given files
 
     :param files: The list of file IDs to delete
@@ -27,6 +27,8 @@ def create_delete_files_messages(files, job_id, trigger_id, purge):
     :type job_id: int
     :param trigger_id: The trigger event id for the purge operation
     :type trigger_id: int
+    :param source_file_id: The source file id for the original file being purged
+    :type source_file_id: int
     :param purge: Boolean value to determine if files should be purged from workspace
     :type purge: bool
     :return: The list of messages
@@ -45,6 +47,7 @@ def create_delete_files_messages(files, job_id, trigger_id, purge):
         message.add_file(scale_file.id)
         message.job_id = job_id
         message.trigger_id = trigger_id
+        message.source_file_id = source_file_id
         message.purge = purge
     if message:
         messages.append(message)
@@ -64,6 +67,7 @@ class DeleteFiles(CommandMessage):
         self._file_ids = []
         self.job_id = None
         self.trigger_id = None
+        self.source_file_id = None
         self.purge = False
 
     def add_file(self, file_id):
@@ -92,6 +96,7 @@ class DeleteFiles(CommandMessage):
             'file_ids': self._file_ids,
             'job_id': self.job_id,
             'trigger_id': self.trigger_id,
+            'source_file_id': self.source_file_id,
             'purge': str(self.purge)
         }
 
@@ -103,6 +108,7 @@ class DeleteFiles(CommandMessage):
         message = DeleteFiles()
         message.job_id = json_dict['job_id']
         message.trigger_id = json_dict['trigger_id']
+        message.source_file_id = json_dict['source_file_id']
         message.purge = bool(json_dict['purge'])
         for file_id in json_dict['file_ids']:
             message.add_file(file_id)
@@ -120,7 +126,8 @@ class DeleteFiles(CommandMessage):
 
             # Kick off purge_jobs for the given job_id
             self.new_messages.extend(create_purge_jobs_messages(purge_job_ids=[self.job_id],
-                                                                trigger_id=self.trigger_id))
+                                                                trigger_id=self.trigger_id,
+                                                                source_file_id=self.source_file_id))
         else:
             files_to_delete.update(is_deleted=True, deleted=when, is_published=False, unpublished=when)
 

--- a/scale/storage/test/management/commands/test_scale_delete_files.py
+++ b/scale/storage/test/management/commands/test_scale_delete_files.py
@@ -22,6 +22,7 @@ class TestCallScaleDeleteFiles(TestCase):
         self.trigger_1 = trigger_test_utils.create_trigger_event()
         self.job_exe_1 = job_test_utils.create_job_exe(job=self.job_1)
         self.file_1 = storage_test_utils.create_file(job_exe=self.job_exe_1)
+        self.source_file = storage_test_utils.create_file(file_type='SOURCE')
         self.workspace = storage_test_utils.create_workspace()
 
     @patch('storage.management.commands.scale_delete_files.delete_files_job')
@@ -40,6 +41,7 @@ class TestCallScaleDeleteFiles(TestCase):
         os.environ['PURGE'] = str(False)
         os.environ['JOB_ID'] = str(self.job_1.id)
         os.environ['TRIGGER_ID'] = str(self.trigger_1.id)
+        os.environ['SOURCE_FILE_ID'] = str(self.source_file.id)
 
         with self.assertRaises(SystemExit):
             django.core.management.call_command('scale_delete_files')

--- a/scale/storage/test/messages/test_delete_files.py
+++ b/scale/storage/test/messages/test_delete_files.py
@@ -17,6 +17,8 @@ class TestDeleteFiles(TestCase):
     def setUp(self):
         django.setup()
 
+        self.source_file = storage_test_utils.create_file(file_type='SOURCE')
+
     def test_json(self):
         """Tests coverting a DeleteFiles message to and from JSON"""
 
@@ -33,6 +35,7 @@ class TestDeleteFiles(TestCase):
         message = DeleteFiles()
         message.purge = True
         message.job_id = job.id
+        message.source_file_id = self.source_file.id
         if message.can_fit_more():
             message.add_file(file_1.id)
         if message.can_fit_more():
@@ -56,7 +59,7 @@ class TestDeleteFiles(TestCase):
 
         job = job_test_utils.create_job()
         job_exe = job_test_utils.create_job_exe(job=job)
-        
+
         file_path_1 = os.path.join('my_dir', 'my_file.txt')
         file_path_2 = os.path.join('my_dir', 'my_file1.json')
         file_path_3 = os.path.join('my_dir', 'my_file2.json')
@@ -99,6 +102,7 @@ class TestDeleteFiles(TestCase):
         message = DeleteFiles()
         message.purge = True
         message.job_id = job.id
+        message.source_file_id = self.source_file.id
         if message.can_fit_more():
             message.add_file(file_5.id)
         if message.can_fit_more():
@@ -133,6 +137,7 @@ class TestDeleteFiles(TestCase):
         file_path_3 = os.path.join('my_dir', 'my_file2.json')
         file_path_4 = os.path.join('my_dir', 'my_file3.json')
 
+
         file_1 = storage_test_utils.create_file(file_path=file_path_1, job_exe=job_exe)
         file_2 = storage_test_utils.create_file(file_path=file_path_2, job_exe=job_exe)
         file_3 = storage_test_utils.create_file(file_path=file_path_3, job_exe=job_exe)
@@ -141,4 +146,5 @@ class TestDeleteFiles(TestCase):
         files = [file_1, file_2, file_3, file_4]
 
         # No exception is success
-        create_delete_files_messages(files=files, job_id=job.id, trigger_id=trigger.id, purge=True)
+        create_delete_files_messages(files=files, job_id=job.id, trigger_id=trigger.id,
+                                     source_file_id=self.source_file.id, purge=True)


### PR DESCRIPTION
- Added `source_file_id` passing to the messages that are involved with the purge process. 
- Modified `purge_job` and `purge_recipe` to use the given `source_file_id` when calling `purge_source_file` instead of doing a database operation. 

**I will update the command metrics wiki page after review but before merge**