### PR TITLE
Issue 1174 - Message for recipe conditions

### DIFF
--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -364,7 +364,7 @@ class QueueManager(models.Manager):
         # Create and send messages to update dependent jobs so that they are BLOCKED
         job = Job.objects.get(id=job_id)
         if job.root_recipe_id:
-            msgs = create_update_recipe_messages_from_node([job.root_recipe_ids])
+            msgs = create_update_recipe_messages_from_node([job.root_recipe_id])
             CommandMessageManager().send_messages(msgs)
 
     @transaction.atomic

--- a/scale/recipe/apps.py
+++ b/scale/recipe/apps.py
@@ -17,6 +17,7 @@ class RecipeConfig(AppConfig):
         # Register recipe message types
         from messaging.messages.factory import add_message_type
         from recipe.messages.create_recipes import CreateRecipes
+        from recipe.messages.process_condition import ProcessCondition
         from recipe.messages.process_recipe_input import ProcessRecipeInput
         from recipe.messages.purge_recipe import PurgeRecipe
         from recipe.messages.reprocess_recipes import ReprocessRecipes
@@ -26,6 +27,7 @@ class RecipeConfig(AppConfig):
         from recipe.messages.update_recipes import UpdateRecipes
 
         add_message_type(CreateRecipes)
+        add_message_type(ProcessCondition)
         add_message_type(ProcessRecipeInput)
         add_message_type(PurgeRecipe)
         add_message_type(ReprocessRecipes)

--- a/scale/recipe/definition/json/definition_v6.py
+++ b/scale/recipe/definition/json/definition_v6.py
@@ -105,13 +105,14 @@ RECIPE_DEFINITION_SCHEMA = {
         'condition_node': {
             'description': 'A condition node in the recipe graph',
             'type': 'object',
-            'required': ['node_type'],
+            'required': ['node_type', 'interface'],
             'additionalProperties': False,
             'properties': {
                 'node_type': {
                     'description': 'The name of the node type',
                     'enum': ['condition'],
                 },
+                'interface': INTERFACE_SCHEMA,
             },
         },
         'job_node': {
@@ -215,7 +216,8 @@ def convert_node_to_v6_json(node):
 
     if isinstance(node, ConditionNodeDefinition):
         # TODO: complete recipe condition implementation
-        node_type_dict = {'node_type': 'condition'}
+        interface_dict = convert_interface_to_v6_json(node.input_interface).get_dict()
+        node_type_dict = {'node_type': 'condition', 'interface': interface_dict}
     elif isinstance(node, JobNodeDefinition):
         node_type_dict = {'node_type': 'job', 'job_type_name': node.job_type_name,
                           'job_type_version': node.job_type_version, 'job_type_revision': node.revision_num}
@@ -276,7 +278,8 @@ class RecipeDefinitionV6(object):
             node_type_dict = node_dict['node_type']
             if node_type_dict['node_type'] == 'condition':
                 # TODO: complete recipe condition implementation
-                definition.add_condition_node(node_name, Interface(), DataFilter(True))
+                cond_interface_json = InterfaceV6(node_type_dict['interface'], do_validate=False)
+                definition.add_condition_node(node_name, cond_interface_json.get_interface(), DataFilter(True))
             elif node_type_dict['node_type'] == 'job':
                 definition.add_job_node(node_name, node_type_dict['job_type_name'], node_type_dict['job_type_version'],
                                         node_type_dict['job_type_revision'])

--- a/scale/recipe/messages/process_condition.py
+++ b/scale/recipe/messages/process_condition.py
@@ -1,0 +1,97 @@
+"""Defines a command message that processes a recipe condition"""
+from __future__ import unicode_literals
+
+import logging
+
+from data.data.exceptions import InvalidData
+from messaging.messages.message import CommandMessage
+from recipe.messages.update_recipe import create_update_recipe_message
+from recipe.models import RecipeCondition, RecipeNode
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_process_condition_messages(condition_ids):
+    """Creates messages to process the given conditions
+
+    :param condition_ids: The condition IDs
+    :type condition_ids: list
+    :return: The list of messages
+    :rtype: list
+    """
+
+    messages = []
+
+    for condition_id in condition_ids:
+        message = ProcessCondition()
+        message.condition_id = condition_id
+        messages.append(message)
+
+    return messages
+
+
+class ProcessCondition(CommandMessage):
+    """Command message that processes a recipe condition
+    """
+
+    def __init__(self):
+        """Constructor
+        """
+
+        super(ProcessCondition, self).__init__('process_condition')
+
+        self.condition_id = None
+
+    def to_json(self):
+        """See :meth:`messaging.messages.message.CommandMessage.to_json`
+        """
+
+        return {'condition_id': self.condition_id}
+
+    @staticmethod
+    def from_json(json_dict):
+        """See :meth:`messaging.messages.message.CommandMessage.from_json`
+        """
+
+        message = ProcessCondition()
+        message.condition_id = json_dict['condition_id']
+        return message
+
+    def execute(self):
+        """See :meth:`messaging.messages.message.CommandMessage.execute`
+        """
+
+        condition = RecipeCondition.objects.get_condition_with_interfaces(self.condition_id)
+
+        if not condition.is_processed:
+            definition = condition.recipe.recipe_type_rev.get_definition()
+
+            # Get condition data from dependencies in the recipe
+            recipe_input_data = condition.recipe.get_input_data()
+            node_outputs = RecipeNode.objects.get_recipe_node_outputs(condition.recipe_id)
+            for node_output in node_outputs.values():
+                if node_output.node_type == 'condition' and node_output.id == condition.id:
+                    node_name = node_output.node_name
+                    break
+
+            # Set data on the condition model
+            try:
+                data = definition.generate_node_input_data(node_name, recipe_input_data, node_outputs)
+                RecipeCondition.objects.set_condition_data_v6(condition, data, node_name)
+            except InvalidData:
+                logger.exception('Recipe created invalid input data for condition %d. Message will not re-run.',
+                                 self.condition_id)
+                return True
+
+            # Process filter and set whether condition was accepted
+            data_filter = definition.graph[node_name].data_filter
+            is_accepted = data_filter.is_data_accepted(data)
+            RecipeCondition.objects.set_processed(condition.id, is_accepted)
+
+        # Create message to update the condition's recipe
+        root_recipe_id = condition.recipe.root_recipe_id if condition.recipe.root_recipe_id else condition.recipe_id
+        logger.info('Processed data for condition %d, sending message to update recipe', self.condition_id)
+        self.new_messages.append(create_update_recipe_message(root_recipe_id))
+
+        return True

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -1040,7 +1040,7 @@ class RecipeConditionManager(models.Manager):
         :type is_accepted: bool
         """
 
-        self.filter(id=condition.id).update(is_processed=True, is_accepted=is_accepted, processed=now())
+        self.filter(id=condition_id).update(is_processed=True, is_accepted=is_accepted, processed=now())
 
     def set_condition_data_v6(self, condition, data, node_name):
         """Sets the given data as a v6 JSON for the given condition. The condition model must have its related
@@ -1057,7 +1057,7 @@ class RecipeConditionManager(models.Manager):
         """
 
         recipe_definition = condition.recipe.recipe_type_rev.get_definition()
-        condition_interface = recipe_definition.graph[node_name]
+        condition_interface = recipe_definition.graph[node_name].input_interface
         data.validate(condition_interface)
 
         data_dict = convert_data_to_v6_json(data).get_dict()

--- a/scale/recipe/test/messages/test_process_condition.py
+++ b/scale/recipe/test/messages/test_process_condition.py
@@ -1,0 +1,180 @@
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+import django
+from django.test import TestCase
+
+from data.filter.filter import DataFilter
+from data.interface.interface import Interface
+from data.interface.parameter import FileParameter
+from job.test import utils as job_test_utils
+from recipe.definition.definition import RecipeDefinition
+from recipe.definition.json.definition_v6 import convert_recipe_definition_to_v6_json
+from recipe.messages.process_condition import create_process_condition_messages, ProcessCondition
+from recipe.models import RecipeCondition, RecipeNode
+from recipe.test import utils as recipe_test_utils
+from storage.test import utils as storage_test_utils
+
+
+class TestProcessCondition(TestCase):
+
+    def setUp(self):
+        django.setup()
+
+    def test_json(self):
+        """Tests converting a ProcessCondition message to and from JSON"""
+
+        definition = RecipeDefinition(Interface())
+        # TODO: once DataFilter is implemented, create a DataFilter object here that accepts the inputs
+        definition.add_condition_node('node_a', Interface(), DataFilter(True))
+        definition_dict = convert_recipe_definition_to_v6_json(definition).get_dict()
+        recipe_type = recipe_test_utils.create_recipe_type(definition=definition_dict)
+        recipe = recipe_test_utils.create_recipe(recipe_type=recipe_type)
+        condition = recipe_test_utils.create_recipe_condition(recipe=recipe, save=True)
+        recipe_test_utils.create_recipe_node(recipe=recipe, node_name='node_a', condition=condition, save=True)
+
+        # Create message
+        message = create_process_condition_messages([condition.id])[0]
+
+        # Convert message to JSON and back, and then execute
+        message_json_dict = message.to_json()
+        new_message = ProcessCondition.from_json(message_json_dict)
+        result = new_message.execute()
+
+        self.assertTrue(result)
+        condition = RecipeCondition.objects.get(id=condition.id)
+        self.assertEqual(len(new_message.new_messages), 1)
+        self.assertEqual(new_message.new_messages[0].type, 'update_recipe')
+        self.assertEqual(new_message.new_messages[0].root_recipe_id, recipe.id)
+        self.assertTrue(condition.is_processed)
+        self.assertIsNotNone(condition.processed)
+        self.assertTrue(condition.is_accepted)
+
+    def test_execute(self):
+        """Tests calling ProcessCondition.execute() successfully"""
+
+        workspace = storage_test_utils.create_workspace()
+        file_1 = storage_test_utils.create_file(workspace=workspace, file_size=104857600.0)
+        file_2 = storage_test_utils.create_file(workspace=workspace, file_size=987654321.0)
+        file_3 = storage_test_utils.create_file(workspace=workspace, file_size=65456.0)
+        file_4 = storage_test_utils.create_file(workspace=workspace, file_size=24564165456.0)
+        manifest_1 = {
+            'seedVersion': '1.0.0',
+            'job': {
+                'name': 'job-a',
+                'jobVersion': '1.0.0',
+                'packageVersion': '1.0.0',
+                'title': '',
+                'description': '',
+                'maintainer': {
+                    'name': 'John Doe',
+                    'email': 'jdoe@example.com'
+                },
+                'timeout': 10,
+                'interface': {
+                    'command': '',
+                    'inputs': {'files': [], 'json': []},
+                    'outputs': {
+                        'files': [{'name': 'OUTPUT_A', 'pattern': '*.png', 'multiple': True}]
+                    }
+                }
+            }
+        }
+        job_type_1 = job_test_utils.create_job_type(interface=manifest_1)
+        manifest_2 = {
+            'seedVersion': '1.0.0',
+            'job': {
+                'name': 'job-b',
+                'jobVersion': '1.0.0',
+                'packageVersion': '1.0.0',
+                'title': '',
+                'description': '',
+                'maintainer': {
+                    'name': 'John Doe',
+                    'email': 'jdoe@example.com'
+                },
+                'timeout': 10,
+                'interface': {
+                    'command': '',
+                    'inputs': {'files': []},
+                    'outputs': {
+                        'files': [{'name': 'OUTPUT_B', 'pattern': '*.png', 'multiple': True}]
+                    }
+                }
+            }
+        }
+        job_type_2 = job_test_utils.create_job_type(interface=manifest_2)
+        output_1_dict = {
+            'version': '1.0',
+            'output_data': [{
+                'name': 'OUTPUT_A',
+                'file_ids': [file_1.id, file_2.id]
+            }]
+        }
+        output_2_dict = {
+            'version': '1.0',
+            'output_data': [{
+                'name': 'OUTPUT_B',
+                'file_ids': [file_3.id, file_4.id]
+            }]
+        }
+
+        cond_interface = Interface()
+        cond_interface.add_parameter(FileParameter('INPUT_C_1', [], multiple=True))
+        cond_interface.add_parameter(FileParameter('INPUT_C_2', [], multiple=True))
+        definition = RecipeDefinition(Interface())
+        definition.add_job_node('node_a', job_type_1.name, job_type_1.version, job_type_1.revision_num)
+        definition.add_job_node('node_b', job_type_2.name, job_type_2.version, job_type_2.revision_num)
+        # TODO: once DataFilter is implemented, create a DataFilter object here that accepts the inputs
+        definition.add_condition_node('node_c', cond_interface, DataFilter(True))
+        definition.add_dependency('node_a', 'node_c')
+        definition.add_dependency('node_b', 'node_c')
+        definition.add_dependency_input_connection('node_c', 'INPUT_C_1', 'node_a', 'OUTPUT_A')
+        definition.add_dependency_input_connection('node_c', 'INPUT_C_2', 'node_b', 'OUTPUT_B')
+        def_dict = convert_recipe_definition_to_v6_json(definition).get_dict()
+        recipe_type = recipe_test_utils.create_recipe_type(definition=def_dict)
+        recipe_data_dict = {'version': '1.0', 'input_data': [], 'workspace_id': workspace.id}
+        recipe = recipe_test_utils.create_recipe(recipe_type=recipe_type, input=recipe_data_dict)
+        job_1 = job_test_utils.create_job(job_type=job_type_1, num_exes=1, status='COMPLETED', output=output_1_dict,
+                                          recipe=recipe)
+        job_2 = job_test_utils.create_job(job_type=job_type_2, num_exes=1, status='COMPLETED', output=output_2_dict,
+                                          recipe=recipe)
+        condition = recipe_test_utils.create_recipe_condition(recipe=recipe, save=True)
+        node_a = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='node_a', job=job_1, save=False)
+        node_b = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='node_b', job=job_2, save=False)
+        node_c = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='node_c', condition=condition,
+                                                      save=False)
+        RecipeNode.objects.bulk_create([node_a, node_b, node_c])
+
+        # Create message
+        message = create_process_condition_messages([condition.id])[0]
+
+        # Execute message
+        result = message.execute()
+        self.assertTrue(result)
+
+        condition = RecipeCondition.objects.get(id=condition.id)
+        # Check for update_recipe message
+        self.assertEqual(len(message.new_messages), 1)
+        self.assertEqual(message.new_messages[0].type, 'update_recipe')
+        self.assertEqual(message.new_messages[0].root_recipe_id, recipe.id)
+
+        # Check condition flags
+        self.assertTrue(condition.is_processed)
+        self.assertIsNotNone(condition.processed)
+        self.assertTrue(condition.is_accepted)
+        # Check condition for expected data
+        self.assertSetEqual(set(condition.get_data().values.keys()), {'INPUT_C_1', 'INPUT_C_2'})
+        self.assertListEqual(condition.get_data().values['INPUT_C_1'].file_ids, [file_1.id, file_2.id])
+        self.assertListEqual(condition.get_data().values['INPUT_C_2'].file_ids, [file_3.id, file_4.id])
+
+        # Test executing message again
+        message_json_dict = message.to_json()
+        message = ProcessCondition.from_json(message_json_dict)
+        result = message.execute()
+        self.assertTrue(result)
+
+        # Still should have update_recipe message
+        self.assertEqual(len(message.new_messages), 1)
+        self.assertEqual(message.new_messages[0].type, 'update_recipe')
+        self.assertEqual(message.new_messages[0].root_recipe_id, recipe.id)

--- a/scale/recipe/test/utils.py
+++ b/scale/recipe/test/utils.py
@@ -205,8 +205,10 @@ def create_recipe_condition(root_recipe=None, recipe=None, batch=None, is_proces
     condition.root_recipe = root_recipe if root_recipe else recipe
     condition.recipe = recipe
     condition.batch = batch
-    condition.is_processed = is_processed
-    condition.is_accepted = is_accepted
+    if is_processed is not None:
+        condition.is_processed = is_processed
+    if is_accepted is not None:
+        condition.is_accepted = is_accepted
 
     if condition.is_processed:
         condition.processed = timezone.now()


### PR DESCRIPTION
Created a new message, `process_condition`, that grabs a condition's data from its recipe dependencies, applies its data filter to the data, and saves whether the data is accepted or not. Then it sends a message to update the condition's recipe so the recipe can execute the nodes depending on the condition (or not).