### PR TITLE
#1397 - Filter PurgeResults record edits on trigger_event and not source_file

### DIFF
--- a/scale/job/messages/purge_jobs.py
+++ b/scale/job/messages/purge_jobs.py
@@ -113,7 +113,7 @@ class PurgeJobs(CommandMessage):
         """
 
         # Check to see if a force stop was placed on this purge process
-        results = PurgeResults.objects.get(source_file_id=self.source_file_id)
+        results = PurgeResults.objects.get(trigger_event=self.trigger_id)
         if results.force_stop_purge:
             return True
 

--- a/scale/job/messages/spawn_delete_files_job.py
+++ b/scale/job/messages/spawn_delete_files_job.py
@@ -81,7 +81,7 @@ class SpawnDeleteFilesJob(CommandMessage):
         """
 
         # Check to see if a force stop was placed on this purge process
-        results = PurgeResults.objects.get(source_file_id=self.source_file_id)
+        results = PurgeResults.objects.get(trigger_event=self.trigger_id)
         if results.force_stop_purge:
             return True
 

--- a/scale/job/test/messages/test_purge_jobs.py
+++ b/scale/job/test/messages/test_purge_jobs.py
@@ -30,6 +30,7 @@ class TestPurgeJobs(TransactionTestCase):
         # Add job to message
         message = PurgeJobs()
         message._purge_job_ids = [job.id]
+        message.trigger_id = trigger.id
         message.source_file_id = input_file.id
         message.status_change = timezone.now()
 
@@ -56,6 +57,7 @@ class TestPurgeJobs(TransactionTestCase):
         # Add job to message
         message = PurgeJobs()
         message._purge_job_ids = [job.id]
+        message.trigger_id = trigger.id
         message.source_file_id = input_file.id
         message.status_change = timezone.now()
 
@@ -83,6 +85,7 @@ class TestPurgeJobs(TransactionTestCase):
         # Add job to message
         message = PurgeJobs()
         message._purge_job_ids = [job.id]
+        message.trigger_id = trigger.id
         message.source_file_id = source_file.id
         message.status_change = timezone.now()
 
@@ -116,6 +119,7 @@ class TestPurgeJobs(TransactionTestCase):
         # Add job to message
         message = PurgeJobs()
         message.source_file_id = source_file.id
+        message.trigger_id = trigger.id
         message._purge_job_ids = [job_1.id, job_2.id, job_3.id]
         message.status_change = timezone.now()
 
@@ -147,6 +151,7 @@ class TestPurgeJobs(TransactionTestCase):
         # Add job to message
         message = PurgeJobs()
         message.source_file_id = source_file.id
+        message.trigger_id = trigger.id
         message._purge_job_ids = [job_1.id, job_2.id, job_3.id]
         message.status_change = timezone.now()
 

--- a/scale/job/test/messages/test_spawn_delete_files_job.py
+++ b/scale/job/test/messages/test_spawn_delete_files_job.py
@@ -27,10 +27,9 @@ class TestSpawnDeleteFilesJob(TransactionTestCase):
         self.prod1 = storage_test_utils.create_file(file_type='PRODUCT', workspace=self.wp1, job_exe=self.job_exe)
         self.prod2 = storage_test_utils.create_file(file_type='PRODUCT', workspace=self.wp1, job_exe=self.job_exe)
         self.prod3 = storage_test_utils.create_file(file_type='PRODUCT', workspace=self.wp2, job_exe=self.job_exe)
-        self.event = trigger_test_utils.create_trigger_event()
         self.file_1 = storage_test_utils.create_file(file_type='SOURCE')
-        trigger = trigger_test_utils.create_trigger_event()
-        PurgeResults.objects.create(source_file_id=self.file_1.id, trigger_event=trigger)
+        self.event = trigger_test_utils.create_trigger_event()
+        PurgeResults.objects.create(source_file_id=self.file_1.id, trigger_event=self.event)
 
     def test_json(self):
         """Tests coverting a SpawnDeleteFilesJob message to and from JSON"""
@@ -93,11 +92,11 @@ class TestSpawnDeleteFilesJob(TransactionTestCase):
         file_2 = storage_test_utils.create_file(file_type='SOURCE')
         trigger = trigger_test_utils.create_trigger_event()
         PurgeResults.objects.create(source_file_id=file_2.id, trigger_event=trigger, force_stop_purge=True)
-        
+
         job_type_id = JobType.objects.values_list('id', flat=True).get(name='scale-delete-files')
         job_id = 1234574223462
         # Make the message
-        message = create_spawn_delete_files_job(job_id=job_id, trigger_id=self.event.id,
+        message = create_spawn_delete_files_job(job_id=job_id, trigger_id=trigger.id,
                                                 source_file_id=self.file_1.id, purge=True)
 
         # Capture message that creates job

--- a/scale/recipe/messages/purge_recipe.py
+++ b/scale/recipe/messages/purge_recipe.py
@@ -75,7 +75,7 @@ class PurgeRecipe(CommandMessage):
         """
 
         # Check to see if a force stop was placed on this purge process
-        results = PurgeResults.objects.get(source_file_id=self.source_file_id)
+        results = PurgeResults.objects.get(trigger_event=self.trigger_id)
         if results.force_stop_purge:
             return True
 

--- a/scale/recipe/test/messages/test_purge_recipe.py
+++ b/scale/recipe/test/messages/test_purge_recipe.py
@@ -295,16 +295,16 @@ class TestPurgeRecipe(TransactionTestCase):
         # Create PurgeResults entry
         file_2 = storage_test_utils.create_file(file_type='SOURCE')
         trigger = trigger_test_utils.create_trigger_event()
-        PurgeResults.objects.create(source_file_id=file_2.id, trigger_event=self.trigger, force_stop_purge=True)
+        PurgeResults.objects.create(source_file_id=file_2.id, trigger_event=trigger, force_stop_purge=True)
         self.assertEqual(PurgeResults.objects.values_list('num_recipes_deleted', flat=True).get(
-            source_file_id=file_2.id), 0)
+            trigger_event=trigger.id), 0)
 
         # Create recipes
         recipe_type = recipe_test_utils.create_recipe_type()
         recipe = recipe_test_utils.create_recipe(recipe_type=recipe_type)
 
         # Create message
-        message = create_purge_recipe_message(recipe_id=recipe.id, trigger_id=self.trigger.id,
+        message = create_purge_recipe_message(recipe_id=recipe.id, trigger_id=trigger.id,
                                               source_file_id=file_2.id)
 
         # Execute message

--- a/scale/source/messages/purge_source_file.py
+++ b/scale/source/messages/purge_source_file.py
@@ -69,7 +69,7 @@ class PurgeSourceFile(CommandMessage):
         """
 
         # Check to see if a force stop was placed on this purge process
-        results = PurgeResults.objects.get(source_file_id=self.source_file_id)
+        results = PurgeResults.objects.get(trigger_event=self.trigger_id)
         if results.force_stop_purge:
             return True
 

--- a/scale/source/test/messages/test_purge_source_file.py
+++ b/scale/source/test/messages/test_purge_source_file.py
@@ -31,7 +31,7 @@ class TestPurgeSourceFile(TransactionTestCase):
         
         # Create message
         message = create_purge_source_file_message(source_file_id=source_file.id,
-                                                   trigger_id=self.trigger.id)
+                                                   trigger_id=trigger.id)
 
         # Convert message to JSON and back, and then execute
         message_json_dict = message.to_json()
@@ -50,7 +50,7 @@ class TestPurgeSourceFile(TransactionTestCase):
 
         # Create message
         message = create_purge_source_file_message(source_file_id=source_file.id,
-                                                   trigger_id=self.trigger.id)
+                                                   trigger_id=trigger.id)
         # Execute message
         result = message.execute()
         self.assertTrue(result)
@@ -91,18 +91,18 @@ class TestPurgeSourceFile(TransactionTestCase):
         trigger = trigger_test_utils.create_trigger_event()
         PurgeResults.objects.create(source_file_id=source_file.id, trigger_event=trigger, force_stop_purge=True)
         self.assertIsNone(PurgeResults.objects.values_list('purge_completed', flat=True).get(
-            source_file_id=source_file.id))
+            trigger_event=trigger))
 
         # Create message
         message = create_purge_source_file_message(source_file_id=source_file.id,
-                                                   trigger_id=self.trigger.id)
+                                                   trigger_id=trigger.id)
         # Execute message
         result = message.execute()
         self.assertTrue(result)
 
         # Test to see that the PurgeResults was completed
         self.assertIsNone(PurgeResults.objects.values_list('purge_completed', flat=True).get(
-            source_file_id=source_file.id))
+            trigger_event=trigger))
 
     def test_execute_with_job(self):
         """Tests calling PurgeSourceFile.execute() successfully"""
@@ -118,7 +118,7 @@ class TestPurgeSourceFile(TransactionTestCase):
 
         # Create message
         message = create_purge_source_file_message(source_file_id=source_file.id,
-                                                   trigger_id=self.trigger.id)
+                                                   trigger_id=trigger.id)
         # Execute message
         result = message.execute()
         self.assertTrue(result)
@@ -143,7 +143,7 @@ class TestPurgeSourceFile(TransactionTestCase):
 
         # Create message
         message = create_purge_source_file_message(source_file_id=source_file.id,
-                                                   trigger_id=self.trigger.id)
+                                                   trigger_id=trigger.id)
 
         # Execute message
         result = message.execute()

--- a/scale/storage/messages/delete_files.py
+++ b/scale/storage/messages/delete_files.py
@@ -120,7 +120,7 @@ class DeleteFiles(CommandMessage):
         """
 
         # Check to see if a force stop was placed on this purge process
-        results = PurgeResults.objects.get(source_file_id=self.source_file_id)
+        results = PurgeResults.objects.get(trigger_event=self.trigger_id)
         if results.force_stop_purge:
             return True
 

--- a/scale/storage/test/messages/test_delete_files.py
+++ b/scale/storage/test/messages/test_delete_files.py
@@ -27,6 +27,9 @@ class TestDeleteFiles(TestCase):
         job = job_test_utils.create_job()
         job_exe = job_test_utils.create_job_exe(job=job)
 
+        trigger = trigger_test_utils.create_trigger_event()
+        PurgeResults.objects.create(source_file_id=self.source_file.id, trigger_event=trigger)
+
         file_path_1 = os.path.join('my_dir', 'my_file.txt')
         file_path_2 = os.path.join('my_dir', 'my_file.json')
 
@@ -37,6 +40,7 @@ class TestDeleteFiles(TestCase):
         message = DeleteFiles()
         message.purge = True
         message.job_id = job.id
+        message.trigger_id = trigger.id
         message.source_file_id = self.source_file.id
         if message.can_fit_more():
             message.add_file(file_1.id)
@@ -62,6 +66,9 @@ class TestDeleteFiles(TestCase):
         job = job_test_utils.create_job()
         job_exe = job_test_utils.create_job_exe(job=job)
 
+        trigger = trigger_test_utils.create_trigger_event()
+        PurgeResults.objects.create(source_file_id=self.source_file.id, trigger_event=trigger)
+
         file_path_1 = os.path.join('my_dir', 'my_file.txt')
         file_path_2 = os.path.join('my_dir', 'my_file1.json')
         file_path_3 = os.path.join('my_dir', 'my_file2.json')
@@ -76,6 +83,7 @@ class TestDeleteFiles(TestCase):
         message = DeleteFiles()
         message.purge = False
         message.job_id = job.id
+        message.trigger_id = trigger.id
         message.source_file_id = self.source_file.id
         if message.can_fit_more():
             message.add_file(file_1.id)
@@ -105,6 +113,7 @@ class TestDeleteFiles(TestCase):
         message = DeleteFiles()
         message.purge = True
         message.job_id = job.id
+        message.trigger_id = trigger.id
         message.source_file_id = self.source_file.id
         if message.can_fit_more():
             message.add_file(file_5.id)


### PR DESCRIPTION
Updated the PurgeResults check to use the trigger event as a reference.  This will allow a user to resubmit a source_file to purge.  