### PR TITLE
#1409 Setting injected input variable correctly if multiple inputs

### DIFF
--- a/scale/data/data/value.py
+++ b/scale/data/data/value.py
@@ -60,7 +60,7 @@ class FileValue(DataValue):
     """Represents a data value containing one or more files
     """
 
-    def __init__(self, name, file_ids):
+    def __init__(self, name, file_ids, multiple=False):
         """Constructor
 
         :param name: The name of the parameter
@@ -72,6 +72,7 @@ class FileValue(DataValue):
         super(FileValue, self).__init__(name, FileParameter.PARAM_TYPE)
 
         self.file_ids = file_ids
+        self.multiple = multiple
 
     def validate(self, parameter):
         """See :meth:`data.data.value.DataValue.validate`

--- a/scale/job/data/job_data.py
+++ b/scale/job/data/job_data.py
@@ -361,7 +361,7 @@ class JobData(object):
         for file_input in self._new_data.values.values():
             if isinstance(file_input, FileValue):
                 env_var_name = normalize_env_var_name(file_input.name)
-                if len(file_input.file_ids) > 1:
+                if file_input.multiple:
                     # When we have input for multiple files, map in the entire directory
                     env_vars[env_var_name] = os.path.join(SCALE_JOB_EXE_INPUT_PATH, file_input.name)
                 else:

--- a/scale/job/test/seed/test_job_data.py
+++ b/scale/job/test/seed/test_job_data.py
@@ -65,12 +65,12 @@ class TestJobData(TransactionTestCase):
         job_exe.job_type.get_job_configuration.return_value = job_config
 
         results = JobResults()._store_output_data_files(files, job_data, job_exe)
-        self.assertEqual({'OUTPUT_TIFFS': [1]}, results.files)
+        self.assertEqual({'OUTPUT_TIFFS': {'multiple': True, 'file_ids': [1]}}, results.files)
 
     @patch('os.path.join', return_value='/scale/input')
     @patch('job.data.job_data.JobData._retrieve_files')
     def test_retrieve_input_data_files_success_single_input_file(self, retrieve_files, join):
-        job_data = JobData({'files': {'TEST_FILE_INPUT': [1]}})
+        job_data = JobData({'files': {'TEST_FILE_INPUT': {'file_ids': [1]}}})
         retrieve_files.return_value = {1: '/scale/input/TEST_FILE_INPUT'}
 
         data_files = [SeedInputFiles({'name':'TEST_FILE_INPUT', 'multiple': False, 'required': True, 'mediaTypes': [], 'partial': False})]
@@ -81,7 +81,7 @@ class TestJobData(TransactionTestCase):
     @patch('os.path.join', return_value='/scale/input')
     @patch('job.data.job_data.JobData._retrieve_files')
     def test_retrieve_input_data_files_success_multiple_input_file(self, retrieve_files, join):
-        job_data = JobData({'files': {'TEST_FILE_INPUT': [1, 2]}})
+        job_data = JobData({'files': {'TEST_FILE_INPUT': {'file_ids': [1, 2], 'multiple': True}}})
         retrieve_files.return_value = {1: '/scale/input/TEST_FILE_INPUT1', 2: '/scale/input/TEST_FILE_INPUT2'}
 
         data_files = [SeedInputFiles(
@@ -105,7 +105,7 @@ class TestJobData(TransactionTestCase):
     @patch('os.path.join', return_value='/scale/input')
     @patch('job.data.job_data.JobData._retrieve_files')
     def test_retrieve_input_data_files_missing_file(self, retrieve_files, join):
-        job_data = JobData({'files': {'TEST_FILE_INPUT': [1]}})
+        job_data = JobData({'files': {'TEST_FILE_INPUT': {'file_ids':[1], 'multiple': False}}})
         retrieve_files.return_value = {}
 
         data_files = [SeedInputFiles(
@@ -117,7 +117,7 @@ class TestJobData(TransactionTestCase):
     @patch('os.path.join', return_value='/scale/input')
     @patch('job.data.job_data.JobData._retrieve_files')
     def test_retrieve_input_data_files_missing_plurality_mismatch(self, retrieve_files, join):
-        job_data = JobData({'files': {'TEST_FILE_INPUT': [1]}})
+        job_data = JobData({'files': {'TEST_FILE_INPUT': {'multiple': False, 'file_ids': [1]}}})
         retrieve_files.return_value = {}
 
         data_files = [SeedInputFiles(

--- a/scale/job/test/seed/test_job_data.py
+++ b/scale/job/test/seed/test_job_data.py
@@ -65,7 +65,7 @@ class TestJobData(TransactionTestCase):
         job_exe.job_type.get_job_configuration.return_value = job_config
 
         results = JobResults()._store_output_data_files(files, job_data, job_exe)
-        self.assertEqual({'OUTPUT_TIFFS': {'multiple': True, 'file_ids': [1]}}, results.files)
+        self.assertEqual({'OUTPUT_TIFFS': {'file_ids': [1], 'multiple': False}}, results.files)
 
     @patch('os.path.join', return_value='/scale/input')
     @patch('job.data.job_data.JobData._retrieve_files')

--- a/scale/queue/test/test_models.py
+++ b/scale/queue/test/test_models.py
@@ -337,7 +337,7 @@ class TestQueueManagerQueueNewJob(TransactionTestCase):
             'version': '1.0',
             'input_data': [{
                 'name': 'input_a',
-                'file_id': source_file.id,
+                'file_id': source_file.id
             }],
             'output_data': [{
                 'name': 'output_a',
@@ -345,8 +345,9 @@ class TestQueueManagerQueueNewJob(TransactionTestCase):
             }]
         }
         data = JobData(data_dict)
-
+        
         job = Queue.objects.queue_new_job(job_type, data, event)
+
         self.assertEqual(job.status, 'QUEUED')
 
 


### PR DESCRIPTION
Added a multiple field on the FileValue class in order to properly set the injected input file value. Instead of checking the number of file ids being passed to the job, the new multiple value is checked.