### PR TITLE
Correcting TypeError: object of type 'bool' has no len()

### DIFF
--- a/scale/job/migrations/0050_auto_20181109_2037.py
+++ b/scale/job/migrations/0050_auto_20181109_2037.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
                 if 'input_file' in job_input['files'] and isinstance(job_input['files']['input_file'], list):
                     input_file = {}
                     input_file['file_ids'] = job_input['files']['input_file']
-                    input_file['multiple'] = len(job_input['files']['input_file'] > 1)
+                    input_file['multiple'] = len(job_input['files']['input_file']) > 1
                     job_input['files']['input_file'] = input_file
                     job.save()
 


### PR DESCRIPTION
The job data migration was performing a `len(job_input['files']['input_file']>1)` when it should have been doing `len(job_input['files']['input_file']) > 1`