### PR TITLE
Purge fixes

### DIFF
--- a/scale/job/messages/purge_jobs.py
+++ b/scale/job/messages/purge_jobs.py
@@ -142,7 +142,7 @@ class PurgeJobs(CommandMessage):
             Job.objects.filter(id__in=self._purge_job_ids).delete()
 
             # Update results
-            results.num_jobs_deleted = F('num_jobs_deleted') + len(self._purge_job_ids)
-            results.save()
+            PurgeResults.objects.filter(trigger_event=self.trigger_id).update(
+                num_jobs_deleted = F('num_jobs_deleted') + len(self._purge_job_ids))
 
         return True

--- a/scale/recipe/messages/purge_recipe.py
+++ b/scale/recipe/messages/purge_recipe.py
@@ -126,7 +126,7 @@ class PurgeRecipe(CommandMessage):
             recipe.delete()
 
             # Update results
-            results.num_recipes_deleted = F('num_recipes_deleted') + 1
-            results.save()
+            PurgeResults.objects.filter(trigger_event=self.trigger_id).update(
+                num_recipes_deleted = F('num_recipes_deleted') + 1)
 
         return True

--- a/scale/storage/test/messages/test_delete_files.py
+++ b/scale/storage/test/messages/test_delete_files.py
@@ -6,6 +6,8 @@ import django
 from django.test import TestCase
 
 from job.test import utils as job_test_utils
+from product.models import FileAncestryLink
+from product.test import utils as product_test_utils
 from storage.messages.delete_files import create_delete_files_messages, DeleteFiles
 from storage.models import PurgeResults, ScaleFile
 from storage.test import utils as storage_test_utils
@@ -298,3 +300,53 @@ class TestDeleteFiles(TestCase):
         # Check results are accurate. Should be 0 since purge flag was False
         self.assertEqual(PurgeResults.objects.values_list('num_products_deleted', flat=True).get(
             source_file_id=self.source_file.id), 0)
+            
+    def test_execute_ancestor(self):
+        """Tests calling DeleteFile.execute() successfully"""
+
+        # Create PurgeResults entry
+        source_file = storage_test_utils.create_file()
+        trigger = trigger_test_utils.create_trigger_event()
+        PurgeResults.objects.create(source_file_id=source_file.id, trigger_event=trigger)
+        self.assertEqual(PurgeResults.objects.values_list('num_products_deleted', flat=True).get(
+            source_file_id=source_file.id), 0)
+
+        job = job_test_utils.create_job()
+        job_exe = job_test_utils.create_job_exe(job=job)
+
+        file_path_1 = os.path.join('my_dir', 'my_file.txt')
+        file_path_2 = os.path.join('my_dir', 'my_file1.json')
+        file_path_3 = os.path.join('my_dir', 'my_file2.json')
+        file_path_4 = os.path.join('my_dir', 'my_file3.json')
+
+        file_1 = storage_test_utils.create_file(file_path=file_path_1, job_exe=job_exe)
+        file_2 = storage_test_utils.create_file(file_path=file_path_2, job_exe=job_exe)
+        file_3 = storage_test_utils.create_file(file_path=file_path_3, job_exe=job_exe)
+        file_4 = storage_test_utils.create_file(file_path=file_path_4, job_exe=job_exe)
+        product_test_utils.create_file_link(ancestor=source_file, descendant=file_1, job=job, job_exe=job_exe)
+        product_test_utils.create_file_link(ancestor=source_file, descendant=file_2, job=job, job_exe=job_exe)
+        product_test_utils.create_file_link(ancestor=source_file, descendant=file_3, job=job, job_exe=job_exe)
+        product_test_utils.create_file_link(ancestor=source_file, descendant=file_4, job=job, job_exe=job_exe)
+
+        # Add files to message
+        message = DeleteFiles()
+        message.purge = True
+        message.job_id = job.id
+        message.source_file_id = source_file.id
+        message.trigger_id = trigger.id
+        if message.can_fit_more():
+            message.add_file(file_1.id)
+        if message.can_fit_more():
+            message.add_file(file_2.id)
+        if message.can_fit_more():
+            message.add_file(file_3.id)
+        if message.can_fit_more():
+            message.add_file(file_4.id)
+
+        # Execute message
+        result = message.execute()
+        self.assertTrue(result)
+
+        # Check results are accurate.
+        self.assertEqual(PurgeResults.objects.values_list('num_products_deleted', flat=True).get(
+            trigger_event=trigger), 4)


### PR DESCRIPTION
Found bug in testing purge where the `file_ancestry_link` needs to be deleted before the product `scale_file` record can be purged. 

I don't think the increment logic worked before, this should. 