### PR TITLE
#1450: S3 EventNotification v2 support

### DIFF
--- a/scale/ingest/test/strike/monitors/test_s3_monitor.py
+++ b/scale/ingest/test/strike/monitors/test_s3_monitor.py
@@ -55,8 +55,8 @@ class TestS3Monitor(TestCase):
         S3Monitor().validate_configuration(config)
 
     @patch('ingest.strike.monitors.s3_monitor.S3Monitor._ingest_s3_notification_object')
-    def test_process_s3_notification_success(self, ingest_mock):
-        """Tests calling S3Monitor._process_s3_notification() successfully"""
+    def test_process_s3_minimal_notification_success(self, ingest_mock):
+        """Tests calling S3Monitor._process_s3_notification() successfully with minimal v2.0 message"""
 
         message = {
             "Records": [
@@ -87,7 +87,156 @@ class TestS3Monitor(TestCase):
             ]
         }
 
-        sqs_message = SQSMessage(json.dumps(message))
+        payload = { "Message": json.dumps(message)}
+        sqs_message = SQSMessage(json.dumps(payload))
+
+        monitor = S3Monitor()
+        monitor._process_s3_notification(sqs_message)
+        self.assertEqual(ingest_mock.call_count, 1)
+
+    @patch('ingest.strike.monitors.s3_monitor.S3Monitor._ingest_s3_notification_object')
+    def test_process_s3_notional_v2_notification_success(self, ingest_mock):
+        """Tests calling S3Monitor._process_s3_notification() successfully with notional v2 message"""
+
+        message = {
+            "Records": [
+                {
+                    "eventVersion": "2.x",
+                    "awsRegion": "us-east-1",
+                    "eventTime": "1970-01-01T00:00:00.000Z",
+                    "eventName": "ObjectCreated:Put",
+                    "s3": {
+                        "s3SchemaVersion": "1.0",
+                        "configurationId": "testConfigRule",
+                        "bucket": {
+                            "name": "mybucket",
+                            "ownerIdentity": {
+                                "principalId": "A3NL1KOZZKExample"
+                            },
+                            "arn": "arn:aws:s3:::mybucket"
+                        },
+                        "object": {
+                            "key": "HappyFace.jpg",
+                            "size": 1024,
+                            "eTag": "d41d8cd98f00b204e9800998ecf8427e",
+                            "versionId": "096fKKXTRTtl3on89fVO.nfljtsv6qko",
+                            "sequencer": "0055AED6DCD90281E5"
+                        }
+                    }
+                }
+            ]
+        }
+
+        payload = { "Message": json.dumps(message)}
+        sqs_message = SQSMessage(json.dumps(payload))
+
+        monitor = S3Monitor()
+        monitor._process_s3_notification(sqs_message)
+        self.assertEqual(ingest_mock.call_count, 1)
+
+    @patch('ingest.strike.monitors.s3_monitor.S3Monitor._ingest_s3_notification_object')
+    def test_process_s3_v21_notification_success(self, ingest_mock):
+        """Tests calling S3Monitor._process_s3_notification() successfully with eventVersion 2.1"""
+
+        message = {
+            "Records": [
+                {
+                    "eventVersion": "2.1",
+                    "eventSource": "aws:s3",
+                    "awsRegion": "us-west-2",
+                    "eventTime": "1970-01-01T00:00:00.000Z",
+                    "eventName": "ObjectCreated:Put",
+                    "userIdentity": {
+                        "principalId": "Amazon-customer-ID-of-the-user-who-caused-the-event"
+                    },
+                    "requestParameters": {
+                        "sourceIPAddress": "ip-address-where-request-came-from"
+                    },
+                    "responseElements": {
+                        "x-amz-request-id": "Amazon S3 generated request ID",
+                        "x-amz-id-2": "Amazon S3 host that processed the request"
+                    },
+                    "s3": {
+                        "s3SchemaVersion": "1.0",
+                        "configurationId": "ID found in the bucket notification configuration",
+                        "bucket": {
+                            "name": "bucket-name",
+                            "ownerIdentity": {
+                                "principalId": "Amazon-customer-ID-of-the-bucket-owner"
+                            },
+                            "arn": "bucket-ARN"
+                        },
+                        "object": {
+                            "key": "object-key",
+                            "size": 1024,
+                            "eTag": "object eTag",
+                            "versionId": "object version if bucket is versioning-enabled, otherwise null",
+                            "sequencer": "0055AED6DCD90281E5"
+                        }
+                    },
+                    "glacierEventData": {
+                        "restoreEventData": {
+                            "lifecycleRestorationExpiryTime": "1970-01-01T00:00:00.000Z",
+                            "lifecycleRestoreStorageClass": "Source storage class for restore"
+                        }
+                    }
+                }
+            ]
+        }
+
+        payload = { "Message": json.dumps(message)}
+        sqs_message = SQSMessage(json.dumps(payload))
+
+        monitor = S3Monitor()
+        monitor._process_s3_notification(sqs_message)
+        self.assertEqual(ingest_mock.call_count, 1)
+
+    @patch('ingest.strike.monitors.s3_monitor.S3Monitor._ingest_s3_notification_object')
+    def test_process_s3_v20_notification_success(self, ingest_mock):
+        """Tests calling S3Monitor._process_s3_notification() successfully with eventVersion 2.0"""
+
+        message = {
+            "Records": [
+                {
+                    "eventVersion": "2.0",
+                    "eventSource": "aws:s3",
+                    "awsRegion": "us-west-2",
+                    "eventTime": "1970-01-01T00:00:00.000Z",
+                    "eventName": "ObjectCreated:Put",
+                    "userIdentity": {
+                        "principalId": "Amazon-customer-ID-of-the-user-who-caused-the-event"
+                    },
+                    "requestParameters": {
+                        "sourceIPAddress": "ip-address-where-request-came-from"
+                    },
+                    "responseElements": {
+                        "x-amz-request-id": "Amazon S3 generated request ID",
+                        "x-amz-id-2": "Amazon S3 host that processed the request"
+                    },
+                    "s3": {
+                        "s3SchemaVersion": "1.0",
+                        "configurationId": "ID found in the bucket notification configuration",
+                        "bucket": {
+                            "name": "bucket-name",
+                            "ownerIdentity": {
+                                "principalId": "Amazon-customer-ID-of-the-bucket-owner"
+                            },
+                            "arn": "bucket-ARN"
+                        },
+                        "object": {
+                            "key": "object-key",
+                            "size": 1024,
+                            "eTag": "object eTag",
+                            "versionId": "object version if bucket is versioning-enabled, otherwise null",
+                            "sequencer": "0055AED6DCD90281E5"
+                        }
+                    }
+                }
+            ]
+        }
+
+        payload = { "Message": json.dumps(message)}
+        sqs_message = SQSMessage(json.dumps(payload))
 
         monitor = S3Monitor()
         monitor._process_s3_notification(sqs_message)
@@ -134,7 +283,8 @@ class TestS3Monitor(TestCase):
             ]
         }
 
-        sqs_message = SQSMessage(json.dumps(message))
+        payload = { "Message": json.dumps(message)}
+        sqs_message = SQSMessage(json.dumps(payload))
 
         monitor = S3Monitor()
         with self.assertRaises(SQSNotificationError):
@@ -172,7 +322,8 @@ class TestS3Monitor(TestCase):
             ]
         }
 
-        sqs_message = SQSMessage(json.dumps(message))
+        payload = { "Message": json.dumps(message)}
+        sqs_message = SQSMessage(json.dumps(payload))
 
         monitor = S3Monitor()
         with self.assertRaises(SQSNotificationError):


### PR DESCRIPTION
#1450: Added support for any future version of v2 assuming they do not introduce breaking changes. Modified updates from @jeremysnyder that add support for direct S3->SQS notification. 
#1413: We now support S3->SQS event notification, as well as the previous method via S3->SNS->SQS.