### PR TITLE
#1458 - Inject Recipe Metadata As Environment Variables To Each Job

### DIFF
--- a/scale/job/execution/configuration/configurators.py
+++ b/scale/job/execution/configuration/configurators.py
@@ -348,16 +348,20 @@ class ScheduledExecutionConfigurator(object):
             input_metadata = {}
             if 'input_files' in config._configuration:
                 input_metadata['JOB'] = {}
-                for i in config._configuration['input_files'].keys():
-                    input_metadata['JOB'][i] = [ScaleFile.objects.get(pk=f['id'])._get_url() for f in config._configuration['input_files'][i]]
+                input_data = job_exe.job.get_input_data()
+                for i in input_data.values.keys():
+                    if type(input_data.values[i]) is JsonValue:
+                        input_metadata['JOB'][i] = input_data.values[i].value
+                    elif type(input_data.values[i]) is FileValue:
+                        input_metadata['JOB'][i] = [ScaleFile.objects.get(pk=f)._get_url() for f in input_data.values[i].file_ids]
             if job_exe.recipe_id and job_exe.recipe.has_input():
                 input_metadata['RECIPE'] = {}
-                r_input_data = job_exe.recipe.get_input_data() 
-                for i in r_input_data.values.keys():
-                    if type(r_input_data.values[i]) is JsonValue:
-                        input_metadata['RECIPE'][i] = r_input_data.values[i].value
-                    elif type(r_input_data.values[i]) is FileValue:
-                        input_metadata['RECIPE'][i] = [ScaleFile.objects.get(pk=f)._get_url() for f in r_input_data.values[i].file_ids]
+                input_data = job_exe.recipe.get_input_data() 
+                for i in input_data.values.keys():
+                    if type(input_data.values[i]) is JsonValue:
+                        input_metadata['RECIPE'][i] = input_data.values[i].value
+                    elif type(input_data.values[i]) is FileValue:
+                        input_metadata['RECIPE'][i] = [ScaleFile.objects.get(pk=f)._get_url() for f in input_data.values[i].file_ids]
             if input_metadata:
                 env_vars['INPUT_METADATA'] = json.dumps(input_metadata)
             

--- a/scale/job/execution/configuration/configurators.py
+++ b/scale/job/execution/configuration/configurators.py
@@ -1,6 +1,7 @@
 """Defines the classes that handle processing job and execution configuration"""
 from __future__ import absolute_import, unicode_literals
 
+import json
 import logging
 import math
 
@@ -59,6 +60,7 @@ class QueuedExecutionConfigurator(object):
         :rtype: :class:`job.execution.configuration.json.exe_config.ExecutionConfiguration`
         """
 
+        print 'configure_queued_job'
         config = ExecutionConfiguration()
         data = job.get_job_data()
 
@@ -318,6 +320,20 @@ class ScheduledExecutionConfigurator(object):
                 env_vars['SCALE_RECIPE_ID'] = unicode(job_exe.recipe_id)
             if job_exe.batch_id:
                 env_vars['SCALE_BATCH_ID'] = unicode(job_exe.batch_id)
+                
+            # Configure the input_metadata env variables
+            # import pdb; pdb.set_trace()
+            input_metadata = {}
+            input_metadata['JOB'] = {}
+            for i in config._configuration['input_files'].keys():
+                input_metadata['JOB'][i] = [x['workspace_path'] for x in config._configuration['input_files'][i]]
+            if job_exe.recipe_id:
+                # Configure 
+                print 'Recipe has input? ', job_exe.recipe.has_input()
+                input_metadata['RECIPE'] = {}
+            print json.dumps(input_metadata)
+            
+            # env_vars['INPUT_METADATA'] = json.dumps(input_metadata)
 
             # Configure workspace volumes
             workspace_volumes = {}

--- a/scale/job/execution/configuration/configurators.py
+++ b/scale/job/execution/configuration/configurators.py
@@ -415,12 +415,12 @@ class ScheduledExecutionConfigurator(object):
         if 'input_files' in config._configuration:
             input_metadata['JOB'] = {}
             for i in config._configuration['input_files'].keys():
-                input_metadata['JOB'][i] = [x['workspace_path'] for x in config._configuration['input_files'][i]]
+                input_metadata['JOB'][i] = [ScaleFile.objects.get(pk=f['id'])._get_url() for f in config._configuration['input_files'][i]]
         if job_exe.recipe_id and job_exe.recipe.has_input():
             input_metadata['RECIPE'] = {}
             r_input_data = job_exe.recipe.get_input_data() 
             for i in r_input_data.values.keys():
-                input_metadata['RECIPE'][i] = [ScaleFile.objects.get(pk=f).file_path for f in r_input_data.values[i].file_ids]
+                input_metadata['RECIPE'][i] = [ScaleFile.objects.get(pk=f)._get_url() for f in r_input_data.values[i].file_ids]
         if input_metadata:
             config.add_to_task('main', env_vars={'INPUT_METADATA': json.dumps(input_metadata)})
 

--- a/scale/job/test/execution/configuration/test_configurators.py
+++ b/scale/job/test/execution/configuration/test_configurators.py
@@ -1,6 +1,7 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import os
+import json
 
 import django
 from django.test import TestCase
@@ -585,7 +586,7 @@ class TestScheduledExecutionConfigurator(TestCase):
         framework_id = '1234'
         node = node_test_utils.create_node()
         broker_dict = {'version': '1.0', 'broker': {'type': 'host', 'host_path': '/w_1/host/path'}}
-        input_workspace = storage_test_utils.create_workspace(json_config=broker_dict)
+        input_workspace = storage_test_utils.create_workspace(json_config=broker_dict, base_url="http://host/my/path/")
         broker_dict = {'version': '1.0', 'broker': {'type': 's3', 'bucket_name': 'bucket1',
                                                     'host_path': '/w_2/host/path', 'region_name': 'us-east-1'}}
         output_workspace = storage_test_utils.create_workspace(json_config=broker_dict)
@@ -630,7 +631,6 @@ class TestScheduledExecutionConfigurator(TestCase):
         queued_job_exe = QueuedJobExecution(queue)
         queued_job_exe.scheduled('agent_1', node.id, resources)
         job_exe_model = queued_job_exe.create_job_exe_model(framework_id, now())
-
         # Test method
         with patch('job.execution.configuration.configurators.settings') as mock_settings:
             with patch('job.execution.configuration.configurators.secrets_mgr') as mock_secrets_mgr:
@@ -658,7 +658,14 @@ class TestScheduledExecutionConfigurator(TestCase):
         output_vol_name = get_job_exe_output_vol_name(job_exe_model)
         input_2_val = os.path.join(SCALE_JOB_EXE_INPUT_PATH, 'input_2', file_1.file_name)
         input_3_val = os.path.join(SCALE_JOB_EXE_INPUT_PATH, 'input_3')
+
         expected_input_files = queue.get_execution_configuration().get_dict()['input_files']
+        input_metadata = {}
+        input_metadata['JOB'] = {}
+        from storage.models import ScaleFile
+        for i in expected_input_files.keys():
+            input_metadata['JOB'][i] = [ScaleFile.objects.get(pk=f['id'])._get_url() for f in expected_input_files[i]]
+
         expected_output_workspaces = {'output_1': output_workspace.name}
         expected_pull_task = {'task_id': '%s_pull' % job_exe_model.get_cluster_id(), 'type': 'pull',
                               'resources': {'cpus': resources.cpus, 'mem': resources.mem, 'disk': resources.disk, 'gpus': resources.gpus},
@@ -811,7 +818,8 @@ class TestScheduledExecutionConfigurator(TestCase):
                                            'ALLOCATED_DISK': unicode(main_resources.disk),
                                            'ALLOCATED_GPUS': unicode(main_resources.gpus),
                                            'SCALE_JOB_ID': unicode(job.id), 'SCALE_EXE_NUM': unicode(job.num_exes),
-                                           'SCALE_RECIPE_ID': unicode(recipe.id), 'SCALE_BATCH_ID': unicode(batch.id)
+                                           'SCALE_RECIPE_ID': unicode(recipe.id), 'SCALE_BATCH_ID': unicode(batch.id),
+                                           'INPUT_METADATA': unicode(json.dumps(input_metadata))
                               },
                               'workspaces': {input_workspace.name: {'mode': 'ro', 'volume_name': input_wksp_vol_name}},
                               'mounts': {'m_1': m_1_vol_name, 'm_2': None, 'm_3': None, input_mnt_name: input_vol_name,
@@ -841,6 +849,7 @@ class TestScheduledExecutionConfigurator(TestCase):
                                                 {'flag': 'env', 'value': 'SCALE_EXE_NUM=%s' % unicode(job.num_exes)},
                                                 {'flag': 'env', 'value': 'SCALE_RECIPE_ID=%s' % unicode(recipe.id)},
                                                 {'flag': 'env', 'value': 'SCALE_BATCH_ID=%s' % unicode(batch.id)},
+                                                {'flag': 'env', 'value': 'INPUT_METADATA=%s' % unicode(json.dumps(input_metadata))},
                                                 {'flag': 'label',
                                                  'value': 'scale-job-execution-id=%s' % unicode(job.num_exes)},
                                                 {'flag': 'label',
@@ -863,7 +872,6 @@ class TestScheduledExecutionConfigurator(TestCase):
                            'input_files': expected_input_files,
                            'output_workspaces': expected_output_workspaces,
                            'tasks': [expected_pull_task, expected_pre_task, expected_main_task, expected_pst_task]}
-
         # Ensure configuration is valid
         ExecutionConfiguration(exe_config_with_secrets.get_dict())
         # Compare results including secrets, but convert Docker param lists to sets so order is ignored

--- a/scale/job/test/execution/configuration/test_configurators.py
+++ b/scale/job/test/execution/configuration/test_configurators.py
@@ -663,7 +663,7 @@ class TestScheduledExecutionConfigurator(TestCase):
         expected_input_files = queue.get_execution_configuration().get_dict()['input_files']
         
         input_metadata = {}
-        input_metadata['JOB'] = {}
+        input_metadata['JOB'] = {'input_1': 'my_val'}
         from storage.models import ScaleFile
         for i in expected_input_files.keys():
             input_metadata['JOB'][i] = [ScaleFile.objects.get(pk=f['id'])._get_url() for f in expected_input_files[i]]


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropiate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
job/execution/configuration

### Description of change
<!-- Please provide a description of the change here. -->
Added a new environment variable INPUT_METADATA to each Scale task that includes inputs for the specific job,. as well as the inputs for the encompassing recipe. The environment variable is a stringified json object in the form of:

```
INPUT_METADATA = {
  'JOB': {'input_1_name': ['public/facing/url/to/input', 'public/facing/url/to/input/2'], 'input_2_name': ['public/facing/url/to/input']},
  'RECIPE': {'input_1_name': ['public/facing/url/to/input'], 'input_2_name': 'my_json_value'}
}