### PR TITLE
Issue 1429 - purge_recipe unexpected function return

### DIFF
--- a/scale/recipe/instance/recipe.py
+++ b/scale/recipe/instance/recipe.py
@@ -108,7 +108,9 @@ class RecipeInstance(object):
         :rtype: dict
         """
 
-        leaf_nodes = {n.name: n for n in self.graph.values() if n.is_original and not n.children}  # {Name: Node}
+        leaf_nodes = {n.name: n for n in self.graph.values() if n.is_original 
+                                                                and n.is_real_node 
+                                                                and not n.children}  # {Name: Node}
 
         return leaf_nodes
 

--- a/scale/recipe/instance/recipe.py
+++ b/scale/recipe/instance/recipe.py
@@ -108,8 +108,8 @@ class RecipeInstance(object):
         :rtype: dict
         """
 
-        leaf_nodes = {n.name: n for n in self.graph.values() if n.is_original 
-                                                                and n.is_real_node 
+        leaf_nodes = {n.name: n for n in self.graph.values() if n.is_original
+                                                                and n.is_real_node
                                                                 and not n.children}  # {Name: Node}
 
         return leaf_nodes

--- a/scale/recipe/test/messages/test_purge_recipe.py
+++ b/scale/recipe/test/messages/test_purge_recipe.py
@@ -321,7 +321,7 @@ class TestPurgeRecipe(TransactionTestCase):
             source_file_id=file_2.id), 0)
 
     def test_execute_dummy_recipe(self):
-        """Tests callign PurgeRecipe.execute() with dummy nodes"""
+        """Tests calling PurgeRecipe.execute() with dummy nodes"""
 
         file_2 = storage_test_utils.create_file(file_type='SOURCE')
         trigger = trigger_test_utils.create_trigger_event()

--- a/scale/recipe/test/messages/test_purge_recipe.py
+++ b/scale/recipe/test/messages/test_purge_recipe.py
@@ -2,11 +2,16 @@ from __future__ import unicode_literals
 
 import django
 from django.test import TransactionTestCase
+import mock
 
+from data.filter.filter import DataFilter
 from data.interface.interface import Interface
+from data.interface.parameter import FileParameter, JsonParameter
 from job.test import utils as job_test_utils
+from job.models import Job
 from recipe.definition.definition import RecipeDefinition
 from recipe.definition.json.definition_v6 import convert_recipe_definition_to_v6_json
+from recipe.instance.recipe import RecipeInstance
 from recipe.messages.purge_recipe import create_purge_recipe_message, PurgeRecipe
 from recipe.models import Recipe, RecipeNode
 from recipe.test import utils as recipe_test_utils
@@ -314,3 +319,70 @@ class TestPurgeRecipe(TransactionTestCase):
         # Check results are accurate
         self.assertEqual(PurgeResults.objects.values_list('num_recipes_deleted', flat=True).get(
             source_file_id=file_2.id), 0)
+
+    def test_execute_dummy_recipe(self):
+        """Tests callign PurgeRecipe.execute() with dummy nodes"""
+
+        file_2 = storage_test_utils.create_file(file_type='SOURCE')
+        trigger = trigger_test_utils.create_trigger_event()
+        PurgeResults.objects.create(source_file_id=file_2.id, trigger_event=trigger, force_stop_purge=True)
+        self.assertEqual(PurgeResults.objects.values_list('num_recipes_deleted', flat=True).get(
+            trigger_event=trigger.id), 0)
+
+        job_type_1 = job_test_utils.create_job_type()
+        job_type_2 = job_test_utils.create_job_type()
+        job_type_3 = job_test_utils.create_job_type()
+        job_type_4 = job_test_utils.create_job_type()
+        recipe_type_1 = recipe_test_utils.create_recipe_type_v5()
+
+        interface = Interface()
+        interface.add_parameter(FileParameter('file_param_1', ['image/gif']))
+        interface.add_parameter(JsonParameter('json_param_1', 'object'))
+
+        definition = RecipeDefinition(interface)
+        definition.add_job_node('A', job_type_1.name, job_type_1.version, job_type_1.revision_num)
+        definition.add_job_node('B', job_type_2.name, job_type_2.version, job_type_2.revision_num)
+        definition.add_job_node('C', job_type_3.name, job_type_3.version, job_type_3.revision_num)
+        definition.add_recipe_node('D', recipe_type_1.name, recipe_type_1.revision_num)
+        definition.add_job_node('E', job_type_4.name, job_type_4.version, job_type_4.revision_num)
+        definition.add_condition_node('F', Interface(), DataFilter(False))
+        definition.add_job_node('G', job_type_4.name, job_type_4.version, job_type_4.revision_num)
+        definition.add_dependency('A', 'B')
+        definition.add_dependency('A', 'C')
+        definition.add_dependency('B', 'E')
+        definition.add_dependency('C', 'D')
+        definition.add_dependency('A', 'F')
+        definition.add_dependency('F', 'G')
+        definition.add_recipe_input_connection('A', 'input_1', 'file_param_1')
+        definition.add_dependency_input_connection('B', 'b_input_1', 'A', 'a_output_1')
+        definition.add_dependency_input_connection('C', 'c_input_1', 'A', 'a_output_2')
+        definition.add_dependency_input_connection('D', 'd_input_1', 'C', 'c_output_1')
+        definition.add_recipe_input_connection('D', 'd_input_2', 'json_param_1')
+
+        recipe = recipe_test_utils.create_recipe()
+        job_a = job_test_utils.create_job(job_type=job_type_1, status='COMPLETED', save=False)
+        job_b = job_test_utils.create_job(job_type=job_type_2, status='RUNNING', save=False)
+        job_c = job_test_utils.create_job(job_type=job_type_3, status='COMPLETED', save=False)
+        job_e = job_test_utils.create_job(job_type=job_type_4, status='PENDING', num_exes=0, save=False)
+        Job.objects.bulk_create([job_a, job_b, job_c, job_e])
+        condition_f = recipe_test_utils.create_recipe_condition(is_processed=True, is_accepted=False, save=True)
+        recipe_d = recipe_test_utils.create_recipe(recipe_type=recipe_type_1)
+        recipe_node_a = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='A', job=job_a, save=False)
+        recipe_node_b = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='B', job=job_b, save=False)
+        recipe_node_c = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='C', job=job_c, save=False)
+        recipe_node_d = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='D', sub_recipe=recipe_d,
+                                                             save=False)
+        recipe_node_e = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='E', job=job_e, save=False)
+        recipe_node_f = recipe_test_utils.create_recipe_node(recipe=recipe, node_name='F', condition=condition_f,
+                                                             save=False)
+        recipe_nodes = [recipe_node_a, recipe_node_b, recipe_node_c, recipe_node_d, recipe_node_e, recipe_node_f]
+
+        # Create message
+        message = create_purge_recipe_message(recipe_id=recipe.id, trigger_id=trigger.id,
+                                              source_file_id=file_2.id)
+
+        # Execute message
+        with mock.patch('recipe.models.RecipeManager.get_recipe_instance', 
+                        return_value=RecipeInstance(definition, recipe, recipe_nodes)) as recipe_instance_mock:
+            result = message.execute()
+            self.assertTrue(result)


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
- recipe
### Description of change
<!-- Please provide a description of the change here. -->
- Added a simple `is_real_node` check when gathering recipe nodes that need to be purged. 

- Full disclosure: I was not able to reproduce this error with just a Scale test.  I have no idea how a DummyNode came into existence with a `node_type` that equals `JobNodeDefinition.NODE_TYPE`

### Background 
https://github.com/ngageoint/scale/blob/8d8cca814936528a333374e35af5122e652f4900/scale/recipe/messages/purge_recipe.py#L94

is getting back `DummyNodeInstance` when it is expecting only `JobNodeInstance`.

Error (actual error is on Line # 96):
```AttributeError: 'DummyNodeInstance' object has no attribute 'job' ```

Also may apply to:
https://github.com/ngageoint/scale/blob/8d8cca814936528a333374e35af5122e652f4900/scale/recipe/messages/purge_recipe.py#L102

