### PR TITLE
#1381 - v6 Reprocess Recipe REST API

### DIFF
--- a/scale/docs/rest/v6/recipe.rst
+++ b/scale/docs/rest/v6/recipe.rst
@@ -731,7 +731,7 @@ See :ref:`Scale Files <rest_v6_scale_file_list>` for an example response
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Recipe Input Files**                                                                                                  |
 +=========================================================================================================================+
-| Returns detailed information about input files associated with a given Job ID.                                          |
+| Returns detailed information about input files associated with a given Recipe ID.                                       |
 +-------------------------------------------------------------------------------------------------------------------------+
 | **GET** /v6/recipes/{id}/input_files/                                                                                   |
 |         Where {id} is the unique identifier of an existing recipe.                                                      |
@@ -782,3 +782,40 @@ See :ref:`Scale Files <rest_v6_scale_file_list>` for an example response
 | results            | Array             | List of result JSON objects that match the query parameters.                   |
 |                    |                   | (See :ref:`Scale Files <rest_v6_scale_file_list>`)                             |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
+
+.. _rest_v6_recipe_reprocess:
+
+v6 Reprocess Recipe
+-------------------
+
+**Example POST /v6/recipes/{id}/reprocess/ API call**
+
+Request: POST http://.../v6/recipes/{id}/reprocess/
+
+.. code-block:: javascript
+
+  {
+    "forced_nodes": :ref:`rest_v6_recipe_json_forced_nodes`
+  }
+
+Response: 202 ACCEPTED
+
++-------------------------------------------------------------------------------------------------------------------------+
+| **Re-process Recipe**                                                                                                   |
++=========================================================================================================================+
+| Creates a new recipe using its latest type revision by superseding an existing recipe and associated jobs.              |
+| Note that if the recipe type definition has not changed since the recipe was created, then one or more job names must be|
+| specified to force the recipe to be re-processed. A recipe that is already superseded cannot be re-processed again.     |
++-------------------------------------------------------------------------------------------------------------------------+
+| **POST** /v6/recipes/{id}/reprocess/                                                                                    |
+|          Where {id} is the unique identifier of an existing recipe.                                                     |
++-------------------------------------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| forced_nodes       | JSON Object       | Required | Set of recipe nodes that should be forced to re-process             |
+|                    |                   |          | See :ref:`Recipe Forced Nodes <rest_v6_recipe_json_forced_nodes>`   |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| **Successful Response**                                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Status**         | 202 ACCEPTED                                                                                       |
++--------------------+----------------------------------------------------------------------------------------------------+

--- a/scale/docs/rest/v6/recipe.yml
+++ b/scale/docs/rest/v6/recipe.yml
@@ -214,6 +214,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/file_list'
 
+  /recipes/{id}/reprocess/:
+    post:
+      operationId: _rest_v6_recipe_reprocess
+      summary: Reprocess Recipe
+      description: Creates a new recipe using its latest type revision by superseding an existing recipe and associated|
+        jobs. Note that if the recipe type definition has not changed since the recipe was created, then one or more   |
+        job names must be specified to force the recipe to be re-processed. A recipe that is already superseded cannot |
+        be re-processed again.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/forced_nodes'
+      responses:
+        '202':
+          description: 202 accepted
+
 components:
   schemas:
     recipe_list:
@@ -589,3 +607,30 @@ components:
             description:
               type: object
               additionalProperties: true
+              
+    forced_nodes:
+      title: Forced Nodes
+      required: [all]
+      properties:
+        all:
+          type: boolean
+          description: If true, then all nodes within the recipe should be forced to |
+            re-process and the 'nodes' and 'sub_recipes' fields should be omitted. If|
+            false, then the 'nodes' array is used to indicate which nodes should be |
+            forced to re-process.
+          example: false
+        nodes:
+          type: array
+          items:
+            type: string
+          description: An array listing the names of the recipe nodes that should be |
+            forced to re-process
+          example: ["job_a_1", "job_a_2", "recipe_b", "recipe_c"]
+        sub_recipes:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/forced_nodes'
+          description: A JSON object where the key names are the sub-recipe node names |
+            that are being forced to re-process. The values are forced nodes JSON |
+            objects that recursively define the nodes with the sub-recipe to force to |
+            reprocess.

--- a/scale/docs/rest/v6/recipe.yml
+++ b/scale/docs/rest/v6/recipe.yml
@@ -227,7 +227,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/forced_nodes'
+              $ref: '#/components/schemas/reprocess_post'
       responses:
         '202':
           description: 202 accepted
@@ -607,7 +607,14 @@ components:
             description:
               type: object
               additionalProperties: true
-              
+
+    reprocess_post:
+      title: Reprocess Post
+      required: [forced_nodes]
+      properties:
+        forced_nodes:
+          $ref: '#/components/schemas/forced_nodes'
+
     forced_nodes:
       title: Forced Nodes
       required: [all]

--- a/scale/recipe/definition/definition.py
+++ b/scale/recipe/definition/definition.py
@@ -220,8 +220,8 @@ class RecipeDefinition(object):
 
         :param recipe_type_name: The name of the recipe type
         :type recipe_type_name: string
-        :returns: list of JobNodeDefinition objects
-        :rtype: list[:class:`recipe.definition.node.JobNodeDefinition`]
+        :returns: list of RecipeNodeDefinition objects
+        :rtype: list[:class:`recipe.definition.node.RecipeNodeDefinition`]
         """
 
         nodes = []

--- a/scale/recipe/diff/forced_nodes.py
+++ b/scale/recipe/diff/forced_nodes.py
@@ -65,6 +65,15 @@ class ForcedNodes(object):
 
         return self._nodes
 
+    def get_sub_recipe_names(self):
+        """Returns the sub-recipe node names
+
+        :returns: The sub-recipe node names
+        :rtype: set
+        """
+
+        return self._subrecipe_nodes.keys()
+
     def is_node_forced_to_reprocess(self, node_name):
         """Indicates whether the given node is forced to reprocess
 

--- a/scale/recipe/diff/json/forced_nodes_v6.py
+++ b/scale/recipe/diff/json/forced_nodes_v6.py
@@ -21,6 +21,10 @@ FORCED_NODES_SCHEMA = {
             'required': ['all'],
             'additionalProperties': False,
             'properties': {
+                'version': {
+                    'description': 'Version of the forced nodes schema',
+                    'type': 'string',
+                },
                 'all': {
                     'description': 'Whether all nodes should be forced to be reprocessed',
                     'type': 'boolean',

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -2391,7 +2391,7 @@ class RecipeTypeRevision(models.Model):
         """
 
         from recipe.diff.exceptions import InvalidDiff
-        from recipe.diff.json.forced_nodes_v6 import ForcedNodesV6
+        from recipe.diff.json.forced_nodes_v6 import ForcedNodesV6, convert_forced_nodes_to_v6
 
         is_valid = True
         errors = []
@@ -2448,7 +2448,8 @@ class RecipeTypeRevision(models.Model):
                     errors.append(msg % (name, node.recipe_type_name, node.revision_num))
                     is_valid = False
                     continue
-                validate = sub.validate_forced_nodes(forced_nodes.get_forced_nodes_for_subrecipe(name))
+                sub_nodes = forced_nodes.get_forced_nodes_for_subrecipe(name)
+                validate = sub.validate_forced_nodes(convert_forced_nodes_to_v6(sub_nodes).get_dict())
                 is_valid &= validate.is_valid
                 errors.extend(validate.errors)
                 warnings.extend(validate.warnings)

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -44,6 +44,8 @@ RecipeNodeOutput = namedtuple('RecipeNodeOutput', ['node_name', 'node_type', 'id
 
 RecipeTypeValidation = namedtuple('RecipeTypeValidation', ['is_valid', 'errors', 'warnings', 'diff'])
 
+ForcedNodesValidation = namedtuple('ForcedNodesValidation', ['is_valid', 'errors', 'warnings', 'forced_nodes'])
+
 
 
 INPUT_FILE_BATCH_SIZE = 500  # Maximum batch size for creating RecipeInputFile models
@@ -2010,7 +2012,7 @@ class RecipeTypeManager(models.Manager):
         :param definition_dict: The definition for running a recipe of this type
         :type definition_dict: dict
         :returns: The recipe type validation.
-        :rtype: :class:`job.models.RecipeTypeValidation`
+        :rtype: :class:`recipe.models.RecipeTypeValidation`
         """
 
         from recipe.definition.exceptions import InvalidDefinition
@@ -2278,8 +2280,6 @@ class RecipeTypeRevisionManager(models.Manager):
 
         return revs
 
-
-
     def get_revision_map(self, revision_ids, revision_tuples):
         """Returns a dict that maps revision ID to recipe type revision for the recipe type revisions that match the
         given values. Each revision model will have its related recipe type model populated.
@@ -2380,6 +2380,80 @@ class RecipeTypeRevision(models.Model):
         """
 
         return rest_utils.strip_schema_version(convert_recipe_definition_to_v6_json(self.get_definition()).get_dict())
+
+    def validate_forced_nodes(self, forced_nodes_json):
+        """Validates a forced nodes object against the definition for this recipe type revision
+
+        :param forced_nodes_json: The definition of nodes to be forced to reprocess
+        :type forced_nodes_json: dict
+        :returns: The ForcedNodes validation.
+        :rtype: :class:`recipe.models.ForcedNodesValidation`
+        """
+
+        from recipe.diff.exceptions import InvalidDiff
+        from recipe.diff.json.forced_nodes_v6 import ForcedNodesV6
+
+        is_valid = True
+        errors = []
+        warnings = []
+        diff = {}
+
+        definition = None
+
+        try:
+            forced_nodes_v6 = ForcedNodesV6(forced_nodes_json, do_validate=True)
+        except InvalidDiff as ex:
+            is_valid = False
+            errors.append(ex.error)
+            message = 'Invalid forced nodes definition: %s' % ex
+            logger.info(message)
+            pass
+
+        if forced_nodes_v6:
+            forced_nodes = forced_nodes_v6.get_forced_nodes()
+            node_names = forced_nodes.get_forced_node_names()
+            sub_names = forced_nodes.get_sub_recipe_names()
+            if forced_nodes.all_nodes and node_names:
+                warnings.append('nodes defined with all field set to True')
+            definition = self.get_definition()
+            top_level_names = definition.get_topological_order()
+            for name in forced_nodes.get_forced_node_names():
+                if name not in top_level_names:
+                    errors.append('Recipe definition does not have a top level node with name: %s' % name)
+                    is_valid = False
+                    continue
+                node = definition.graph[name]
+                if node.node_type == RecipeNodeDefinition.NODE_TYPE:
+                    if name not in sub_names:
+                        warnings.append('Node %s is a recipe node but is not defined in sub_recipes' % name)
+
+            if forced_nodes.all_nodes and sub_names:
+                warnings.append('sub_recipes defined with all field set to True')
+            for name in sub_names:
+                if name not in forced_nodes.get_forced_node_names():
+                    warnings.append('Sub-recipe %s defined but not listed in nodes' % name)
+                if name not in top_level_names:
+                    errors.append('Recipe definition does not have a top level node with name: %s' % name)
+                    is_valid = False
+                    continue
+                node = definition.graph[name]
+                if node.node_type != RecipeNodeDefinition.NODE_TYPE:
+                    errors.append('Sub-recipe node %s is not a recipe node' % name)
+                    is_valid = False
+                    continue
+                try:
+                    sub = RecipeTypeRevision.objects.get_revision(node.recipe_type_name, node.revision_num)
+                except RecipeTypeRevision.DoesNotExist as ex:
+                    msg = 'Unable to get recipe type revision for sub-recipe %s with name %s and revision %d'
+                    errors.append(msg % (name, node.recipe_type_name, node.revision_num))
+                    is_valid = False
+                    continue
+                validate = sub.validate_forced_nodes(forced_nodes.get_forced_nodes_for_subrecipe(name))
+                is_valid &= validate.is_valid
+                errors.extend(validate.errors)
+                warnings.extend(validate.warnings)
+
+        return ForcedNodesValidation(is_valid, errors, warnings, forced_nodes)
 
     def natural_key(self):
         """Django method to define the natural key for a recipe type revision as the combination of job type and

--- a/scale/recipe/serializers.py
+++ b/scale/recipe/serializers.py
@@ -268,7 +268,6 @@ class OldRecipeDetailsSerializer(RecipeSerializerV5):
     event = TriggerEventDetailsSerializerV5()
     data = serializers.JSONField(default=dict, source='input')
 
-    inputs = RecipeDetailsInputSerializer(many=True)
     jobs = RecipeJobsDetailsSerializerV5(many=True)
 
     root_superseded_recipe = RecipeBaseSerializerV5()

--- a/scale/recipe/serializers.py
+++ b/scale/recipe/serializers.py
@@ -268,6 +268,7 @@ class OldRecipeDetailsSerializer(RecipeSerializerV5):
     event = TriggerEventDetailsSerializerV5()
     data = serializers.JSONField(default=dict, source='input')
 
+    inputs = RecipeDetailsInputSerializer(many=True)
     jobs = RecipeJobsDetailsSerializerV5(many=True)
 
     root_superseded_recipe = RecipeBaseSerializerV5()

--- a/scale/recipe/test/diff/json/test_forced_nodes_v6.py
+++ b/scale/recipe/test/diff/json/test_forced_nodes_v6.py
@@ -1,0 +1,108 @@
+from __future__ import unicode_literals
+
+import django
+from django.test import TestCase
+
+from data.filter.filter import DataFilter
+from data.interface.interface import Interface
+from data.interface.parameter import FileParameter, JsonParameter
+from job.models import JobType
+from job.test import utils as job_test_utils
+from recipe.configuration.definition.recipe_definition import LegacyRecipeDefinition as OldRecipeDefinition
+from recipe.definition.definition import RecipeDefinition
+from recipe.diff.forced_nodes import ForcedNodes
+from recipe.diff.exceptions import InvalidDiff
+from recipe.diff.json.forced_nodes_v6 import convert_forced_nodes_to_v6, ForcedNodesV6
+from recipe.handlers.graph import RecipeGraph
+from recipe.handlers.graph_delta import RecipeGraphDelta
+
+
+class TestForcedNodesV6(TestCase):
+
+    def setUp(self):
+        django.setup()
+
+    def test_convert_forced_nodes_to_v6_empty(self):
+        """Tests calling convert_forced_nodes_to_v6() with an empty forced nodes object"""
+
+        empty = ForcedNodes()
+        v6 = convert_forced_nodes_to_v6(empty)
+        self.assertDictEqual(v6.get_dict(), {'version': '6', 'all': False})
+
+    def test_convert_forced_nodes_to_v6_full(self):
+        """Tests calling convert_forced_nodes_to_v6() with a full diff with all types (deleted, new, changed, etc) of nodes"""
+
+        recipe_d_forced_nodes = ForcedNodes()
+        recipe_d_forced_nodes.add_node('1')
+        recipe_d_forced_nodes.add_node('2')
+        top_forced_nodes = ForcedNodes()
+        top_forced_nodes.add_node('C')
+        top_forced_nodes.add_subrecipe('D', recipe_d_forced_nodes)
+        v6 = convert_forced_nodes_to_v6(top_forced_nodes)
+        full = {
+            'version': '6',
+            'all': False,
+            'nodes': [u'C', u'D'],
+            'sub_recipes': {
+                'D': {
+                    'version': '6',
+                    'all': False,
+                    'nodes': ['1', '2']}}}
+        self.assertDictEqual(v6.get_dict(), full)
+
+    def test_missing_all(self):
+        """Tests calling ForcedNodesV6() with json that doesn't match the schema"""
+
+        json_data = {
+            'nodes': ['missing-all']
+        }
+        #no error without validate call, raises error when validating
+        ForcedNodesV6(forced_nodes=json_data, do_validate=False)
+        self.assertRaises(InvalidDiff, ForcedNodesV6, json_data, True)
+
+    def test_invalid_additional_property(self):
+        """Tests calling ForcedNodesV6() with json that doesn't match the schema"""
+
+        json_data = {
+            'all': False,
+            'invalid': 'test'
+        }
+        #no error without validate call, raises error when validating
+        ForcedNodesV6(forced_nodes=json_data, do_validate=False)
+        self.assertRaises(InvalidDiff, ForcedNodesV6, json_data, True)
+
+    def test_invalid_version(self):
+        """Tests calling ForcedNodesV6() with json that doesn't match the schema"""
+
+        json_data = {
+            'version': '999',
+            'all': False
+        }
+        self.assertRaises(InvalidDiff, ForcedNodesV6, json_data, False)
+
+    def test_minimal(self):
+        """Tests calling ForcedNodesV6() with no args"""
+
+        min = ForcedNodesV6()
+        self.assertDictEqual(min.get_dict(), {'version': '6', 'all': False})
+
+    def test_full_json(self):
+        """Tests calling ForcedNodesV6() with full valid json"""
+
+        json_data = {
+            'version': '6',
+            'all': False,
+            'nodes': ['job_a_1', 'job_a_2', 'recipe_b', 'recipe_c'],
+            'sub_recipes': {
+                'recipe_b': {
+                    'all': True
+                },
+                'recipe_c': {
+                    'all': False,
+                    'nodes': ['job_c_1', 'job_c_2']
+                }
+            }
+        }
+        #no error without validate call, raises error when validating
+        fn = ForcedNodesV6(forced_nodes=json_data, do_validate=True)
+        self.assertDictEqual(fn.get_dict(), json_data)

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -2537,7 +2537,26 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         json_data = {
             'forced_nodes': {
                 'all': False,
-                'nodes': [self.job_type1.name]
+                'nodes': ['node_a']
+            }
+        }
+
+        url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
+
+    def test_full_recipe(self):
+        """Tests reprocessing a full recipe"""
+
+        json_data = {
+            'forced_nodes': {
+                'all': False,
+                'nodes': ['node_a, node_b'],
+                'sub_recipes': {
+                    'node_b': {
+                        'all': False,
+                        'nodes': ['node_a']}
+                }
             }
         }
 
@@ -2546,12 +2565,31 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
 
     def test_bad_job(self):
-        """Tests reprocessing a non-existant job throws and error"""
+        """Tests reprocessing a non-existant job throws an error"""
 
         json_data = {
             'forced_nodes': {
                 'all': False,
                 'nodes': ['does-not-exist']
+            }
+        }
+
+        url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+
+    def test_bad_recipe(self):
+        """Tests reprocessing a non-existant job throws an error"""
+
+        json_data = {
+            'forced_nodes': {
+                'all': False,
+                'nodes': ['node_a'],
+                'sub_recipes': {
+                    'node_a': {
+                        'all': False,
+                        'nodes': ['node_a']}
+                }
             }
         }
 

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -2559,6 +2559,19 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
 
+    def test_bad_json(self):
+        """Tests reprocessing with bad forced_nodes json input"""
+
+        json_data = {
+            'forced_nodes': {
+                'invalid': 'missing "all" field'
+            }
+        }
+
+        url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+
     def test_superseded(self):
         """Tests reprocessing a recipe that is already superseded throws an error."""
 

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -2463,76 +2463,86 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
     def setUp(self):
         django.setup()
 
-        self.job_type1 = job_test_utils.create_job_type()
+        self.date_1 = datetime.datetime(2016, 1, 1, tzinfo=utc)
+        self.date_2 = datetime.datetime(2016, 1, 2, tzinfo=utc)
+        self.s_class = 'A'
+        self.s_sensor = '1'
+        self.collection = '12345'
+        self.task = 'abcd'
+        
+        manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
+        manifest['job']['name'] = 'scale-batch-creator'
 
-        definition = {
-            'version': '1.0',
-            'input_data': [{
-                'media_types': [
-                    'image/x-hdf5-image',
-                ],
-                'type': 'file',
-                'name': 'input_file',
-            }],
-            'jobs': [{
-                'job_type': {
-                    'name': self.job_type1.name,
-                    'version': self.job_type1.version,
-                },
-                'name': 'kml',
-                'recipe_inputs': [{
-                    'job_input': 'input_file',
-                    'recipe_input': 'input_file',
-                }],
-            }],
+        self.job_type1 = job_test_utils.create_seed_job_type(manifest=manifest)
+        self.jt2 = job_test_utils.create_seed_job_type(manifest=job_test_utils.MINIMUM_MANIFEST)
+
+        def_v6_dict_sub = {'version': '6',
+                       'input': { 'files': [],
+                                  'json': []},
+                       'nodes': {'node_a': {'dependencies': [],
+                                            'input': {},
+                                            'node_type': {'node_type': 'job', 'job_type_name': self.jt2.name,
+                                                          'job_type_version': self.jt2.version, 'job_type_revision': self.jt2.revision_num}}}}
+
+        self.sub = recipe_test_utils.create_recipe_type_v6(definition=def_v6_dict_sub)
+
+        def_v6_dict = {'version': '6',
+                       'input': {'files': [{'name': 'INPUT_FILE', 'media_types': ['image/tiff'], 'required': True,
+                                            'multiple': True}],
+                                 'json': [{'name': 'INPUT_JSON', 'type': 'string', 'required': True}]},
+                       'nodes': {'node_a': {'dependencies': [],
+                                            'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'},
+                                                      'INPUT_JSON': {'type': 'recipe', 'input': 'INPUT_JSON'}},
+                                            'node_type': {'node_type': 'job', 'job_type_name': self.job_type1.name,
+                                                          'job_type_version': self.job_type1.version, 'job_type_revision': 1}},
+                                 'node_b': {'dependencies': [],
+                                            'input': {},
+                                            'node_type': {'node_type': 'recipe', 'recipe_type_name': self.sub.name,
+                                                          'recipe_type_revision': self.sub.revision_num}}
+                           
+                       }
+            
         }
 
-        workspace1 = storage_test_utils.create_workspace()
-        file1 = storage_test_utils.create_file(workspace=workspace1)
+        self.workspace = storage_test_utils.create_workspace()
+        self.file1 = storage_test_utils.create_file(workspace=self.workspace, file_size=104857600.0,
+                                               source_started=self.date_1, source_ended=self.date_2,
+                                               source_sensor_class=self.s_class, source_sensor=self.s_sensor,
+                                               source_collection=self.collection, source_task=self.task)
 
-        data = {
-            'version': '1.0',
-            'input_data': [{
-                'name': 'input_file',
-                'file_id': file1.id,
-            }],
-            'workspace_id': workspace1.id,
-        }
 
-        self.recipe_type = recipe_test_utils.create_recipe_type_v6(name='my-type', definition=definition)
-        recipe_handler = recipe_test_utils.create_recipe_handler(recipe_type=self.recipe_type, data=data)
-        self.recipe1 = recipe_handler.recipe
-        self.recipe1_jobs = recipe_handler.recipe_jobs
+        self.data = {'version': '6', 'files': {'INPUT_FILE': [self.file1.id]},
+                'json': {'INPUT_JSON': 'hello'}}
+
+        self.recipe_type = recipe_test_utils.create_recipe_type_v6(name='my-type', definition=def_v6_dict)
+        self.recipe1 = recipe_test_utils.create_recipe(recipe_type=self.recipe_type, input=self.data)
 
     def test_all_jobs(self):
         """Tests reprocessing all jobs in an existing recipe"""
 
         json_data = {
-            'all_jobs': True,
+            'forced_nodes': {
+                'all': True
+            }
         }
 
         url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
-
-        results = json.loads(response.content)
-        self.assertNotEqual(results['id'], self.recipe1.id)
-        self.assertEqual(results['recipe_type']['id'], self.recipe1.recipe_type.id)
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
 
     def test_job(self):
         """Tests reprocessing one job in an existing recipe"""
 
         json_data = {
-            'job_names': ['kml'],
+            'forced_nodes': {
+                'all': False,
+                'nodes': [self.job_type1.name]
+            }
         }
 
         url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
-
-        results = json.loads(response.content)
-        self.assertNotEqual(results['id'], self.recipe1.id)
-        self.assertEqual(results['recipe_type']['id'], self.recipe1.recipe_type.id)
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
 
     def test_priority(self):
         """Tests reprocessing all jobs in an existing recipe with a priority override"""
@@ -2560,7 +2570,9 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         self.recipe1.save()
 
         json_data = {
-            'all_jobs': True,
+            'forced_nodes': {
+                'all': True
+            }
         }
 
         url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -2518,8 +2518,8 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         self.recipe1 = recipe_test_utils.create_recipe(recipe_type=self.recipe_type, input=self.data)
         recipe_test_utils.process_recipe_inputs([self.recipe1.id])
 
-    @patch('recipe.models.CommandMessageManager')
-    @patch('recipe.messages.create_recipes.create_reprocess_messages')
+    @patch('recipe.views.CommandMessageManager')
+    @patch('recipe.views.create_reprocess_messages')
     def test_all_jobs(self, mock_create, mock_msg_mgr):
         """Tests reprocessing all jobs in an existing recipe"""
 
@@ -2535,8 +2535,8 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
 
         mock_create.assert_called()
 
-    @patch('recipe.models.CommandMessageManager')
-    @patch('recipe.messages.create_recipes.create_reprocess_messages')
+    @patch('recipe.views.CommandMessageManager')
+    @patch('recipe.views.create_reprocess_messages')
     def test_job(self, mock_create, mock_msg_mgr):
         """Tests reprocessing one job in an existing recipe"""
 
@@ -2553,8 +2553,8 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
 
         mock_create.assert_called()
 
-    @patch('recipe.models.CommandMessageManager')
-    @patch('recipe.messages.create_recipes.create_reprocess_messages')
+    @patch('recipe.views.CommandMessageManager')
+    @patch('recipe.views.create_reprocess_messages')
     def test_full_recipe(self, mock_create, mock_msg_mgr):
         """Tests reprocessing a full recipe"""
 

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -2551,7 +2551,7 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         json_data = {
             'forced_nodes': {
                 'all': False,
-                'nodes': ['node_a, node_b'],
+                'nodes': ['node_a', 'node_b'],
                 'sub_recipes': {
                     'node_b': {
                         'all': False,

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -2518,7 +2518,9 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         self.recipe1 = recipe_test_utils.create_recipe(recipe_type=self.recipe_type, input=self.data)
         recipe_test_utils.process_recipe_inputs([self.recipe1.id])
 
-    def test_all_jobs(self):
+    @patch('recipe.models.CommandMessageManager')
+    @patch('recipe.messages.create_recipes.create_reprocess_messages')
+    def test_all_jobs(self, mock_create, mock_msg_mgr):
         """Tests reprocessing all jobs in an existing recipe"""
 
         json_data = {
@@ -2531,7 +2533,11 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
 
-    def test_job(self):
+        mock_create.assert_called()
+
+    @patch('recipe.models.CommandMessageManager')
+    @patch('recipe.messages.create_recipes.create_reprocess_messages')
+    def test_job(self, mock_create, mock_msg_mgr):
         """Tests reprocessing one job in an existing recipe"""
 
         json_data = {
@@ -2545,7 +2551,11 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
 
-    def test_full_recipe(self):
+        mock_create.assert_called()
+
+    @patch('recipe.models.CommandMessageManager')
+    @patch('recipe.messages.create_recipes.create_reprocess_messages')
+    def test_full_recipe(self, mock_create, mock_msg_mgr):
         """Tests reprocessing a full recipe"""
 
         json_data = {
@@ -2563,6 +2573,8 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
+
+        mock_create.assert_called()
 
     def test_bad_job(self):
         """Tests reprocessing a non-existant job throws an error"""

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -6,6 +6,7 @@ import rest_framework.status as status
 from django.db import transaction
 from django.http.response import Http404, HttpResponse
 from django.utils.timezone import now
+
 from recipe.deprecation import RecipeDefinitionSunset
 from rest_framework.generics import GenericAPIView, ListAPIView, RetrieveAPIView, ListCreateAPIView
 from rest_framework.response import Response
@@ -16,6 +17,7 @@ import trigger.handler as trigger_handler
 import util.rest as rest_util
 
 from data.data.json.data_v6 import DataV6
+from messaging.manager import CommandMessageManager
 from job.models import Job, JobType
 from queue.models import Queue
 from recipe.configuration.data.exceptions import InvalidRecipeConnection, InvalidRecipeData
@@ -65,8 +67,10 @@ class RecipeTypesView(ListCreateAPIView):
 
         if self.request.version == 'v6':
             return self.list_v6(request)
-        else:
+        elif self.request.version == 'v5':
             return self.list_v5(request)
+
+        raise Http404
 
     def list_v5(self, request):
         """Retrieves the list of all recipe types returns it in JSON form
@@ -120,8 +124,10 @@ class RecipeTypesView(ListCreateAPIView):
         
         if self.request.version == 'v6':
             return self._create_v6(request)
-        else:
+        elif self.request.version == 'v5':
             return self._create_v5(request)
+
+        raise Http404
         
     def _create_v5(self, request):
         """Creates a new recipe type and returns a link to the detail URL
@@ -234,7 +240,7 @@ class RecipeTypeIDDetailsView(GenericAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
-        if self.request.version == 'v4' or self.request.version == 'v5':
+        if self.request.version == 'v5':
             return self.get_v5(request, recipe_type_id)
         else:
             raise Http404
@@ -274,7 +280,7 @@ class RecipeTypeIDDetailsView(GenericAPIView):
         :returns: the HTTP response to send back to the user
         """
 
-        if self.request.version == 'v4' or self.request.version == 'v5':
+        if self.request.version == 'v5':
             return self.patch_v5(request, recipe_type_id)
         else:
             raise Http404
@@ -546,8 +552,10 @@ class RecipeTypesValidationView(APIView):
 
         if self.request.version == 'v6':
             return self._post_v6(request)
-        else:
+        elif self.request.version == 'v5':
             return self._post_v5(request)
+
+        raise Http404
 
     def _post_v5(self, request):
         """Validates a new recipe type and returns any warnings discovered
@@ -642,8 +650,6 @@ class RecipesView(ListAPIView):
         if request.version == 'v6':
             return self._list_v6(request)
         elif request.version == 'v5':
-            return self._list_v5(request)
-        elif request.version == 'v4':
             return self._list_v5(request)
 
         raise Http404()
@@ -766,18 +772,50 @@ class RecipeDetailsView(RetrieveAPIView):
         :returns: the HTTP response to send back to the user
         """
 
+        if request.version == 'v6':
+            return self._retrieve_v5(request, recipe_id)
+        elif request.version == 'v5':
+            return self._retrieve_v6(request, recipe_id)
+
+        raise Http404()
+
+    def _retrieve_v5(self, request, recipe_id):
+        """Retrieves the details for a recipe and returns it in JSON form
+
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :param recipe_id: The id of the recipe
+        :type recipe_id: int encoded as a str
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+
         try:
-            # TODO: remove check when REST API v5 is removed
-            if request.version == 'v6':
-                recipe = Recipe.objects.get_details(recipe_id)
-            else:
-                recipe = Recipe.objects.get_details_v5(recipe_id)
+            recipe = Recipe.objects.get_details_v5(recipe_id)
         except Recipe.DoesNotExist:
             raise Http404
 
         serializer = self.get_serializer(recipe)
         return Response(serializer.data)
 
+    def _retrieve_v6(self, request, recipe_id):
+        """Retrieves the details for a recipe and returns it in JSON form
+
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :param recipe_id: The id of the recipe
+        :type recipe_id: int encoded as a str
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+
+        try:
+            recipe = Recipe.objects.get_details(recipe_id)
+        except Recipe.DoesNotExist:
+            raise Http404
+
+        serializer = self.get_serializer(recipe)
+        return Response(serializer.data)
 
 class RecipeInputFilesView(ListAPIView):
     """This is the endpoint for retrieving details about input files associated with a given recipe."""
@@ -794,43 +832,50 @@ class RecipeInputFilesView(ListAPIView):
     def get(self, request, recipe_id):
         """Retrieve detailed information about the input files for a recipe
 
-        -*-*-
-        parameters:
-          - name: recipe_id
-            in: path
-            description: The ID of the recipe the file is associated with
-            required: true
-            example: 113
-          - name: started
-            in: query
-            description: The start time of a start/end time range
-            required: false
-            example: 2016-01-01T00:00:00Z
-          - name: ended
-            in: query
-            description: The end time of a start/end time range
-            required: false
-            example: 2016-01-02T00:00:00Z
-          - name: time_field
-            in: query
-            description: 'The database time field to apply `started` and `ended` time filters
-                          [Valid fields: `source`, `data`, `last_modified`]'
-            required: false
-            example: source
-          - name: file_name
-            in: query
-            description: The name of a specific file in Scale
-            required: false
-            example: some_file_i_need_to_find.zip
-          - name: recipe_input
-            in: query
-            description: The name of the input the file is passed to in a recipe
-            required: false
-            example: input_1
-        responses:
-          '200':
-            description: A JSON list of files with metadata
-        -*-*-
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :param recipe_id: The ID for the recipe.
+        :type recipe_id: int encoded as a str
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+
+        if request.version == 'v6':
+            return self._get_v6(request, recipe_id)
+        elif request.version == 'v5':
+            return self._get_v5(request, recipe_id)
+
+        raise Http404()
+
+    def _get_v5(self, request, recipe_id):
+        """Retrieve detailed information about the input files for a recipe
+
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :param recipe_id: The ID for the recipe.
+        :type recipe_id: int encoded as a str
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+
+        started = rest_util.parse_timestamp(request, 'started', required=False)
+        ended = rest_util.parse_timestamp(request, 'ended', required=False)
+        rest_util.check_time_range(started, ended)
+        time_field = rest_util.parse_string(request, 'time_field', required=False,
+                                            accepted_values=ScaleFile.VALID_TIME_FIELDS)
+        file_name = rest_util.parse_string(request, 'file_name', required=False)
+        recipe_input = rest_util.parse_string(request, 'recipe_input', required=False)
+
+        files = RecipeInputFile.objects.get_recipe_input_files(recipe_id, started=started, ended=ended,
+                                                               time_field=time_field, file_name=file_name,
+                                                               recipe_input=recipe_input)
+
+        page = self.paginate_queryset(files)
+        serializer = self.get_serializer(page, many=True)
+        return self.get_paginated_response(serializer.data)
+
+    def _get_v6(self, request, recipe_id):
+        """Retrieve detailed information about the input files for a recipe
 
         :param request: the HTTP GET request
         :type request: :class:`rest_framework.request.Request`
@@ -889,7 +934,7 @@ class RecipeReprocessView(GenericAPIView):
 
         raise Http404()
 
-    def post_v5(self, request, recipe_id):
+    def _post_v5(self, request, recipe_id):
         """Schedules a recipe for reprocessing and returns it in JSON form
 
         :param request: the HTTP GET request
@@ -948,7 +993,7 @@ class RecipeReprocessView(GenericAPIView):
         url = reverse('recipe_details_view', args=[new_recipe.id], request=request)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=dict(location=url))
 
-    def post_v6(self, request, recipe_id):
+    def _post_v6(self, request, recipe_id):
         """Schedules a recipe for reprocessing and returns it in JSON form
 
         :param request: the HTTP GET request
@@ -973,41 +1018,16 @@ class RecipeReprocessView(GenericAPIView):
             raise Http404
         if recipe.is_superseded:
             raise BadParameter('Cannot reprocess a superseded recipe')
-        
+
         event = TriggerEvent.objects.create_trigger_event('USER', None, {'user': 'Anonymous'}, now())
         root_recipe_id = recipe.root_superseded_recipe_id if recipe.root_superseded_recipe_id else recipe.id
         recipe_type_name = recipe.recipe_type.name
         revision_num = recipe.recipe_type_rev.revision_num
-        forced_nodes = ForcedNodes()
-        if all_jobs:
-            forced_nodes.set_all_nodes()
-        elif job_names:
-            for job_name in job_names:
-                forced_nodes.add_node(job_name)
 
         # Execute all of the messages to perform the reprocess
         messages = create_reprocess_messages([root_recipe_id], recipe_type_name, revision_num, event.id,
-                                             forced_nodes=forced_nodes)
-        while messages:
-            msg = messages.pop(0)
-            result = msg.execute()
-            if not result:
-                raise Exception('Reprocess failed on message type \'%s\'' % msg.type)
-            messages.extend(msg.new_messages)
+                                             forced_nodes=forced_nodes.get_forced_nodes())
 
-        # Update job priorities
-        if priority is not None:
-            Job.objects.filter(event_id=event.id).update(priority=priority)
-            from queue.models import Queue
-            Queue.objects.filter(job__event_id=event.id).update(priority=priority)
+        CommandMessageManager().send_messages(messages)
 
-        new_recipe = Recipe.objects.get(root_superseded_recipe_id=root_recipe_id, is_superseded=False)
-        try:
-            new_recipe = Recipe.objects.get_details_v5(new_recipe.id)
-        except Recipe.DoesNotExist:
-            raise Http404
-
-        serializer = self.get_serializer(new_recipe)
-
-        url = reverse('recipe_details_view', args=[new_recipe.id], request=request)
-        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=dict(location=url))
+        return Response(status=status.HTTP_202_ACCEPTED)


### PR DESCRIPTION
##### Checklist
- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

### Affected app(s)
- Recipe

### Description of change
- Implemented v6 Reprocess Recipe REST API
- Added tests for for v6 Forced Nodes Json
