### PR TITLE
#1472 - Fix recipe type details serializer

### DIFF
--- a/scale/recipe/serializers.py
+++ b/scale/recipe/serializers.py
@@ -72,7 +72,7 @@ class RecipeTypeSerializerV6(RecipeTypeBaseSerializerV6):
     is_active = serializers.BooleanField()
     is_system = serializers.BooleanField()
     revision_num = serializers.IntegerField()
-    definition = serializers.JSONField(default=dict)
+    definition = None
     job_types = None
     sub_recipe_types = None
     created = serializers.DateTimeField()
@@ -95,6 +95,7 @@ class RecipeTypeDetailsSerializerV5(RecipeTypeSerializerV5):
 class RecipeTypeDetailsSerializerV6(RecipeTypeSerializerV6):
     """Converts recipe type model fields to REST output."""
     from job.job_type_serializers import JobTypeDetailsSerializerV6
+    definition = serializers.JSONField(source='get_v6_definition_json')
     job_types = JobTypeDetailsSerializerV6(many=True)
     sub_recipe_types = RecipeTypeSerializerV6(many=True)
 

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -896,6 +896,10 @@ class TestRecipeTypeDetailsViewV6(TransactionTestCase):
 
         self.assertIn('deprecated', result)
         self.assertNotIn('trigger_rule', result)
+        
+        versionless = copy.deepcopy(self.main_definition)
+        del versionless['version']
+        self.assertDictEqual(result['definition'], versionless)
 
     def test_edit_simple(self):
         """Tests editing only the basic attributes of a recipe type"""


### PR DESCRIPTION
- [x] `manage.py test` passes
- [x] tests are included

### Affected app(s)
- Recipe

### Description of change
Fixed broken recipe type details serializer
