### PR TITLE
#1477 - v6 job-types API documentation for adding seed image

### DIFF
--- a/scale/docs/rest/v6/job_type.rst
+++ b/scale/docs/rest/v6/job_type.rst
@@ -451,6 +451,10 @@ Request: POST http://.../v6/job-types/
             "host_path": "/path/on/host"
           }
         },
+        "output_workspaces": {
+         "default": "workspace_1",
+         "outputs": {"output_1": "workspace_2"}
+        },
         "settings": {
           "DB_HOST": "som.host.name",
           "DB_PASS": "secret_password"
@@ -652,6 +656,10 @@ Request: POST http://.../v6/job-types/validation/
             "host_path": "/path/on/host"
           }
         },
+        "output_workspaces": {
+         "default": "workspace_1",
+         "outputs": {"output_1": "workspace_2"}
+        },
         "settings": {
           "DB_HOST": "som.host.name",
           "DB_PASS": "secret_password"
@@ -838,6 +846,10 @@ Request: PATCH http://.../v6/job-types/test/1.0.0/
             "type": "host",
             "host_path": "/path/on/host"
           }
+        },
+        "output_workspaces": {
+         "default": "workspace_1",
+         "outputs": {"output_1": "workspace_2"}
         },
         "settings": {
           "DB_HOST": "som.host.name",

--- a/scale/job/configuration/configuration.py
+++ b/scale/job/configuration/configuration.py
@@ -232,11 +232,15 @@ class JobConfiguration(object):
                 warnings.append(ValidationWarning('DEPRECATED_WORKSPACE', 'Workspace \'%s\' is deprecated' % name))
             # TODO: add RO/RW mode to workspaces and add warning if using a RO workspace for output
 
+        missing_workspace_names = []
         if not self.default_output_workspace:
             for name in seed_outputs:
                 if name not in self.output_workspaces:
-                    msg = 'Missing workspace for output \'%s\''
-                    raise InvalidJobConfiguration('MISSING_WORKSPACE', msg % name)
+                    missing_workspace_names.append(name)
+
+        if missing_workspace_names:
+            msg = 'Missing workspace for outputs \'%s\''
+            raise InvalidJobConfiguration('MISSING_WORKSPACE', msg % missing_workspace_names)
 
         return warnings
 

--- a/scale/job/configuration/configuration.py
+++ b/scale/job/configuration/configuration.py
@@ -236,7 +236,7 @@ class JobConfiguration(object):
             for name in seed_outputs:
                 if name not in self.output_workspaces:
                     msg = 'Missing workspace for output \'%s\''
-                    warnings.append(ValidationWarning('MISSING_WORKSPACE', msg % name))
+                    raise InvalidJobConfiguration('MISSING_WORKSPACE', msg % name)
 
         return warnings
 

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -2907,7 +2907,7 @@ class JobTypeManager(models.Manager):
             currentManifest = SeedManifest(job_type.manifest)
 
         if not configuration:
-            configuration = JobConfiguration()
+            configuration = job_type.get_job_configuration()
         configuration.validate(currentManifest)
         secrets = configuration.remove_secret_settings(currentManifest)
         job_type.configuration = convert_config_to_v6_json(configuration).get_dict()

--- a/scale/job/test/configuration/test_configuration.py
+++ b/scale/job/test/configuration/test_configuration.py
@@ -178,10 +178,9 @@ class TestJobConfiguration(TestCase):
         configuration = JobConfiguration()
 
         # No workspaces defined
-        warnings = configuration.validate(manifest)
-        self.assertEqual(len(warnings), 2)
-        self.assertEqual(warnings[0].name, 'MISSING_WORKSPACE')
-        self.assertEqual(warnings[1].name, 'MISSING_WORKSPACE')
+        with self.assertRaises(InvalidJobConfiguration) as context:
+            warnings = configuration.validate(manifest)
+        self.assertEqual(context.exception.error.name, 'MISSING_WORKSPACE')
 
         # Workspace does not exist
         configuration.default_output_workspace = 'workspace_1'
@@ -197,9 +196,9 @@ class TestJobConfiguration(TestCase):
         # Workspace is only defined for output_a
         configuration.default_output_workspace = None
         configuration.add_output_workspace('output_a', 'workspace_1')
-        warnings = configuration.validate(manifest)
-        self.assertEqual(len(warnings), 1)
-        self.assertEqual(warnings[0].name, 'MISSING_WORKSPACE')
+        with self.assertRaises(InvalidJobConfiguration) as context:
+            warnings = configuration.validate(manifest)
+        self.assertEqual(context.exception.error.name, 'MISSING_WORKSPACE')
 
         # Workspace defined for both outputs
         storage_test_utils.create_workspace(name='workspace_2')
@@ -240,10 +239,9 @@ class TestJobConfiguration(TestCase):
         configuration = JobConfiguration()
 
         # No workspaces defined for outputs
-        warnings = configuration.validate(manifest)
-        self.assertEqual(len(warnings), 2)
-        self.assertEqual(warnings[0].name, 'MISSING_WORKSPACE')
-        self.assertEqual(warnings[1].name, 'MISSING_WORKSPACE')
+        with self.assertRaises(InvalidJobConfiguration) as context:
+            warnings = configuration.validate(manifest)
+        self.assertEqual(context.exception.error.name, 'MISSING_WORKSPACE')
 
     def test_validate_priority(self):
         """Tests calling JobConfiguration.validate() to validate priority"""

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -2090,7 +2090,8 @@ class TestJobTypesPostViewV6(TestCase):
             'output_data': [],
             'shared_resources': [],
         }
-        
+
+        self.output_workspace = storage_test_utils.create_workspace()
         self.configuration = {
             'version': '6',
             'mounts': {
@@ -2099,6 +2100,7 @@ class TestJobTypesPostViewV6(TestCase):
                     'host_path': '/path/to/dted',
                     },
             },
+            'output_workspaces': {'default': self.output_workspace.name},
             'settings': {
                 'DB_HOST': 'scale',
             },
@@ -3136,6 +3138,7 @@ class TestJobTypeDetailsViewV6(TestCase):
 
         self.manifest = job_test_utils.COMPLETE_MANIFEST
 
+        self.output_workspace = storage_test_utils.create_workspace()
         self.configuration = {
             'version': '6',
             'mounts': {
@@ -3148,6 +3151,7 @@ class TestJobTypeDetailsViewV6(TestCase):
                     'host_path': '/path/to/dted',
                     },
             },
+            'output_workspaces': {'default': self.output_workspace.name},
             'settings': {
                 'DB_HOST': 'scale',
             },
@@ -3269,14 +3273,16 @@ class TestJobTypeRevisionsViewV6(TestCase):
         
         self.manifest = job_test_utils.COMPLETE_MANIFEST
 
+        self.output_workspace = storage_test_utils.create_workspace()
         self.configuration = {
-            'version': '2.0',
+            'version': '6',
             'mounts': {
                 'dted': {
                     'type': 'host',
                     'host_path': '/path/to/dted',
                     },
             },
+            'output_workspaces': {'default': self.output_workspace.name},
             'settings': {
                 'DB_HOST': 'scale',
             },
@@ -4130,10 +4136,9 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         results = json.loads(response.content)
-        self.assertTrue(results['is_valid'])
-        self.assertEqual(len(results['warnings']), 2)
-        self.assertEqual(results['warnings'][0]['name'], 'MISSING_WORKSPACE')
-        self.assertEqual(results['warnings'][1]['name'], 'MISSING_WORKSPACE')
+        self.assertFalse(results['is_valid'])
+        self.assertEqual(len(results['errors']), 1)
+        self.assertEqual(results['errors'][0]['name'], 'MISSING_WORKSPACE')
 
 
 class TestJobTypesStatusView(TestCase):

--- a/scale/job/test/utils.py
+++ b/scale/job/test/utils.py
@@ -476,9 +476,10 @@ def create_seed_job_type(manifest=None, priority=50, max_tries=3, max_scheduled=
 
     if not configuration:
         configuration = {
-            'version': '1.0',
-            'default_settings': {}
+            'version': '6',
+            'output_workspaces': {'default': storage_test_utils.create_workspace().name}
         }
+        configuration = JobConfigurationV6(config=configuration).get_dict()
 
     job_type = JobType.objects.create(name=manifest['job']['name'], version=manifest['job']['jobVersion'],
                                       manifest=manifest, priority=priority, timeout=manifest['job']['timeout'],


### PR DESCRIPTION
##### Checklist
- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

### Affected app(s)
- job

### Description of change
Added output workspaces example to api docs and updated configuration validation to report an error if a manifest has an output without a workspace.
