### PR TITLE
#1383 - Support for pinned resource reservations

### DIFF
--- a/scale/README.md
+++ b/scale/README.md
@@ -228,6 +228,7 @@ below for reference.
 
 | Env Var                     | Default Value                   | Meaning                                    |
 | --------------------------- | ------------------------------- | -------------------------------------------|
+| ACCEPTED_RESOURCE_ROLE      | MESOS_ROLE                      | Resource role to accept in offers          |
 | APPLICATION_GROUP           | None                            | Optional Marathon application group        |
 | CONFIG_URI                  | None                            | A URI or URL to docker credentials file    |
 | DCOS_PACKAGE_FRAMEWORK_NAME | None                            | Unique name for Scale cluster framework    |
@@ -237,6 +238,7 @@ below for reference.
 | LOGSTASH_DOCKER_IMAGE       | 'geoint/logstash-elastic-ha'    | Docker image for logstash                  |
 | MARATHON_APP_DOCKER_IMAGE   | 'geoint/scale'                  | Scale docker image name                    |
 | MESOS_MASTER_URL            | 'zk://localhost:2181/scale'     | Mesos master location                      |
+| MESOS_ROLE                  | '*'                             | Mesos Role to assume                       |
 | SCALE_BROKER_URL            | None                            | broker configuration for messaging         |
 | SCALE_DB_URL                | use link to `db` or 'localhost' | database host name                         |
 | SCALE_DB_NAME               | 'scale'                         | database name for scale                    |

--- a/scale/mesos_api/tasks.py
+++ b/scale/mesos_api/tasks.py
@@ -53,6 +53,9 @@ def _create_base_task(task):
     for resource in resources.resources:
         if resource.value > 0.0:
             task_resource = {}
+            if settings.ACCEPTED_RESOURCE_ROLE != '*':
+                task_resource['role'] = settings.ACCEPTED_RESOURCE_ROLE
+                task_resource['reservation'] = {'principal': settings.ACCEPTED_RESOURCE_ROLE}
             task_resource['name'] = resource.name
             task_resource['type'] = RESOURCE_TYPE_SCALAR
             task_resource['scalar'] = {'value': resource.value}

--- a/scale/pip/production.txt
+++ b/scale/pip/production.txt
@@ -11,7 +11,7 @@ jsonschema>=2.3,<3
 kombu>=4.0.2,<5
 psycopg2>=2.7.1,<3
 PyJWT>=1.6.1,<2
-marathon>=0.9.1,<1
+marathon>=0.11.0,<1
 mesoshttp>=0.3.0,<0.4
 pytz
 requests>=2.8.1,<3

--- a/scale/pip/requirements.txt
+++ b/scale/pip/requirements.txt
@@ -12,7 +12,7 @@ kombu>=4.0.2,<5
 psycopg2>=2.7.1,<3
 PyJWT>=1.6.1,<2
 pytz
-marathon>=0.9.1,<1
+marathon>=0.11.0,<1
 mesoshttp>=0.3.0,<0.4
 requests>=2.8.1,<3
 semver>=2.8.1,<2.9.0

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -25,7 +25,11 @@ DOCKER_VERSION = scale.__docker_version__
 MESOS_MASTER = os.getenv('MESOS_MASTER', 'zk://leader.mesos:2181/mesos')
 
 # We by default, use the '*' role, meaning all resources are unreserved offers are received
+# By default, use the '*' role, meaning all resources are unreserved offers are received
 MESOS_ROLE = os.getenv('MESOS_ROLE', '*')
+
+# By default, the accepted resources match reservations to the MESOS_ROLE
+ACCEPTED_RESOURCE_ROLE = os.getenv('ACCEPTED_RESOURCE_ROLE', MESOS_ROLE)
 
 # Placeholder for service secret that will be overridden in local_settings_docker
 SERVICE_SECRET = None

--- a/scale/scheduler/management/commands/scale_scheduler.py
+++ b/scale/scheduler/management/commands/scale_scheduler.py
@@ -63,7 +63,11 @@ class Command(BaseCommand):
         elif settings.PRINCIPAL and settings.SECRET:
             self.client.set_credentials(settings.PRINCIPAL, settings.SECRET)
 
+        mesos_role = settings.MESOS_ROLE
+        logger.info('Launching scheduler with role: %s' % mesos_role)
         self.client.set_role(settings.MESOS_ROLE)
+
+        logger.info('Accepting offers from role: %s' % settings.ACCEPTED_RESOURCE_ROLE)
 
         self.client.add_capability('GPU_RESOURCES')
 

--- a/scale/scheduler/scale_scheduler.py
+++ b/scale/scheduler/scale_scheduler.py
@@ -7,6 +7,7 @@ import logging
 import threading
 
 from django.utils.timezone import now
+from django.conf import settings
 
 from error.models import reset_error_cache
 from job.execution.manager import job_exe_mgr
@@ -24,7 +25,6 @@ from scheduler.cleanup.manager import cleanup_mgr
 from scheduler.initialize import initialize_system
 from scheduler.manager import scheduler_mgr
 from scheduler.messages.restart_scheduler import RestartScheduler
-from scheduler.models import Scheduler
 from scheduler.node.agent import Agent
 from scheduler.node.manager import node_mgr
 from scheduler.recon.manager import recon_mgr
@@ -234,6 +234,7 @@ class ScaleScheduler(object):
         agents = {}
         resource_offers = []
         total_resources = NodeResources()
+        skipped_roles = set()
         for offer in offers:
             offer = from_mesos_offer(offer)
             offer_id = offer.id.value
@@ -242,18 +243,35 @@ class ScaleScheduler(object):
             hostname = offer.hostname
             resource_list = []
             for resource in offer.resources:
-                if resource.type == RESOURCE_TYPE_SCALAR:  # This is the SCALAR type
-                    resource_list.append(ScalarResource(resource.name, resource.scalar.value))
-            resources = NodeResources(resource_list)
-            total_resources.add(resources)
-            agents[agent_id] = Agent(agent_id, hostname)
-            resource_offers.append(ResourceOffer(offer_id, agent_id, framework_id, resources, started))
+                # Only accept resource that are of SCALAR type and have a role matching our accept list
+                if resource.type == RESOURCE_TYPE_SCALAR:
+                    if resource.role in settings.ACCEPTED_RESOURCE_ROLE:
+                        logger.debug("Received scalar resource %s with value %i associated with role %s" %
+                                     (resource.name, resource.scalar.value, resource.role))
+                        resource_list.append(ScalarResource(resource.name, resource.scalar.value, resource.role))
+                    else:
+                        skipped_roles.add(resource.role)
+
+            logger.info("Number of resources: %i" % len(resource_list))
+
+            # Only register agent, if offers are being received
+            if len(resource_list) > 0:
+                resources = NodeResources(resource_list)
+                total_resources.add(resources)
+                agents[agent_id] = Agent(agent_id, hostname)
+                resource_offers.append(ResourceOffer(offer_id, agent_id, framework_id, resources, started))
+
+        logger.debug("Offer analysis complete with %i resource offers." % len(resource_offers))
 
         node_mgr.register_agents(agents.values())
+        logger.debug("Agents registered.")
         resource_mgr.add_new_offers(resource_offers)
+        logger.debug("Resource offers added.")
 
         num_offers = len(resource_offers)
         logger.info('Received %d offer(s) with %s from %d node(s)', num_offers, total_resources, len(agents))
+        if len(skipped_roles):
+            logger.warning('Skipped offers from roles that are not marked as accepted: %s', ','.join(skipped_roles))
         scheduler_mgr.add_new_offer_count(num_offers)
 
         duration = now() - started

--- a/scale/scheduler/scale_scheduler.py
+++ b/scale/scheduler/scale_scheduler.py
@@ -248,7 +248,7 @@ class ScaleScheduler(object):
                     if resource.role in settings.ACCEPTED_RESOURCE_ROLE:
                         logger.debug("Received scalar resource %s with value %i associated with role %s" %
                                      (resource.name, resource.scalar.value, resource.role))
-                        resource_list.append(ScalarResource(resource.name, resource.scalar.value, resource.role))
+                        resource_list.append(ScalarResource(resource.name, resource.scalar.value))
                     else:
                         skipped_roles.add(resource.role)
 

--- a/scale/scheduler/test/test_scheduler.py
+++ b/scale/scheduler/test/test_scheduler.py
@@ -3,7 +3,9 @@ from __future__ import unicode_literals
 
 import django
 
+from django.conf import settings
 from django.test.testcases import TransactionTestCase
+from mesoshttp.offers import Offer
 from mock import patch, Mock
 
 from messaging.backends.amqp import AMQPMessagingBackend
@@ -56,3 +58,54 @@ class TestScheduler(TransactionTestCase):
         reconcile_calls_after = mock_reconcile_running_jobs.call_count
         self.assertEqual(reconcile_calls_after - reconcile_calls_before, 1,
                          're-registering the scheduler should trigger a call to reconcile running jobs')
+
+    @patch('scheduler.manager.SchedulerManager.add_new_offer_count')
+    @patch('scheduler.resources.manager.ResourceManager.add_new_offers')
+    @patch('scheduler.node.manager.NodeManager.register_agents')
+    def test_offer_match_against_matched_and_unmatched(self, register_agents, add_new_offers, add_new_offer_count):
+        """Validate resource reservations that don't match with ACCEPTED_RESOURCE_ROLE are ignored"""
+
+        settings.ACCEPTED_RESOURCE_ROLE = 'service-account'
+
+        offers_json = {u'offers': {u'offers': [
+            {u'domain': {u'fault_domain': {u'region': {u'name': u'us-east-2'}, u'zone': {u'name': u'us-east-2a'}}},
+             u'url': {u'path': u'/slave(1)', u'scheme': u'http',
+                      u'address': {u'ip': u'172.12.4.140', u'hostname': u'172.12.4.140', u'port': 5051}},
+             u'hostname': u'172.12.4.140', u'framework_id': {u'value': u'6777f785-2d17-4a2c-9e06-2bf56efa3417-0003'},
+             u'agent_id': {u'value': u'6777f785-2d17-4a2c-9e06-2bf56efa3417-S3'},
+             u'id': {u'value': u'6777f785-2d17-4a2c-9e06-2bf56efa3417-O1693'}, u'resources': [
+                {u'role': u'service-account', u'scalar': {u'value': 4.0}, u'type': u'SCALAR', u'name': u'cpus',
+                 u'reservation': {u'principal': u'service-account'}}, {u'ranges': {
+                    u'range': [{u'begin': 1025, u'end': 2180}, {u'begin': 2182, u'end': 3887},
+                               {u'begin': 3889, u'end': 5049}, {u'begin': 5052, u'end': 8079},
+                               {u'begin': 8082, u'end': 8180}, {u'begin': 8182, u'end': 32000}]},
+                    u'role': u'service-account', u'type': u'RANGES',
+                    u'name': u'ports', u'reservation': {
+                        u'principal': u'service-account'}},
+                {u'role': u'service-account', u'scalar': {u'value': 119396.0}, u'type': u'SCALAR', u'name': u'disk',
+                 u'reservation': {u'principal': u'service-account'}},
+                {u'role': u'service-account', u'scalar': {u'value': 14861.0}, u'type': u'SCALAR', u'name': u'mem',
+                 u'reservation': {u'principal': u'service-account'}}]},
+            {u'domain': {u'fault_domain': {u'region': {u'name': u'us-east-2'}, u'zone': {u'name': u'us-east-2a'}}},
+             u'url': {u'path': u'/slave(1)', u'scheme': u'http',
+                      u'address': {u'ip': u'172.12.4.140', u'hostname': u'172.12.4.140', u'port': 5051}},
+             u'hostname': u'172.12.4.140', u'framework_id': {u'value': u'6777f785-2d17-4a2c-9e06-2bf56efa3417-0003'},
+             u'agent_id': {u'value': u'6777f785-2d17-4a2c-9e06-2bf56efa3417-S3'},
+             u'id': {u'value': u'6777f785-2d17-4a2c-9e06-2bf56efa3417-O1693'}, u'resources': [
+                {u'role': u'*', u'scalar': {u'value': 4.0}, u'type': u'SCALAR', u'name': u'cpus'}, {u'ranges': {
+                    u'range': [{u'begin': 1025, u'end': 2180}, {u'begin': 2182, u'end': 3887},
+                               {u'begin': 3889, u'end': 5049}, {u'begin': 5052, u'end': 8079},
+                               {u'begin': 8082, u'end': 8180}, {u'begin': 8182, u'end': 32000}]},
+                    u'role': u'*', u'type': u'RANGES',
+                    u'name': u'ports'},
+                {u'role': u'*', u'scalar': {u'value': 119396.0}, u'type': u'SCALAR', u'name': u'disk'},
+                {u'role': u'*', u'scalar': {u'value': 14861.0}, u'type': u'SCALAR', u'name': u'mem'}]}
+        ]}, u'type': u'OFFERS'}
+
+        offers = [Offer('', '', '', x) for x in offers_json['offers']['offers']]
+
+        ScaleScheduler().offers(offers)
+
+        register_agents.called_with(['6777f785-2d17-4a2c-9e06-2bf56efa3417-S3'])
+        add_new_offer_count.called_with(1)
+        self.assertEquals(add_new_offers.call_count, 1)


### PR DESCRIPTION
##### Checklist

- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

### Affected app(s)
- scheduler: updated offer evaluation logic 

### Description of change
- Added `ACCEPTED_RESOURCE_ROLE` environment variable that allows for specification of the resources that should be accepted upon offer. In the default case, MESOS_ROLE will be '*' and only unreserved resources will be consumed by Scale.
- Set `ACCEPTED_RESOURCE_ROLE` to default to the `MESOS_ROLE` environment value.
- Added unit test to validate only resources associated with accepted resource role are consume.
- Documented the use of `MESOS_ROLE` and `ACCEPTED_RESOURCE_ROLE` in the README.md.
- Documented configuration of DC/OS and Scale for using Mesos Roles in wiki entry: https://github.com/ngageoint/scale/wiki/DCOS-EE-and-Mesos-Roles


