### PR TITLE
#1482 Adding ID to v6 /job-type/ GET REST API results

### DIFF
--- a/scale/docs/rest/v6/job_type.rst
+++ b/scale/docs/rest/v6/job_type.rst
@@ -20,24 +20,25 @@ Request: GET http://.../v6/job-types/
 
 Response: 200 OK
 
- .. code-block:: javascript  
- 
-    { 
-        "count": 1, 
-        "next": null, 
-        "previous": null, 
-        "results": [ 
-            { 
+ .. code-block:: javascript
+
+    {
+        "count": 1,
+        "next": null,
+        "previous": null,
+        "results": [
+            {
+                "id": 3,
                 "name": "my-job",
-                "title": "My Job", 
-                "description": "A simple job type", 
-                "icon_code": "f013", 
-                "versions": ["1.0.0"], 
-                "latest_version": "1.0.0" 
+                "title": "My Job",
+                "description": "A simple job type",
+                "icon_code": "f013",
+                "versions": ["1.0.0"],
+                "latest_version": "1.0.0"
             }
-        ] 
-    } 
-    
+        ]
+    }
+
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Job Type Names**                                                                                                      |
 +=========================================================================================================================+
@@ -84,6 +85,8 @@ Response: 200 OK
 +--------------------------+-------------------+--------------------------------------------------------------------------+
 | results                  | Array             | List of result JSON objects that match the query parameters.             |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
+| .id                      | Integer           | The id of the job type.                                                  |
++--------------------------+-------------------+--------------------------------------------------------------------------+
 | .name                    | String            | The name of the job type.                                                |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
 | .title                   | String            | The human readable display name for the latest version of the job type.  |
@@ -108,35 +111,35 @@ Request: GET http://.../v6/job-types/{name}/
 
 Response: 200 OK
 
- .. code-block:: javascript  
- 
-    { 
-        "count": 2, 
-        "next": null, 
-        "previous": null, 
-        "results": [ 
-            { 
-                "id": 3, 
+ .. code-block:: javascript
+
+    {
+        "count": 2,
+        "next": null,
+        "previous": null,
+        "results": [
+            {
+                "id": 3,
                 "name": "my-job",
-                "version": "1.0.0" 
-                "title": "My Job", 
-                "description": "A simple job type", 
-                "icon_code": "f013", 
-                "is_active": true, 
-                "is_paused": false, 
-                "is_system": false, 
-                "max_scheduled": 1, 
-                "revision_num": 1, 
-                "docker_image": "my-job-1.0.0-seed:1.0.0", 
-                "created": "2015-03-11T00:00:00Z", 
-                "deprecated": null, 
-                "paused": null, 
-                "last_modified": "2015-03-11T00:00:00Z" 
-            }, 
-            ... 
-        ] 
-    } 
-    
+                "version": "1.0.0"
+                "title": "My Job",
+                "description": "A simple job type",
+                "icon_code": "f013",
+                "is_active": true,
+                "is_paused": false,
+                "is_system": false,
+                "max_scheduled": 1,
+                "revision_num": 1,
+                "docker_image": "my-job-1.0.0-seed:1.0.0",
+                "created": "2015-03-11T00:00:00Z",
+                "deprecated": null,
+                "paused": null,
+                "last_modified": "2015-03-11T00:00:00Z"
+            },
+            ...
+        ]
+    }
+
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Retrieve Job Type Versions**                                                                                          |
 +=========================================================================================================================+
@@ -215,29 +218,29 @@ Request: GET http://.../v6/job-types/{name}/{version}/
 
 Response: 200 OK
 
- .. code-block:: javascript  
- 
-    { 
-		"id": 3, 
-		"name": "my-job", 
-		"version": "1.0.0" 
-		"title": "My Job", 
-		"description": "A simple job type", 
-		"icon_code": "f013", 
-		"is_active": true, 
-		"is_paused": false, 
-		"is_system": false, 
-		"max_scheduled": 1, 
-		"revision_num": 1, 
-		"docker_image": "my-job-1.0.0-seed:1.0.0", 
-		"manifest": { ... }, 
+ .. code-block:: javascript
+
+    {
+		"id": 3,
+		"name": "my-job",
+		"version": "1.0.0"
+		"title": "My Job",
+		"description": "A simple job type",
+		"icon_code": "f013",
+		"is_active": true,
+		"is_paused": false,
+		"is_system": false,
+		"max_scheduled": 1,
+		"revision_num": 1,
+		"docker_image": "my-job-1.0.0-seed:1.0.0",
+		"manifest": { ... },
 		"configuration": { ... },
-		"created": "2015-03-11T00:00:00Z", 
-		"deprecated": null, 
-		"paused": null, 
-		"last_modified": "2015-03-11T00:00:00Z" 
-    } 
-    
+		"created": "2015-03-11T00:00:00Z",
+		"deprecated": null,
+		"paused": null,
+		"last_modified": "2015-03-11T00:00:00Z"
+    }
+
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Retrieve Job Type Details**                                                                                           |
 +=========================================================================================================================+
@@ -281,7 +284,7 @@ Response: 200 OK
 | docker_image             | String            | The Docker image containing the code to run for this job.                |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
 | manifest                 | String            | Seed manifest describing Job, interface and requirements.                |
-|                          |                   | (See :ref:`architecture_seed_manifest_spec`)                             | 
+|                          |                   | (See :ref:`architecture_seed_manifest_spec`)                             |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
 | configuration            | JSON Object       | JSON description of the configuration for running the job                |
 |                          |                   | (See :ref:`rest_v6_job_type_configuration`)                              |
@@ -306,8 +309,8 @@ Request: GET http://.../v6/job-types/{name}/{version}/revisions/
 
 Response: 200 OK
 
- .. code-block:: javascript  
- 
+ .. code-block:: javascript
+
     {
       "count": 1,
       "next": null,
@@ -328,7 +331,7 @@ Response: 200 OK
         }
       ]
     }
-    
+
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Retrieve Job Type Revisions**                                                                                         |
 +=========================================================================================================================+
@@ -382,8 +385,8 @@ Request: GET http://.../v6/job-types/{name}/{version}/revisions/{revision_num}/
 
 Response: 200 OK
 
- .. code-block:: javascript  
- 
+ .. code-block:: javascript
+
     {
       "id": 3,
       "job_type": {
@@ -398,7 +401,7 @@ Response: 200 OK
       "manifest": "",
       "created": "2015-03-11T00:00:00Z"
     }
-    
+
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Retrieve Job Type Revision Details**                                                                                  |
 +=========================================================================================================================+
@@ -424,7 +427,7 @@ Response: 200 OK
 | docker_image             | String            | The Docker image containing the code to run for this job.                |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
 | manifest                 | String            | Seed manifest describing Job, interface and requirements.                |
-|                          |                   | (See :ref:`architecture_seed_manifest_spec`)                             | 
+|                          |                   | (See :ref:`architecture_seed_manifest_spec`)                             |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
 | created                  | ISO-8601 Datetime | When the associated database model was initially created.                |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
@@ -439,7 +442,7 @@ v6 Add Seed Image
 Request: POST http://.../v6/job-types/
 
  .. code-block:: javascript
- 
+
      {
       "icon_code": "f1c5",
       "max_scheduled": 1,
@@ -572,33 +575,33 @@ Request: POST http://.../v6/job-types/
       },
       "auto_update": true
     }
-    
+
 Response: 201 CREATED
 Headers:
 Location http://.../v6/job-types/test/1.0.0/
 
- .. code-block:: javascript  
- 
-    { 
-		"id": 3, 
-		"name": "test", 
-		"version": "1.0.0" 
-		"title": "Job to demonstrate job type APIs", 
-		"description": "Reads input file and spit out specified number of bytes as output", 
-		"icon_code": "f1c5", 
-		"is_active": true, 
-		"is_paused": false, 
-		"is_system": false, 
-		"max_scheduled": 1, 
-		"revision_num": 1, 
-		"docker_image": "test-1.0.0-seed:1.0.0", 
-		"manifest": { ... }, 
+ .. code-block:: javascript
+
+    {
+		"id": 3,
+		"name": "test",
+		"version": "1.0.0"
+		"title": "Job to demonstrate job type APIs",
+		"description": "Reads input file and spit out specified number of bytes as output",
+		"icon_code": "f1c5",
+		"is_active": true,
+		"is_paused": false,
+		"is_system": false,
+		"max_scheduled": 1,
+		"revision_num": 1,
+		"docker_image": "test-1.0.0-seed:1.0.0",
+		"manifest": { ... },
 		"configuration": { ... },
-		"created": "2015-03-11T00:00:00Z", 
-		"deprecated": null, 
-		"paused": null, 
-		"last_modified": "2015-03-11T00:00:00Z" 
-    } 
+		"created": "2015-03-11T00:00:00Z",
+		"deprecated": null,
+		"paused": null,
+		"last_modified": "2015-03-11T00:00:00Z"
+    }
 
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Add Seed Image**                                                                                                      |
@@ -647,7 +650,7 @@ v6 Validate Job Type
 Request: POST http://.../v6/job-types/validation/
 
  .. code-block:: javascript
- 
+
      {
       "configuration": {
         "mounts": {
@@ -776,7 +779,7 @@ Request: POST http://.../v6/job-types/validation/
         }
       }
     }
-    
+
 Response: 200 OK
 
 .. code-block:: javascript
@@ -786,7 +789,7 @@ Response: 200 OK
       "errors": [],
       "warnings": [{"name": "EXAMPLE_WARNING", "description": "This is an example warning."}]
    }
-   
+
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Validate Job Type**                                                                                                   |
 +=========================================================================================================================+
@@ -834,7 +837,7 @@ v6 Edit Job Type
 Request: PATCH http://.../v6/job-types/test/1.0.0/
 
  .. code-block:: javascript
- 
+
     {
       "icon_code": "012F",
       "is_active": true,

--- a/scale/docs/rest/v6/job_type.yml
+++ b/scale/docs/rest/v6/job_type.yml
@@ -46,7 +46,7 @@ paths:
         '200':
           description: 200 response
           content:
-            application/json: 
+            application/json:
               schema:
                 $ref: '#/components/schemas/job_type_list'
     post:
@@ -56,7 +56,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json: 
+          application/json:
             schema:
               $ref: '#/components/schemas/job_type_post'
       responses:
@@ -68,7 +68,7 @@ paths:
                 type: string
               description: The url of the created/edited job type
           content:
-            application/json: 
+            application/json:
               schema:
                 $ref: '#/components/schemas/job_type_detail'
   /job-types/{name}/:
@@ -102,7 +102,7 @@ paths:
         '200':
           description: 200 response
           content:
-            application/json: 
+            application/json:
               schema:
                 $ref: '#/components/schemas/job_type_versions'
   /job-types/{name}/{version}/:
@@ -125,7 +125,7 @@ paths:
         '200':
           description: 200 response
           content:
-            application/json: 
+            application/json:
               schema:
                 $ref: '#/components/schemas/job_type_detail'
     patch:
@@ -135,7 +135,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json: 
+          application/json:
             schema:
               $ref: '#/components/schemas/job_type_update'
       parameters:
@@ -183,7 +183,7 @@ paths:
         '200':
           description: 200 response
           content:
-            application/json: 
+            application/json:
               schema:
                 $ref: '#/components/schemas/job_type_revisions'
   /job-types/{name}/{version}/revisions/{revision_num}/:
@@ -211,7 +211,7 @@ paths:
         '200':
           description: 200 response
           content:
-            application/json: 
+            application/json:
               schema:
                 $ref: '#/components/schemas/job_type_revision_detail'
 
@@ -223,14 +223,14 @@ paths:
       requestBody:
         required: true
         content:
-          application/json: 
+          application/json:
             schema:
               $ref: '#/components/schemas/job_type_validation_post'
       responses:
         '200':
           description: The 200 OK response indicates a successful event
           content:
-            application/json: 
+            application/json:
               schema:
                 $ref: '#/components/schemas/job_type_validation'
 components:
@@ -241,7 +241,7 @@ components:
       properties:
         count:
           type: integer
-          description: The total number of results that match the query parameters 
+          description: The total number of results that match the query parameters
           example: 10
         next:
           type: string
@@ -262,6 +262,9 @@ components:
       title: Job Type Name
       type: object
       properties:
+        id:
+          type: integer
+          example: 3
         name:
           type: string
           example: my-job
@@ -270,15 +273,15 @@ components:
           example: My Job
         description:
           type: string
-          example: My Job Description 
+          example: My Job Description
         icon_code:
           type: string
-          example: f186 
+          example: f186
         versions:
           type: array
           style: simple
           items:
-            type: string 
+            type: string
           example: ["1.1.0"]
         latest_version:
           type: string
@@ -298,17 +301,17 @@ components:
           example: My Job
         description:
           type: string
-          example: My Job Description 
+          example: My Job Description
         icon_code:
           type: string
-          example: f186 
+          example: f186
     job_type_versions:
       title: Job Type Versions
       type: object
       properties:
         count:
           type: integer
-          description: The total number of results that match the query parameters 
+          description: The total number of results that match the query parameters
           example: 10
         next:
           type: string
@@ -343,10 +346,10 @@ components:
           example: My Job
         description:
           type: string
-          example: My Job Type Description 
+          example: My Job Type Description
         icon_code:
           type: string
-          example: f186 
+          example: f186
         is_active:
           type: boolean
           example: true
@@ -390,7 +393,7 @@ components:
       allOf:
         - ref: '#/components/schemas/job_type'
         - type: object
-          properties: 
+          properties:
             manifest:
               $ref: '../../../job/seed/schema/seed.manifest.schema.json'
             configuration:
@@ -472,14 +475,14 @@ components:
             is the unique name of the workspace to use.
           additionalPropterties:
             type: string
-            
+
     job_type_revisions:
       title: Job Type Revision List
       type: object
       properties:
         count:
           type: integer
-          description: The total number of results that match the query parameters 
+          description: The total number of results that match the query parameters
           example: 10
         next:
           type: string
@@ -502,7 +505,7 @@ components:
       properties:
         id:
           type: integer
-          description: The unique identifier of the model. Can be passed to the details API call 
+          description: The unique identifier of the model. Can be passed to the details API call
           example: 4
     job_type_revision_base:
       title: Job Type Revision Base
@@ -510,7 +513,7 @@ components:
       properties:
         id:
           type: integer
-          description: The unique identifier of the model. Can be passed to the details API call 
+          description: The unique identifier of the model. Can be passed to the details API call
           example: 4
         job_type:
           $ref: '#/components/schemas/model'
@@ -522,7 +525,7 @@ components:
       allOf:
         - ref: '#/components/schemas/job_type_revision_base'
         - type: object
-          properties:   
+          properties:
           job_type:
             $ref: '#/components/schemas/job_type_base'
           docker_image:
@@ -539,7 +542,7 @@ components:
       properties:
         id:
           type: integer
-          description: The unique identifier of the model. Can be passed to the details API call 
+          description: The unique identifier of the model. Can be passed to the details API call
           example: 4
         job_type:
           $ref: '#/components/schemas/job_type_base'
@@ -556,14 +559,14 @@ components:
           example: 2015-09-10T15:24:53.503Z
         manifest:
          $ref: '../../../job/seed/schema/seed.manifest.schema.json'
-          
+
     job_type_update:
       title: Job Type Update
       type: object
       properties:
         icon_code:
           type: string
-          example: f186 
+          example: f186
         is_active:
           type: boolean
           example: true
@@ -575,14 +578,14 @@ components:
           example: 1
         configuration:
           $ref: '#/components/schemas/job_type_config'
-      
+
     job_type_post:
       title: Job Type Create/Edit
       type: object
       properties:
         icon_code:
           type: string
-          example: f186 
+          example: f186
         max_scheduled:
           type: integer
           example: 1
@@ -600,18 +603,18 @@ components:
       required:
       - docker_image
       - manifest
-      
+
     job_type_validation_post:
       title: Job Type Validation Post
       type: object
-      properties: 
+      properties:
         manifest:
           $ref: '../../../job/seed/schema/seed.manifest.schema.json'
         configuration:
           $ref: '#/components/schemas/job_type_config'
       required:
       - manifest
-      
+
     job_type_validation:
       title: Job Type Validation
       type: object

--- a/scale/job/job_type_serializers.py
+++ b/scale/job/job_type_serializers.py
@@ -40,7 +40,7 @@ class JobTypeBaseSerializerV6(ModelIdSerializer):
 
 class JobTypeListSerializerV6(JobTypeBaseSerializerV6):
     """Converts job type model fields to REST output"""
-    id = None
+    id = serializers.IntegerField()
     version = None
     versions = serializers.ListField(child=serializers.CharField())
     latest_version = serializers.CharField(source='version')

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -33,7 +33,7 @@ import util.rest as rest_util
 class TestJobsViewV5(TestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -229,10 +229,10 @@ class TestJobsViewV5(TestCase):
 class TestJobsViewV6(TestCase):
 
     api = 'v6'
-    
+
     def setUp(self):
         django.setup()
-        
+
         self.date_1 = datetime.datetime(2016, 1, 1, tzinfo=utc)
         self.date_2 = datetime.datetime(2016, 1, 2, tzinfo=utc)
         self.date_3 = datetime.datetime(2016, 1, 2, tzinfo=utc)
@@ -245,17 +245,17 @@ class TestJobsViewV6(TestCase):
         self.s_sensor2 = '2'
         self.collection2 = '123456'
         self.task2 = 'abcde'
-        
+
         self.workspace = storage_test_utils.create_workspace()
         self.file_1 = storage_test_utils.create_file(workspace=self.workspace, file_size=104857600.0,
                                                 source_started=self.date_1, source_ended=self.date_2,
                                                 source_sensor_class=self.s_class, source_sensor=self.s_sensor,
                                                 source_collection=self.collection, source_task=self.task)
-        self.file_2 = storage_test_utils.create_file(workspace=self.workspace, file_size=0.154, 
+        self.file_2 = storage_test_utils.create_file(workspace=self.workspace, file_size=0.154,
                                                  source_started=self.date_3, source_ended=self.date_4,
                                                  source_sensor_class=self.s_class2, source_sensor=self.s_sensor2,
                                                  source_collection=self.collection2, source_task=self.task2)
-        
+
         self.data_1 = {
             'version': '1.0',
             'input_data': [{
@@ -286,7 +286,7 @@ class TestJobsViewV6(TestCase):
         manifest2['job']['name'] = 'test2'
         self.job_type2 = job_test_utils.create_seed_job_type(manifest=manifest2)
         self.job2 = job_test_utils.create_job(job_type=self.job_type2, status='PENDING', input=self.data_2, input_file_size=None)
-        
+
         Job.objects.process_job_input(self.job1)
         Job.objects.process_job_input(self.job2)
 
@@ -364,7 +364,7 @@ class TestJobsViewV6(TestCase):
     def test_source_time_successful(self):
         """Tests successfully calling the get jobs by source time"""
 
-        url = '/%s/jobs/?source_started=%s&source_ended=%s' % ( self.api, 
+        url = '/%s/jobs/?source_started=%s&source_ended=%s' % ( self.api,
                                                                  '2016-01-01T00:00:00Z',
                                                                  '2016-01-02T00:00:00Z')
         response = self.client.get(url)
@@ -386,7 +386,7 @@ class TestJobsViewV6(TestCase):
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['source_sensor_class'], self.s_class)
-        
+
     def test_source_sensor(self):
         """Tests successfully calling the jobs view filtered by source sensor."""
 
@@ -397,29 +397,29 @@ class TestJobsViewV6(TestCase):
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['source_sensor'], self.s_sensor)
-        
+
     def test_source_collection(self):
         """Tests successfully calling the jobs view filtered by source collection."""
 
         url = '/%s/jobs/?source_collection=%s' % (self.api, self.collection)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
-        
+
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['source_collection'], self.collection)
-        
+
     def test_source_task(self):
         """Tests successfully calling the jobs view filtered by source task."""
 
         url = '/%s/jobs/?source_task=%s' % (self.api, self.task)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
-        
+
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['source_task'], self.task)
-        
+
     def test_status(self):
         """Tests successfully calling the jobs view filtered by status."""
 
@@ -479,7 +479,7 @@ class TestJobsViewV6(TestCase):
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['id'], job.id)
         self.assertEqual(result['results'][0]['error']['category'], error.category)
-        
+
     def test_error_id(self):
         """Tests successfully calling the jobs view filtered by error id."""
 
@@ -518,7 +518,7 @@ class TestJobsViewV6(TestCase):
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['id'], self.job1.id)
-        
+
     def test_recipe(self):
         """Tests filtering jobs by recipe"""
         recipe = recipe_test_utils.create_recipe()
@@ -554,7 +554,7 @@ class TestJobsViewV6(TestCase):
         self.assertEqual(result['results'][3]['job_type']['id'], self.job_type2.id)
 
 class TestJobsPostViewV6(TestCase):
-    
+
     api = "v6"
 
     def setUp(self):
@@ -584,9 +584,9 @@ class TestJobsPostViewV6(TestCase):
                 }
             }
         }
-        
+
         self.output_workspace = storage_test_utils.create_workspace()
-            
+
         self.configuration = {
             'version': '6',
             'output_workspaces': {'default': self.output_workspace.name},
@@ -604,10 +604,10 @@ class TestJobsPostViewV6(TestCase):
 
         json_data = {
             "input" : {
-                'version': '6', 
+                'version': '6',
                 'files': {'input_a': [self.source_file.id]},
                 'json': {}
-            }, 
+            },
             "job_type_id" : self.job_type1.pk
         }
 
@@ -621,7 +621,7 @@ class TestJobsPostViewV6(TestCase):
         self.assertEqual(result['execution'], None)
         self.assertTrue('/%s/jobs/' % self.api in response['location'])
         mock_create.assert_called_once()
-        
+
     @patch('queue.models.CommandMessageManager')
     @patch('queue.models.create_process_job_input_messages')
     def test_successful_configuration(self, mock_create, mock_msg_mgr):
@@ -629,10 +629,10 @@ class TestJobsPostViewV6(TestCase):
 
         json_data = {
             "input" : {
-                'version': '6', 
+                'version': '6',
                 'files': {'input_a': [self.source_file.id]},
                 'json': {}
-            }, 
+            },
             "job_type_id" : self.job_type1.pk,
             "configuration" : self.configuration
         }
@@ -647,16 +647,16 @@ class TestJobsPostViewV6(TestCase):
         self.assertEqual(result['execution'], None)
         self.assertTrue('/%s/jobs/' % self.api in response['location'])
         mock_create.assert_called_once()
-        
+
     def test_invalid_data(self):
         """Tests successfully calling POST jobs view to queue a new job with invalid input data"""
 
         json_data = {
             "input" : {
-                'version': 'BAD', 
+                'version': 'BAD',
                 'files': {'input_a': [self.source_file.id]},
                 'json': {}
-            }, 
+            },
             "job_type_id" : self.job_type1.pk,
             "configuration" : self.configuration
         }
@@ -664,7 +664,7 @@ class TestJobsPostViewV6(TestCase):
         url = '/%s/jobs/' % self.api
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
-        
+
     def test_invalid_configuration(self):
         """Tests successfully calling POST jobs view to queue a new job with a job type configuration"""
 
@@ -672,10 +672,10 @@ class TestJobsPostViewV6(TestCase):
         config['version'] = 'BAD'
         json_data = {
             "input" : {
-                'version': '6', 
+                'version': '6',
                 'files': {'input_a': [self.source_file.id]},
                 'json': {}
-            }, 
+            },
             "job_type_id" : self.job_type1.pk,
             "configuration" : config
         }
@@ -689,7 +689,7 @@ class TestJobsPostViewV6(TestCase):
 class OldTestJobDetailsViewV5(TestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -958,7 +958,7 @@ class OldTestJobDetailsViewV5(TestCase):
 class TestJobDetailsViewV6(TestCase):
 
     api = 'v6'
-    
+
     def setUp(self):
         django.setup()
 
@@ -1124,7 +1124,7 @@ class TestJobDetailsViewV6(TestCase):
 class TestJobsUpdateView(TestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -1223,9 +1223,9 @@ class TestJobsUpdateView(TestCase):
 
 
 class TestJobTypesViewV5(TestCase):
-    
+
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -1896,9 +1896,9 @@ class TestJobTypesViewV5(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
 
 class TestJobTypesViewV6(TestCase):
-    
+
     api = 'v6'
-    
+
     def setUp(self):
         django.setup()
 
@@ -1932,6 +1932,8 @@ class TestJobTypesViewV6(TestCase):
                 expected = self.job_type6
             else:
                 self.fail('Found unexpected result: %s' % entry['id'])
+
+            self.assertEqual(entry['id'], expected.id)
             self.assertEqual(entry['name'], expected.name)
             self.assertEqual(entry['title'], expected.title)
             self.assertEqual(entry['description'], expected.description)
@@ -1964,13 +1966,13 @@ class TestJobTypesViewV6(TestCase):
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['latest_version'], '1.10.0')
-        
+
         url = '/%s/job-types/?keyword=%s&keyword=%s' % (self.api, 'job-type-for-view-test', self.job_type1.name)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 2)
-        
+
     def test_id(self):
         """Tests successfully calling the job types view filtered by id."""
 
@@ -2002,7 +2004,7 @@ class TestJobTypesViewV6(TestCase):
 
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 2)
-        
+
     def test_is_system(self):
         """Tests successfully calling the job types view filtered by system status."""
 
@@ -2012,14 +2014,14 @@ class TestJobTypesViewV6(TestCase):
 
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 3)
-        
+
         url = '/%s/job-types/?is_system=true' % self.api
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 1)
-        
+
     def test_version_successful(self):
         """Tests successfully calling the job type versions view."""
 
@@ -2050,7 +2052,7 @@ class TestJobTypesViewV6(TestCase):
             self.assertEqual(entry['max_scheduled'], expected.max_scheduled)
             self.assertEqual(entry['revision_num'], expected.revision_num)
             self.assertEqual(entry['docker_image'], expected.docker_image)
-            
+
     def test_version_is_active(self):
         """Tests successfully calling the job type versions view filtered by inactive state."""
 
@@ -2062,14 +2064,14 @@ class TestJobTypesViewV6(TestCase):
         self.assertEqual(len(result['results']), 1)
 
 class TestJobTypesPostViewV6(TestCase):
-    
+
     api = 'v6'
-    
+
     def setUp(self):
         django.setup()
-        
+
         self.manifest = job_test_utils.COMPLETE_MANIFEST
-        
+
         self.interface = {
             'version': '1.4',
             'command': 'test_cmd',
@@ -2120,10 +2122,10 @@ class TestJobTypesPostViewV6(TestCase):
         self.trigger_rule = trigger_test_utils.create_trigger_rule(trigger_type='PARSE', is_active=True,
                                                                    configuration=self.trigger_config)
 
-        self.job_type = job_test_utils.create_seed_job_type(manifest=self.manifest, 
+        self.job_type = job_test_utils.create_seed_job_type(manifest=self.manifest,
                                                        trigger_rule=self.trigger_rule, max_scheduled=2,
                                                        configuration=self.configuration)
-        
+
         self.error = error_test_utils.create_error(category='ALGORITHM')
         self.error_mapping = {
             'version': '1.0',
@@ -2135,10 +2137,10 @@ class TestJobTypesPostViewV6(TestCase):
                                                        interface=self.interface, error_mapping=self.error_mapping,
                                                        trigger_rule=self.trigger_rule, max_scheduled=2,
                                                        configuration=self.configuration)
-        
+
         self.job_type1 = job_test_utils.create_seed_job_type(manifest=job_test_utils.MINIMUM_MANIFEST)
         self.job_type2 = job_test_utils.create_seed_job_type()
-        
+
         self.sub_definition = copy.deepcopy(recipe_test_utils.SUB_RECIPE_DEFINITION)
         self.sub_definition['nodes']['node_a']['node_type']['job_type_name'] = self.job_type1.name
         self.sub_definition['nodes']['node_a']['node_type']['job_type_version'] = self.job_type1.version
@@ -2163,21 +2165,21 @@ class TestJobTypesPostViewV6(TestCase):
                                                                     title="My main recipe",
                                                                     is_active=True,
                                                                     is_system=True)
-        
+
     def test_add_seed_job_type(self):
         """Tests adding a seed image."""
-        
+
         url = '/%s/job-types/' % self.api
         manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
         manifest['job']['name'] = 'my-new-job'
-        
+
         json_data = {
             'icon_code': 'BEEF',
             'docker_image': 'my-new-job-1.0.0-seed:1.0.0',
             'manifest': manifest,
             'configuration': self.configuration
         }
-        
+
         good_setting = {
             'DB_HOST': 'scale'
         }
@@ -2225,11 +2227,11 @@ class TestJobTypesPostViewV6(TestCase):
 
     def test_add_seed_version_job_type(self):
         """Tests adding a new version of a seed image."""
-        
+
         url = '/%s/job-types/' % self.api
         manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
         manifest['job']['jobVersion'] = '1.1.0'
-        
+
         json_data = {
             'icon_code': 'BEEF',
             'max_scheduled': 1,
@@ -2237,7 +2239,7 @@ class TestJobTypesPostViewV6(TestCase):
             'manifest': manifest,
             'configuration': self.configuration
         }
-        
+
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
         self.assertTrue('/%s/job-types/my-job/1.1.0/' % self.api in response['location'])
@@ -2251,14 +2253,14 @@ class TestJobTypesPostViewV6(TestCase):
         self.assertEqual(results['title'], job_type.title)
         self.assertIsNotNone(results['configuration']['mounts'])
         self.assertIsNotNone(results['configuration']['settings'])
-        
+
     def test_edit_seed_job_type(self):
         """Tests editing an existing seed job type."""
-        
+
         url = '/%s/job-types/' % self.api
         manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
         manifest['job']['packageVersion'] = '1.0.1'
-        
+
         json_data = {
             'icon_code': 'BEEF',
             'max_scheduled': 1,
@@ -2266,7 +2268,7 @@ class TestJobTypesPostViewV6(TestCase):
             'manifest': manifest,
             'configuration': self.configuration
         }
-        
+
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
         self.assertTrue('/%s/job-types/my-job/1.0.0/' % self.api in response['location'])
@@ -2282,9 +2284,9 @@ class TestJobTypesPostViewV6(TestCase):
         self.assertEqual(results['revision_num'], 2)
         self.assertIsNotNone(results['configuration']['mounts'])
         self.assertIsNotNone(results['configuration']['settings'])
-        
+
         manifest['job']['maintainer'].pop('url')
-        
+
         json_data = {
             'icon_code': 'BEEF',
             'max_scheduled': 1,
@@ -2292,7 +2294,7 @@ class TestJobTypesPostViewV6(TestCase):
             'manifest': manifest,
             'configuration': self.configuration
         }
-        
+
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
         self.assertTrue('/%s/job-types/my-job/1.0.0/' % self.api in response['location'])
@@ -2302,17 +2304,17 @@ class TestJobTypesPostViewV6(TestCase):
         results = json.loads(response.content)
         self.assertEqual(results['id'], job_type.id)
         self.assertIsNone(results['manifest']['job']['maintainer'].get('url'))
-        
+
     def test_edit_old_job_type(self):
         """Tests editing an existing seed job type and updating it to a seed-compliant one."""
-        
+
         url = '/%s/job-types/' % self.api
         manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
         name = self.old_job_type.name
         version = self.old_job_type.version
         manifest['job']['name'] = name
         manifest['job']['jobVersion'] = version
-        
+
         json_data = {
             'icon_code': 'BEEF',
             'max_scheduled': 1,
@@ -2320,7 +2322,7 @@ class TestJobTypesPostViewV6(TestCase):
             'manifest': manifest,
             'configuration': self.configuration
         }
-        
+
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
         self.assertTrue('/%s/job-types/%s/%s/' % (self.api, name, version) in response['location'])
@@ -2339,7 +2341,7 @@ class TestJobTypesPostViewV6(TestCase):
 
     def test_create_seed_secrets(self):
         """Tests creating a new seed job type with secrets."""
-        
+
         url = '/%s/job-types/' % self.api
         manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
         name = 'job-type-post-test-secret'
@@ -2358,7 +2360,7 @@ class TestJobTypesPostViewV6(TestCase):
               'secret': True
             }
           ]
-        
+
         json_data = {
             'icon_code': 'BEEF',
             'max_scheduled': 1,
@@ -2366,7 +2368,7 @@ class TestJobTypesPostViewV6(TestCase):
             'manifest': manifest,
             'configuration': self.configuration
         }
-        
+
         with patch.object(SecretsHandler, '__init__', return_value=None), \
           patch.object(SecretsHandler, 'set_job_type_secrets', return_value=None) as mock_set_secret:
             response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
@@ -2393,11 +2395,11 @@ class TestJobTypesPostViewV6(TestCase):
         manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
         manifest['job']['name'] = 'my-job-no-mount'
         manifest['job']['interface']['mounts'] = []
-        
+
         config = copy.deepcopy(self.configuration)
         #TODO investigate whether mounts in config but not manifest should be removed
         config['mounts'] = {}
-        
+
         json_data = {
             'icon_code': 'BEEF',
             'max_scheduled': 1,
@@ -2425,7 +2427,7 @@ class TestJobTypesPostViewV6(TestCase):
         config = copy.deepcopy(self.configuration)
         #TODO investigate whether settings in config but not manifest should be removed
         config['settings'] = {}
-        
+
         json_data = {
             'icon_code': 'BEEF',
             'max_scheduled': 1,
@@ -2466,7 +2468,7 @@ class TestJobTypesPostViewV6(TestCase):
         url = '/%s/job-types/' % self.api
         manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
         manifest['job']['name'] = 'my-job-bad-parameter'
-        
+
         json_data = {
             'icon_code': 'BEEF',
             'max_scheduled': 'BAD',
@@ -2482,11 +2484,11 @@ class TestJobTypesPostViewV6(TestCase):
     @patch('recipe.messages.update_recipe_definition.create_job_update_recipe_definition_message')
     def test_edit_seed_job_type_and_update(self, mock_create, mock_msg_mgr):
         """Tests editing an existing seed job type and automatically updating recipes."""
-        
+
         url = '/%s/job-types/' % self.api
         manifest = copy.deepcopy(job_test_utils.MINIMUM_MANIFEST)
         manifest['job']['packageVersion'] = '1.0.1'
-        
+
         json_data = {
             'icon_code': 'BEEF',
             'max_scheduled': 1,
@@ -2495,7 +2497,7 @@ class TestJobTypesPostViewV6(TestCase):
             'configuration': self.configuration,
             'auto_update': True
         }
-        
+
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
         self.assertTrue('/%s/job-types/my-minimum-job/1.0.0/' % self.api in response['location'])
@@ -2511,15 +2513,15 @@ class TestJobTypesPostViewV6(TestCase):
         self.assertEqual(results['revision_num'], 2)
         self.assertIsNotNone(results['configuration']['mounts'])
         self.assertIsNotNone(results['configuration']['settings'])
-        
+
         recipe_type = RecipeType.objects.get(pk=self.recipe_type1.id)
         mock_create.assert_called_with(self.recipe_type1.id, job_type.id)
-        
+
 
 class TestJobTypeDetailsViewV5(TestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -2582,9 +2584,9 @@ class TestJobTypeDetailsViewV5(TestCase):
         self.job_type = job_test_utils.create_job_type(interface=self.interface, error_mapping=self.error_mapping,
                                                        trigger_rule=self.trigger_rule, max_scheduled=2,
                                                        configuration=self.configuration)
-                                                       
+
         self.seed_job_type = job_test_utils.create_seed_job_type()
-        
+
         self.error1 = error_test_utils.create_error()
         self.error2 = error_test_utils.create_error()
 
@@ -3018,7 +3020,7 @@ class TestJobTypeDetailsViewV5(TestCase):
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
-        
+
     def test_edit_seed_configuration(self):
         """Tests editing the configuration of a seed job type"""
         configuration = self.configuration.copy()
@@ -3063,7 +3065,7 @@ class TestJobTypeDetailsViewV5(TestCase):
         self.assertEqual(result['icon_code'], 'BEEF')
         self.assertTrue(result['is_paused'])
         self.assertEqual(result['max_scheduled'], 9)
-        
+
     def test_edit_seed_invalid_field(self):
         """Tests updating an invalid seed field"""
         url = '/%s/job-types/%d/' % (self.api, self.seed_job_type.id)
@@ -3076,7 +3078,7 @@ class TestJobTypeDetailsViewV5(TestCase):
 
     def test_get_seed_job_type_v5(self):
         """Tests getting a Seed job from the v5 API"""
-        
+
         manifest = job_test_utils.COMPLETE_MANIFEST
         expected_cmd_args = "${CUSTOM_COMMAND}"
         manifest['job']['interface']['command'] = expected_cmd_args
@@ -3132,7 +3134,7 @@ class TestJobTypeDetailsViewV5(TestCase):
 class TestJobTypeDetailsViewV6(TestCase):
 
     api = 'v6'
-    
+
     def setUp(self):
         django.setup()
 
@@ -3171,12 +3173,12 @@ class TestJobTypeDetailsViewV6(TestCase):
         self.trigger_rule = trigger_test_utils.create_trigger_rule(trigger_type='PARSE', is_active=True,
                                                                    configuration=self.trigger_config)
 
-        self.job_type = job_test_utils.create_seed_job_type(manifest=self.manifest, 
+        self.job_type = job_test_utils.create_seed_job_type(manifest=self.manifest,
                                                        trigger_rule=self.trigger_rule, max_scheduled=2,
                                                        configuration=self.configuration)
 
         self.old_job_type = job_test_utils.create_job_type()
-        
+
     def test_not_found(self):
         """Tests calling the get job type details view with a job name/version that does not exist."""
 
@@ -3190,7 +3192,7 @@ class TestJobTypeDetailsViewV6(TestCase):
         url = '/%s/job-types/%s/%s/' % (self.api, self.old_job_type.name, self.old_job_type.version)
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
-    
+
     def test_successful(self):
         """Tests successfully calling the get job type details view."""
 
@@ -3220,7 +3222,7 @@ class TestJobTypeDetailsViewV6(TestCase):
         }
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
-        
+
     def test_edit_simple(self):
         """Tests editing only the basic attributes of a job type"""
 
@@ -3267,10 +3269,10 @@ class TestJobTypeDetailsViewV6(TestCase):
 class TestJobTypeRevisionsViewV6(TestCase):
 
     api = 'v6'
-    
+
     def setUp(self):
         django.setup()
-        
+
         self.manifest = job_test_utils.COMPLETE_MANIFEST
 
         self.output_workspace = storage_test_utils.create_workspace()
@@ -3302,10 +3304,10 @@ class TestJobTypeRevisionsViewV6(TestCase):
         self.trigger_rule = trigger_test_utils.create_trigger_rule(trigger_type='PARSE', is_active=True,
                                                                    configuration=self.trigger_config)
 
-        self.job_type = job_test_utils.create_seed_job_type(manifest=self.manifest, 
+        self.job_type = job_test_utils.create_seed_job_type(manifest=self.manifest,
                                                        trigger_rule=self.trigger_rule, max_scheduled=2,
                                                        configuration=self.configuration)
-                                                       
+
         manifest2 = copy.deepcopy(self.manifest)
         manifest2['job']['packageVersion'] = '1.0.1'
         manifest2['job']['maintainer']['name'] = 'Jane Doe'
@@ -3319,7 +3321,7 @@ class TestJobTypeRevisionsViewV6(TestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
-        
+
         # correct job type, bad version
         url = '/%s/job-types/my-job/9.9.9/revisions/' % self.api
         response = self.client.get(url)
@@ -3348,7 +3350,7 @@ class TestJobTypeRevisionsViewV6(TestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
-        
+
     def test_successful_details(self):
         """Tests successfully calling the get job type revision details view."""
 
@@ -3368,7 +3370,7 @@ class TestJobTypesValidationViewV5(TransactionTestCase):
     """Tests related to the job-types validation endpoint"""
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -3865,10 +3867,10 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
     """Tests related to the job-types validation endpoint"""
 
     api = 'v6'
-    
+
     def setUp(self):
         django.setup()
-        
+
         self.configuration = {
             'version': '6',
             'output_workspaces': {
@@ -3895,12 +3897,12 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
         self.workspace1 = storage_test_utils.create_workspace(name='workspace_1')
         self.workspace2 = storage_test_utils.create_workspace(name='workspace_2')
         self.inactivews = storage_test_utils.create_workspace(name='inactive', is_active=False)
-        
+
     def test_successful(self):
         """Tests validating a new job type."""
-        
+
         manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
-        
+
         json_data = {
             'manifest': manifest,
             'configuration': self.configuration
@@ -3950,7 +3952,7 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
         self.assertEqual(len(results['warnings']), 2)
         self.assertEqual(results['warnings'][0]['name'], 'MISSING_MOUNT')
         self.assertEqual(results['warnings'][1]['name'], 'MISSING_MOUNT')
-        
+
     def test_unknown_mount(self):
         """Tests validating a new job type with a mount referenced in configuration but not manifest."""
         url = '/%s/job-types/validation/' % self.api
@@ -4002,7 +4004,7 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
                 'DB_PASS': 'password',
                 'setting': 'extra'
         }
-        
+
         json_data = {
             'manifest': manifest,
             'configuration': config
@@ -4021,7 +4023,7 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
         url = '/%s/job-types/validation/' % self.api
         manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
         config = copy.deepcopy(self.configuration)
-        
+
         json_data = {
             'manifest': manifest,
             'configuration': config
@@ -4047,7 +4049,7 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
 
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
-        
+
         results = json.loads(response.content)
         self.assertFalse(results['is_valid'])
         self.assertEqual(len(results['errors']), 1)
@@ -4073,7 +4075,7 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
         url = '/%s/job-types/validation/' % self.api
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
-        
+
         results = json.loads(response.content)
         self.assertFalse(results['is_valid'])
         self.assertEqual(len(results['errors']), 1)
@@ -4099,7 +4101,7 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
         self.assertFalse(results['is_valid'])
         self.assertEqual(len(results['errors']), 1)
         self.assertEqual(results['errors'][0]['name'], 'INVALID_WORKSPACE')
-        
+
     def test_deprecated_output_workspace(self):
         """Tests validating a new job type with an inactive output workspace."""
         manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
@@ -4120,7 +4122,7 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
         self.assertTrue(results['is_valid'])
         self.assertEqual(len(results['warnings']), 1)
         self.assertEqual(results['warnings'][0]['name'], 'DEPRECATED_WORKSPACE')
-        
+
     def test_missing_output_workspace(self):
         """Tests validating a new job type with a missing output workspace."""
         manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
@@ -4144,7 +4146,7 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
 class TestJobTypesStatusView(TestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -4213,7 +4215,7 @@ class TestJobTypesStatusView(TestCase):
 class TestJobTypesPendingView(TestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -4236,7 +4238,7 @@ class TestJobTypesPendingView(TestCase):
 class TestJobTypesRunningView(TestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -4259,7 +4261,7 @@ class TestJobTypesRunningView(TestCase):
 class TestJobTypesSystemFailuresView(TestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -4285,7 +4287,7 @@ class TestJobsWithExecutionViewV5(TransactionTestCase):
     """An integration test of the Jobs with latest execution view"""
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -4431,7 +4433,7 @@ class TestJobsWithExecutionViewV5(TransactionTestCase):
 class TestJobExecutionsViewV5(TransactionTestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -4497,7 +4499,7 @@ class TestJobExecutionsViewV5(TransactionTestCase):
 class TestJobExecutionsViewV6(TransactionTestCase):
 
     api = 'v6'
-    
+
     def setUp(self):
         django.setup()
 
@@ -4560,7 +4562,7 @@ class TestJobExecutionsViewV6(TransactionTestCase):
         results = json.loads(response.content)
         job_exe_count = results['count']
         self.assertEqual(job_exe_count, 1)
-        
+
         url = '/%s/jobs/%d/executions/?error_category=%s' % (self.api, self.job_1.id, self.error.category)
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
@@ -4572,7 +4574,7 @@ class TestJobExecutionsViewV6(TransactionTestCase):
 class TestJobExecutionDetailsViewV5(TransactionTestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -4597,7 +4599,7 @@ class TestJobExecutionDetailsViewV5(TransactionTestCase):
 class TestJobExecutionDetailsViewV6(TransactionTestCase):
 
     api = 'v6'
-    
+
     def setUp(self):
         django.setup()
 
@@ -4628,7 +4630,7 @@ class TestJobExecutionDetailsViewV6(TransactionTestCase):
 class TestOldJobExecutionsViewV5(TransactionTestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -4739,7 +4741,7 @@ class TestOldJobExecutionsViewV5(TransactionTestCase):
 class TestJobExecutionSpecificLogViewV5(TestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -4993,7 +4995,7 @@ class TestJobExecutionSpecificLogViewV6(TestCase):
 class TestJobInputFilesViewV5(TestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
 
         # Create legacy test files
@@ -5383,7 +5385,7 @@ class TestJobInputFilesViewV6(TestCase):
 class TestCancelJobsViewV5(TestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -5423,7 +5425,7 @@ class TestCancelJobsViewV5(TestCase):
 class TestCancelJobsViewV6(TestCase):
 
     api = 'v6'
-    
+
     def setUp(self):
         django.setup()
 
@@ -5500,7 +5502,7 @@ class TestCancelJobsViewV6(TestCase):
 class TestRequeueJobsViewV5(TestCase):
 
     api = 'v5'
-    
+
     def setUp(self):
         django.setup()
 
@@ -5542,7 +5544,7 @@ class TestRequeueJobsViewV5(TestCase):
 class TestRequeueJobsViewV6(TestCase):
 
     api = 'v6'
-    
+
     def setUp(self):
         django.setup()
 


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
job
### Description of change
<!-- Please provide a description of the change here. -->
Updated the v6 /job-types/ GET REST API call to include the id of the job type in the results:

```
{
        "count": 1,
        "next": null,
        "previous": null,
        "results": [
            {
                "id": 3,
                "name": "my-job",
                "title": "My Job",
                "description": "A simple job type",
                "icon_code": "f013",
                "versions": ["1.0.0"],
                "latest_version": "1.0.0"
            }
        ]
 }
```