### PR TITLE
#1494 - Requeueing queued jobs

### DIFF
--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -349,7 +349,7 @@ class QueueManager(models.Manager):
             queue.queued = when_queued
             queues.append(queue)
 
-        Queue.objects.filter(job__in=job_ids).update(is_canceled=True)
+        self.cancel_queued_jobs(job_ids)
 
         if queues:
             self.bulk_create(queues)

--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -349,7 +349,7 @@ class QueueManager(models.Manager):
             queue.queued = when_queued
             queues.append(queue)
 
-        self.cancel_queued_jobs(job_ids)
+        self.filter(job_id__in=job_ids).delete()
 
         if queues:
             self.bulk_create(queues)

--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -312,8 +312,10 @@ class QueueManager(models.Manager):
 
         # Bulk create queue models
         queues = []
+        job_ids = []
         configurator = QueuedExecutionConfigurator(input_files)
         for job in queued_jobs:
+            job_ids.append(job.id)
             config = configurator.configure_queued_job(job)
 
             manifest = None
@@ -346,6 +348,8 @@ class QueueManager(models.Manager):
             queue.resources = job.get_resources().get_json().get_dict()
             queue.queued = when_queued
             queues.append(queue)
+
+        Queue.objects.filter(job__in=job_ids).update(is_canceled=True)
 
         if queues:
             self.bulk_create(queues)

--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -349,7 +349,7 @@ class QueueManager(models.Manager):
             queue.queued = when_queued
             queues.append(queue)
 
-        self.filter(job_id__in=job_ids).delete()
+        self.cancel_queued_jobs(job_ids)
 
         if queues:
             self.bulk_create(queues)

--- a/scale/queue/test/test_models.py
+++ b/scale/queue/test/test_models.py
@@ -682,10 +682,12 @@ class TestQueueManagerRequeueJobs(TransactionTestCase):
         job_b_3 = Job.objects.get(id=self.job_b_3.id)
         self.assertEqual(job_b_3.status, 'BLOCKED')
 
-        # check queue status; we should have 4 job types with one job in the queue for each type
+        # check queue status
         status = Queue.objects.get_queue_status()
         sum = 0
         for s in status:
-            self.assertEqual(s.count, 1)
             sum += s.count
-        self.assertEqual(sum, 4)
+        self.assertEqual(sum, 5)
+
+        canceled = Queue.objects.filter(is_canceled=True)
+        self.assertEqual(len(canceled), 1)

--- a/scale/queue/test/test_models.py
+++ b/scale/queue/test/test_models.py
@@ -650,8 +650,6 @@ class TestQueueManagerRequeueJobs(TransactionTestCase):
         """Tests calling QueueManager.requeue_jobs() successfully"""
 
         status = Queue.objects.get_queue_status()
-        print len(status)
-        print status[0].job_type.name
         self.assertEqual(status[0].count, 1)
 
         Queue.objects.requeue_jobs(self.job_ids, self.new_priority)
@@ -684,13 +682,10 @@ class TestQueueManagerRequeueJobs(TransactionTestCase):
         job_b_3 = Job.objects.get(id=self.job_b_3.id)
         self.assertEqual(job_b_3.status, 'BLOCKED')
 
-        # standalone queued job should be cancelled and not included in the count
-        # We might have to switch from cancelling these queued jobs to removing them as
-        # canceling them does not remove them from the queue and if we're requeueing due
-        # to resource mismatching these jobs will never get removed by the scheduler.
+        # check queue status; we should have 4 job types with one job in the queue for each type
         status = Queue.objects.get_queue_status()
         sum = 0
         for s in status:
-            print 'job: %s, count: %d' % (s.job_type.name, s.count)
+            self.assertEqual(s.count, 1)
             sum += s.count
         self.assertEqual(sum, 4)

--- a/scale/queue/test/test_models.py
+++ b/scale/queue/test/test_models.py
@@ -545,6 +545,9 @@ class TestQueueManagerRequeueJobs(TransactionTestCase):
 
         data_dict = convert_data_to_v6_json(Data()).get_dict()
         self.new_priority = 200
+        self.standalone_queued_job = job_test_utils.create_job(status='QUEUED', input=data_dict, num_exes=3,
+                                                               priority=100)
+        Queue.objects.queue_jobs([self.standalone_queued_job], requeue=True)
         self.standalone_failed_job = job_test_utils.create_job(status='FAILED', input=data_dict, num_exes=3,
                                                                priority=100)
         self.standalone_superseded_job = job_test_utils.create_job(status='FAILED', input=data_dict, num_exes=1)
@@ -553,7 +556,7 @@ class TestQueueManagerRequeueJobs(TransactionTestCase):
         self.standalone_completed_job = job_test_utils.create_job(status='COMPLETED', input=data_dict,)
         Job.objects.supersede_jobs_old([self.standalone_superseded_job], now())
 
-        # Create recipe for re-queing a job that should now be PENDING (and its dependencies)
+        # Create recipe for re-queueing a job that should now be PENDING (and its dependencies)
         job_type_a_1 = job_test_utils.create_job_type()
         job_type_a_2 = job_test_utils.create_job_type()
         definition_a = {
@@ -589,7 +592,7 @@ class TestQueueManagerRequeueJobs(TransactionTestCase):
         recipe_test_utils.create_recipe_job(recipe=recipe_a, job_name='Job 1', job=self.job_a_1)
         recipe_test_utils.create_recipe_job(recipe=recipe_a, job_name='Job 2', job=self.job_a_2)
 
-        # Create recipe for re-queing a job that should now be BLOCKED (and its dependencies)
+        # Create recipe for re-queueing a job that should now be BLOCKED (and its dependencies)
         job_type_b_1 = job_test_utils.create_job_type()
         job_type_b_2 = job_test_utils.create_job_type()
         job_type_b_3 = job_test_utils.create_job_type()
@@ -640,10 +643,16 @@ class TestQueueManagerRequeueJobs(TransactionTestCase):
 
         # Job IDs to re-queue
         self.job_ids = [self.standalone_failed_job.id, self.standalone_canceled_job.id,
-                        self.standalone_completed_job.id, self.job_a_1.id, self.job_b_2.id]
+                        self.standalone_completed_job.id, self.job_a_1.id, self.job_b_2.id,
+                        self.standalone_queued_job.id]
 
     def test_successful(self):
         """Tests calling QueueManager.requeue_jobs() successfully"""
+
+        status = Queue.objects.get_queue_status()
+        print len(status)
+        print status[0].job_type.name
+        self.assertEqual(status[0].count, 1)
 
         Queue.objects.requeue_jobs(self.job_ids, self.new_priority)
 
@@ -674,3 +683,14 @@ class TestQueueManagerRequeueJobs(TransactionTestCase):
         self.assertEqual(job_b_2.status, 'BLOCKED')
         job_b_3 = Job.objects.get(id=self.job_b_3.id)
         self.assertEqual(job_b_3.status, 'BLOCKED')
+
+        # standalone queued job should be cancelled and not included in the count
+        # We might have to switch from cancelling these queued jobs to removing them as
+        # canceling them does not remove them from the queue and if we're requeueing due
+        # to resource mismatching these jobs will never get removed by the scheduler.
+        status = Queue.objects.get_queue_status()
+        sum = 0
+        for s in status:
+            print 'job: %s, count: %d' % (s.job_type.name, s.count)
+            sum += s.count
+        self.assertEqual(sum, 4)


### PR DESCRIPTION
##### Checklist
- [x] `manage.py test` passes
- [x] tests are included

### Affected app(s)
- queue

### Description of change
If a job is re-queued when it is already in the queue there will be two copies of the job in the queue.  If one of the copies will never be scheduled (e.g. due to invalid resource requirements) it will sit on the queue forever and there's no easy way to get rid of it.  In this scenario it can be assumed that if a user wants to re-queue a job already in the queue, the job already in the queue can be deleted and replaced with the new one.
