### PR TITLE
#1503 - Job Type Names fields 

### DIFF
--- a/scale/docs/rest/v6/job_type.rst
+++ b/scale/docs/rest/v6/job_type.rst
@@ -9,14 +9,14 @@ These services allow for the management of job types within Scale.
 
 The services will be replaced as the new v6 job type services are created:
 
-.. _rest_v6_job_type_list:
+.. _rest_v6_job_type_name_list:
 
 v6 Job Type Names
 -----------------
 
-**Example GET /v6/job-types/ API call**
+**Example GET /v6/job-type-names/ API call**
 
-Request: GET http://.../v6/job-types/
+Request: GET http://.../v6/job-type-names/
 
 Response: 200 OK
 
@@ -97,6 +97,128 @@ Response: 200 OK
 | .versions                | Array             | List of versions of this job type.                                       |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
 | .latest_version          | String            | The latest version of this job type.                                     |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+
+.. _rest_v6_job_type_list:
+
+v6 Job Type List
+----------------
+
+**Example GET /v6/job-types/ API call**
+
+Request: GET http://.../v6/job-types/
+
+Response: 200 OK
+
+ .. code-block:: javascript  
+ 
+    { 
+        "count": 2, 
+        "next": null, 
+        "previous": null, 
+        "results": [ 
+            { 
+                "id": 3, 
+                "name": "my-job",
+                "version": "1.0.0" 
+                "title": "My Job", 
+                "description": "A simple job type", 
+                "icon_code": "f013", 
+                "is_published": true, 
+                "is_active": true, 
+                "is_paused": false, 
+                "is_system": false, 
+                "max_scheduled": 1, 
+                "revision_num": 1, 
+                "docker_image": "my-job-1.0.0-seed:1.0.0", 
+                "created": "2015-03-11T00:00:00Z", 
+                "deprecated": null, 
+                "paused": null, 
+                "last_modified": "2015-03-11T00:00:00Z" 
+            }, 
+            ... 
+        ] 
+    } 
+    
++-------------------------------------------------------------------------------------------------------------------------+
+| **Retrieve Job Types**                                                                                                  |
++=========================================================================================================================+
+| Returns a list of job types                                                                                             |
++-------------------------------------------------------------------------------------------------------------------------+
+| **GET** /v6/job-types/                                                                                                  |
++-------------------------------------------------------------------------------------------------------------------------+
+| **Query Parameters**                                                                                                    |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| page               | Integer           | Optional | The page of the results to return. Defaults to 1.                   |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| page_size          | Integer           | Optional | The size of the page to use for pagination of results.              |
+|                    |                   |          | Defaults to 100, and can be anywhere from 1-1000.                   |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| keyword            | String            | Optional | Performs a like search on name, title, description and tags         |
+|                    |                   |          | Duplicate to search for multiple keywords.                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| id                 | Integer           | Optional | Return only job types with a matching id.                           |
+|                    |                   |          | Duplicate to search for multiple ids.                               |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| is_active          | Boolean           | Optional | Return only job types that match the is_active flag.                |
+|                    |                   |          | Defaults to all job types.                                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| is_system          | Boolean           | Optional | Return only job types that are system (True) or user (False).       |
+|                    |                   |          | Defaults to all job types.                                          |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| order              | String            | Optional | One or more fields to use when ordering the results.                |
+|                    |                   |          | Duplicate it to multi-sort, (ex: order=name&order=version).         |
+|                    |                   |          | Prefix fields with a dash to reverse the sort, (ex: order=-name).   |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| **Successful Response**                                                                                                 |
++--------------------------+----------------------------------------------------------------------------------------------+
+| **Status**               | 200 OK                                                                                       |
++--------------------------+----------------------------------------------------------------------------------------------+
+| **Content Type**         | *application/json*                                                                           |
++--------------------------+----------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                         |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| count                    | Integer           | The total number of results that match the query parameters.             |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| next                     | URL               | A URL to the next page of results.                                       |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| previous                 | URL               | A URL to the previous page of results.                                   |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| results                  | Array             | List of result JSON objects that match the query parameters.             |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .name                    | String            | The name of the job type.                                                |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .version                 | String            | The version number for this version of the job type.                     |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .title                   | String            | The human readable display name for this version of the job type.        |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .description             | String            | A longer description of this version of the job type.                    |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .icon_code               | String            | A font-awesome icon code to use when representing this job type version. |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .is_published            | Boolean           | Whether this job type publishes its output.                              |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .is_active               | Boolean           | Whether this job type is active or deprecated.                           |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .is_paused               | Boolean           | Whether the job type is paused (while paused no jobs of this type will   |
+|                          |                   | be scheduled off of the queue).                                          |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .is_system               | Boolean           | Whether this is a system type.                                           |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .max_scheduled           | Integer           | Maximum  number of jobs of this type that may be scheduled to run at the |
+|                          |                   | same time. May be null.                                                  |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .revision_num            | Integer           | The number of versions of this job type.                                 |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .docker_image            | String            | The Docker image containing the code to run for this job.                |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .created                 | ISO-8601 Datetime | When the associated database model was initially created.                |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .deprecated              | ISO-8601 Datetime | When the job type was last deprecated (archived).                        |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .paused                  | ISO-8601 Datetime | When the job type was last paused.                                       |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| .last_modified           | ISO-8601 Datetime | When the associated database model was last saved.                       |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
 
 .. _rest_v6_job_type_versions:

--- a/scale/docs/rest/v6/job_type.yml
+++ b/scale/docs/rest/v6/job_type.yml
@@ -6,6 +6,74 @@ paths:
   /job-types/:
     get:
       operationId: _rest_v6_job_type_list
+      summary: Job Types
+      description: Returns a list of all job types
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+          description: The page of the results to return. Defaults to 1.
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+          description: The size of the page to use for pagination of results.
+            Defaults to 100, and can be anywhere from 1-1000.
+        - in: query
+          name: keyword
+          schema:
+            type: string
+          description: Keyword to perform a 'like' search on name, title, description, and tag |
+            may be duplicated to search for multiple keywords
+        - in: query
+          name: id
+          schema:
+            type: integer
+          description: if provided, only return job types matching the given id.
+        - in: query
+          name: is_active
+          schema:
+            type: boolean
+          description: if provided, only return job types with a least one version that matches is_active
+        - in: query
+          name: is_system
+          schema:
+            type: boolean
+          description: if provided, only return job types with a least one version that matches is_system
+      responses:
+        '200':
+          description: 200 response
+          content:
+            application/json: 
+              schema:
+                $ref: '#/components/schemas/job_type_versions'
+    post:
+      operationId: _rest_v6_job_type_post
+      summary: Job Type Post
+      description: Creates or edits an existing job type
+      requestBody:
+        required: true
+        content:
+          application/json: 
+            schema:
+              $ref: '#/components/schemas/job_type_post'
+      responses:
+        '201':
+          description: The 201 CREATED response indicates a successful event
+          headers:
+            location:
+              schema:
+                type: string
+              description: The url of the created/edited job type
+          content:
+            application/json: 
+              schema:
+                $ref: '#/components/schemas/job_type_detail'
+                
+  /job-type-names/:
+    get:
+      operationId: _rest_v6_job_type_name_list
       summary: Job Type Names
       description: Returns a list of all job type names
       parameters:
@@ -49,28 +117,7 @@ paths:
             application/json: 
               schema:
                 $ref: '#/components/schemas/job_type_list'
-    post:
-      operationId: _rest_v6_job_type_post
-      summary: Job Type Post
-      description: Creates or edits an existing job type
-      requestBody:
-        required: true
-        content:
-          application/json: 
-            schema:
-              $ref: '#/components/schemas/job_type_post'
-      responses:
-        '201':
-          description: The 201 CREATED response indicates a successful event
-          headers:
-            location:
-              schema:
-                type: string
-              description: The url of the created/edited job type
-          content:
-            application/json: 
-              schema:
-                $ref: '#/components/schemas/job_type_detail'
+
   /job-types/{name}/:
     get:
       operationId: _rest_v6_job_type_versions

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -3024,6 +3024,49 @@ class JobTypeManager(models.Manager):
         return job_types
 
     def get_job_types_v6(self, keywords=None, ids=None, is_active=None, is_system=None, order=None):
+        """Returns a list of all job types
+
+        :param keywords: Query job types with name, title, description or tag matching one of the specified keywords
+        :type keywords: list
+        :param ids: Query job types with a version matching the given ids
+        :type keyword: list
+        :param is_active: Query job types that are actively available for use.
+        :type is_active: bool
+        :param is_system: Query job types that are system job types.
+        :type is_operational: bool
+        :param order: A list of fields to control the sort order.
+        :type order: list
+        :returns: The list of latest version of job types that match the given parameters.
+        :rtype: list
+        """
+
+        # Execute a sub-query that returns distinct job type names that match the provided filter arguments
+        job_types = self.all()
+        if keywords:
+            key_query = Q()
+            for keyword in keywords:
+                key_query |= Q(name__icontains=keyword)
+                key_query |= Q(title__icontains=keyword)
+                key_query |= Q(description__icontains=keyword)
+                key_query |= Q(jobtypetag__tag__icontains=keyword)
+            job_types = job_types.filter(key_query)
+        if ids:
+            job_types = job_types.filter(id__in=ids)
+        if is_active is not None:
+            job_types = job_types.filter(is_active=is_active)
+        if is_system is not None:
+            job_types = job_types.filter(is_system=is_system)
+        
+        # Apply sorting
+        if order:
+            job_types = job_types.order_by(*order)
+        else:
+            job_types = job_types.order_by('last_modified')
+
+        return job_types
+
+
+    def get_job_type_names_v6(self, keywords=None, ids=None, is_active=None, is_system=None, order=None):
         """Returns a list of the latest version of job types
 
         :param keywords: Query job types with name, title, description or tag matching one of the specified keywords

--- a/scale/job/urls.py
+++ b/scale/job/urls.py
@@ -8,6 +8,7 @@ import job.views as views
 urlpatterns = [
     # Job type views
     url(r'^job-types/$', views.JobTypesView.as_view(), name='job_types_view'),
+    url(r'^job-type-names/$', views.JobTypeNamesView.as_view(), name='job_type_names_view'),
     # TODO: Remove JobTypeIDDetailsView url entry when V5 API is removed
     url(r'^job-types/(?P<job_type_id>\d+)/$', views.JobTypeIDDetailsView.as_view(), name='job_type_id_details_view'),
     url(r'^job-types/validation/$', views.JobTypesValidationView.as_view(), name='job_types_validation_view'),


### PR DESCRIPTION
##### Checklist
- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

### Affected app(s)
-jobs

### Description of change
Changing job-types endpoint to return list of all job types and added job-type-names endpoint to return the list of job type names previously returned by the job-types endpoint.
