### PR TITLE
#1511 - Reset unmet_resources flag

### DIFF
--- a/scale/docs/rest/v6/metrics.yml
+++ b/scale/docs/rest/v6/metrics.yml
@@ -251,13 +251,15 @@ components:
             of the filter parameters described above are fields within the model. The list
             of choices allow clients to restrict filtering to only valid combinations. Each
             choice model is specific to a metrics type and so the actual fields vary.
-    choice: #TODO: Update to reflect open-ended nature of this field
+    choice: 
       title: Choice
       type: object
-      properties:
-        id:
-          type: integer
-          description: Unique identifier
+      additionalProperties:
+        oneOf:
+        - $ref: './error.yml/#/components/schemas/error_base'
+        - $ref: './job_type.yml/#/components/schemas/job_type_base'
+        - $ref: './strike.yml/#/components/schemas/strike_base'
+
     metrics_plot:
       title: Metrics Plot Data
       type: object

--- a/scale/docs/rest/v6/recipe_type.rst
+++ b/scale/docs/rest/v6/recipe_type.rst
@@ -267,7 +267,6 @@ which pieces (nodes) within the recipe will be reprocessed when a newer recipe t
 |                            |                |          | revision, if changed in the newer revision                         |
 +----------------------------+----------------+----------+--------------------------------------------------------------------+
 
-#TODO: update when recipe type config is defined
 .. _rest_v6_recipe_type_configuration:
 
 Recipe Type Configuration JSON

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -4295,9 +4295,8 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
     def test_nonstandard_resource(self):
         """Tests validating a new job type with a nonstandard resource."""
         manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
-        manifest['resources']['scalar'].append({'name': 'chocolate', 'value': 1.0 })
+        manifest['job']['resources']['scalar'].append({'name': 'chocolate', 'value': 1.0 })
         config = copy.deepcopy(self.configuration)
-        config['output_workspaces'] = {}
         json_data = {
             'manifest': manifest,
             'configuration': config

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -4292,6 +4292,25 @@ class TestJobTypesValidationViewV6(TransactionTestCase):
         self.assertEqual(len(results['errors']), 1)
         self.assertEqual(results['errors'][0]['name'], 'MISSING_WORKSPACE')
 
+    def test_nonstandard_resource(self):
+        """Tests validating a new job type with a nonstandard resource."""
+        manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
+        manifest['resources']['scalar'].append({'name': 'chocolate', 'value': 1.0 })
+        config = copy.deepcopy(self.configuration)
+        config['output_workspaces'] = {}
+        json_data = {
+            'manifest': manifest,
+            'configuration': config
+        }
+
+        url = '/%s/job-types/validation/' % self.api
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        self.assertTrue(results['is_valid'])
+        self.assertEqual(len(results['warnings']), 1)
+        self.assertEqual(results['warnings'][0]['name'], 'NONSTANDARD_RESOURCE')
 
 class TestJobTypesStatusView(TestCase):
 

--- a/scale/scheduler/manager.py
+++ b/scale/scheduler/manager.py
@@ -13,7 +13,7 @@ from scheduler.models import Scheduler
 from util.active_warnings import ActiveError, ActiveWarning
 from util.parse import datetime_to_string
 
-CLEANUP_WARN_THRESHOLD = datetime.timedelta(hours=3)
+CLEANUP_WARN_THRESHOLD = datetime.timedelta(hours=1)
 
 logger = logging.getLogger(__name__)
 SchedulerState = namedtuple('SchedulerState', ['state', 'title', 'description'])
@@ -94,6 +94,17 @@ class SchedulerManager(object):
                 self._task_fin_count += 1
             if was_job_finished:
                 self._job_fin_count += 1
+
+    def is_warning_active(self, warning, description=None):
+        """Indicates that the given warning is now active
+
+        :param warning: The node warning
+        :type warning: :class:`scheduler.node.conditions.NodeWarning`
+        :param description: An optional specific description for the warning
+        :type description: string
+        """
+
+        return warning.name in self._active_warnings
 
     def warning_active(self, warning, description=None):
         """Indicates that the given warning is now active

--- a/scale/scheduler/scheduling/manager.py
+++ b/scale/scheduler/scheduling/manager.py
@@ -339,7 +339,7 @@ class SchedulingManager(object):
             jt = job_type_mgr.get_job_type(queue.job_type.id)
             name = INVALID_RESOURCES.name + jt.name
             title = INVALID_RESOURCES.title % jt.name
-            warning = SchedulerWarning(name=name, title=title)
+            warning = SchedulerWarning(name=name, title=title, description=None)
             if jt.unmet_resources and scheduler_mgr.is_warning_active(warning):
                 # previously checked this job type and found we lacked resources; wait until warning is inactive to check again
                 continue

--- a/scale/scheduler/scheduling/manager.py
+++ b/scale/scheduler/scheduling/manager.py
@@ -336,6 +336,14 @@ class SchedulingManager(object):
             if not nodes:
                 break
 
+            jt = job_type_mgr.get_job_type(queue.job_type.id)
+            name = INVALID_RESOURCES.name + jt.name
+            title = INVALID_RESOURCES.title % jt.name
+            warning = SchedulerWarning(name=name, title=title)
+            if jt.unmet_resources and scheduler_mgr.is_warning_active(warning):
+                # previously checked this job type and found we lacked resources; wait until warning is inactive to check again
+                continue
+            
             invalid_resources = []
             insufficient_resources = []
             # get resource names offered and compare to job type resources
@@ -348,24 +356,23 @@ class SchedulingManager(object):
                     insufficient_resources.append(resource.name)
 
             if invalid_resources:
-                name = INVALID_RESOURCES.name + queue.job_type.name
-                title = INVALID_RESOURCES.title % queue.job_type.name
                 description = INVALID_RESOURCES.description % invalid_resources
-                scheduler_mgr.warning_active(SchedulerWarning(name=name, title=title, description=None), description)
+                scheduler_mgr.warning_active(warning, description)
 
             if insufficient_resources:
-                name = INSUFFICIENT_RESOURCES.name + queue.job_type.name
-                title = INSUFFICIENT_RESOURCES.title % queue.job_type.name
                 description = INSUFFICIENT_RESOURCES.description % insufficient_resources
-                scheduler_mgr.warning_active(SchedulerWarning(name=name, title=title, description=None), description)
+                scheduler_mgr.warning_active(warning, description)
 
 
             if invalid_resources or insufficient_resources:
                 invalid_resources.extend(insufficient_resources)
-                jt = job_type_mgr.get_job_type(queue.job_type.id)
                 jt.unmet_resources = ','.join(invalid_resources)
                 jt.save()
                 continue
+            else:
+                # reset unmet_resources flag
+                jt.unmet_resources = None
+                jt.save()
             
             # Make sure execution's job type and workspaces have been synced to the scheduler
             job_type_id = queue.job_type_id


### PR DESCRIPTION
##### Checklist
- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

### Affected app(s)
-job
-scheduler

### Description of change
Fixing scheduling logic to skip job types that have been marked as having invalid resource requirements for awhile, and only attempt to schedule them again either after a timeout period or after the job type has been updated and the flag reset.  If a job type is again able to be rescheduled due to the needed resource being offered, unset the flag.  Also, added warning when validating a job type with a nonstandard resource (#1493) and cleaned up some documentation TODOs.
