### PR TITLE
#1102 - Fix deadlocks when locking job models

### DIFF
--- a/scale/job/messages/completed_jobs.py
+++ b/scale/job/messages/completed_jobs.py
@@ -11,6 +11,7 @@ from job.messages.publish_job import create_publish_job_message
 from job.models import Job
 from messaging.messages.message import CommandMessage
 from util.parse import datetime_to_string, parse_datetime
+from util.retry import retry_database_query
 
 # This is the maximum number of job models that can fit in one message. This maximum ensures that every message of this
 # type is less than 25 KiB long.
@@ -143,6 +144,7 @@ class CompletedJobs(CommandMessage):
 
         return message
 
+    @retry_database_query(max_tries=5, base_ms_delay=1000, max_ms_delay=5000)
     def execute(self):
         """See :meth:`messaging.messages.message.CommandMessage.execute`
         """

--- a/scale/job/messages/failed_jobs.py
+++ b/scale/job/messages/failed_jobs.py
@@ -10,6 +10,7 @@ from error.models import get_error
 from job.models import Job
 from messaging.messages.message import CommandMessage
 from util.parse import datetime_to_string, parse_datetime
+from util.retry import retry_database_query
 
 # This is the maximum number of job models that can fit in one message. This maximum ensures that every message of this
 # type is less than 25 KiB long.
@@ -117,6 +118,7 @@ class FailedJobs(CommandMessage):
 
         return message
 
+    @retry_database_query(max_tries=5, base_ms_delay=1000, max_ms_delay=5000)
     def execute(self):
         """See :meth:`messaging.messages.message.CommandMessage.execute`
         """

--- a/scale/job/messages/job_exe_end.py
+++ b/scale/job/messages/job_exe_end.py
@@ -7,6 +7,7 @@ from job.execution.tasks.json.results.task_results import TaskResults
 from job.models import JobExecutionEnd
 from messaging.messages.message import CommandMessage
 from util.parse import datetime_to_string, parse_datetime
+from util.retry import retry_database_query
 
 # This is the maximum number of job_exe_end models that can fit in one message. This maximum ensures that every message
 # of this type is less than 25 KiB long.
@@ -124,6 +125,7 @@ class CreateJobExecutionEnd(CommandMessage):
 
         return message
 
+    @retry_database_query(max_tries=5, base_ms_delay=1000, max_ms_delay=5000)
     def execute(self):
         """See :meth:`messaging.messages.message.CommandMessage.execute`
         """


### PR DESCRIPTION

### Checklist

- [x] `manage.py test` passes

### Affected app(s)
- job

### Description of change
Added retry decoration for three messages that are having deadlock issues.  I believe this should allow scale to retry these messages 5 times and one of these retries should succeed as the failures are only happening sporadically.  This should have the same result the current code achieves by retrying the message when this occurs but without filling up the error log.
