### PR TITLE
#1537 - Legacy Job Data is not populated

### DIFF
--- a/scale/data/data/data.py
+++ b/scale/data/data/data.py
@@ -40,10 +40,13 @@ class Data(object):
         :param output_data: The output data
         :type output_data: :class:`data.data.data.Data`
 
-        :raises :class:`data.data.exceptions.InvalidData`: If the value is a duplicate
+        :raises :class:`data.data.exceptions.InvalidData`: If the value is a duplicate or the key does not exist in the output data
         """
 
-        new_value = output_data.values[output_name].copy()
+        try:
+            new_value = output_data.values[output_name].copy()
+        except KeyError:
+            raise InvalidData('MISSING_VALUE', 'Output name \'%s\' is not present in output data' % output_name)
         new_value.name = input_name
         self.add_value(new_value)
 

--- a/scale/data/test/data/test_data.py
+++ b/scale/data/test/data/test_data.py
@@ -57,6 +57,11 @@ class TestData(TestCase):
             data.add_value_from_output_data('input_1', 'output_1', output_data)
         self.assertEqual(context.exception.error.name, 'DUPLICATE_VALUE')
 
+        # Missing parameter
+        with self.assertRaises(InvalidData) as context:
+            data.add_value_from_output_data('input_1', 'output_3', output_data)
+        self.assertEqual(context.exception.error.name, 'MISSING_VALUE')
+        
     def test_validate(self):
         """Tests calling Data.validate()"""
 

--- a/scale/ingest/urls.py
+++ b/scale/ingest/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     url(r'^ingests/$', views.IngestsView.as_view(), name='ingests_view'),
     url(r'^ingests/status/$', views.IngestsStatusView.as_view(), name='ingests_status_view'),
     url(r'^ingests/(?P<ingest_id>\d+)/$', views.IngestDetailsView.as_view(), name='ingest_details_view'),
-    url(r'^ingests/(?P<file_name>[\w.]{0,250})/$', views.IngestDetailsView.as_view(), name='ingest_details_view'),
+    url(r'^ingests/(?P<file_name>[\w-.]{0,250})/$', views.IngestDetailsView.as_view(), name='ingest_details_view'),
 
     # Scan views
     url(r'^scans/$', views.ScansView.as_view(), name='scans_view'),

--- a/scale/ingest/urls.py
+++ b/scale/ingest/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     url(r'^ingests/$', views.IngestsView.as_view(), name='ingests_view'),
     url(r'^ingests/status/$', views.IngestsStatusView.as_view(), name='ingests_status_view'),
     url(r'^ingests/(?P<ingest_id>\d+)/$', views.IngestDetailsView.as_view(), name='ingest_details_view'),
-    url(r'^ingests/(?P<file_name>[\w-.]{0,250})/$', views.IngestDetailsView.as_view(), name='ingest_details_view'),
+    url(r'^ingests/(?P<file_name>[\w.-]{0,250})/$', views.IngestDetailsView.as_view(), name='ingest_details_view'),
 
     # Scan views
     url(r'^scans/$', views.ScansView.as_view(), name='scans_view'),

--- a/scale/job/configuration/data/job_data.py
+++ b/scale/job/configuration/data/job_data.py
@@ -423,7 +423,7 @@ class JobData(object):
         data_file_parse_saver = DATA_FILE_PARSE_SAVER['DATA_FILE_PARSE_SAVER']
         if not data_file_parse_saver:
             raise Exception('No data file parse saver found')
-        data_file_parse_saver.save_parse_results(parse_results, input_file_ids, is_recipe=is_recipe)
+        data_file_parse_saver.save_parse_results(parse_results, input_file_ids)
 
     def setup_job_dir(self, data_files):
         """Sets up the directory structure for a job execution and downloads the given files

--- a/scale/job/configuration/data/job_data.py
+++ b/scale/job/configuration/data/job_data.py
@@ -368,7 +368,8 @@ class JobData(object):
                 continue
             file_input = self.data_inputs_by_name[name]
             file_ids = []
-            if multiple:
+            # TODO: Remove with legacy job types. This is a protection against multiple being specified for a single file or no file
+            if multiple and 'file_ids' in file_input:
                 for file_id in file_input['file_ids']:
                     file_id = long(file_id)
                     file_ids.append(file_id)

--- a/scale/job/configuration/results/results_manifest/results_manifest.py
+++ b/scale/job/configuration/results/results_manifest/results_manifest.py
@@ -293,6 +293,7 @@ class ResultsManifest(object):
         for manifest_file_entry in self._json_manifest['output_data']:
             entry_name = manifest_file_entry['name']
             if 'files' in manifest_file_entry and not manifest_file_entry['files']:
+                # skip empty lists
                 continue
             file_entry_map[entry_name] = manifest_file_entry
 

--- a/scale/job/configuration/results/results_manifest/results_manifest.py
+++ b/scale/job/configuration/results/results_manifest/results_manifest.py
@@ -292,6 +292,8 @@ class ResultsManifest(object):
         file_entry_map = {}
         for manifest_file_entry in self._json_manifest['output_data']:
             entry_name = manifest_file_entry['name']
+            if 'files' in manifest_file_entry and not manifest_file_entry['files']:
+                continue
             file_entry_map[entry_name] = manifest_file_entry
 
         for file_name, (is_multiple, is_required) in output_file_definitions.items():

--- a/scale/job/data/job_data.py
+++ b/scale/job/data/job_data.py
@@ -435,7 +435,7 @@ class JobData(object):
                 if required:
                     raise InvalidData('Invalid job data: Data input %s is required and was not provided' % name)
 
-        return []
+        return warnings
 
     def validate_input_json(self, input_json):
         """Validates the given property names to ensure they are all populated correctly and exist if they are required.

--- a/scale/job/messages/process_job_input.py
+++ b/scale/job/messages/process_job_input.py
@@ -4,8 +4,10 @@ from __future__ import unicode_literals
 import logging
 
 from django.db import transaction
+from django.utils.timezone import now
 
 from data.data.exceptions import InvalidData
+from job.messages.cancel_jobs import create_cancel_jobs_messages
 from job.models import Job
 from messaging.messages.message import CommandMessage
 
@@ -75,7 +77,8 @@ class ProcessJobInput(CommandMessage):
             try:
                 self._generate_input_data_from_recipe(job)
             except InvalidData:
-                logger.exception('Recipe created invalid input data for job %d. Message will not re-run.', self.job_id)
+                logger.exception('Recipe created invalid input data for job %d. Message will not re-run. Cancelling job that cannot be queued.', self.job_id)
+                self.new_messages.extend(create_cancel_jobs_messages([self.job_id], now()))
                 return True
 
         # Lock job model and process job's input data

--- a/scale/job/seed/results/job_results.py
+++ b/scale/job/seed/results/job_results.py
@@ -286,8 +286,6 @@ class JobResults(object):
             file_id_list.append(file_id)
 
         # Create job results
-        # if no files are found for an output, there won't be a data entry for it. this breaks the handshake between jobs in v6
-        # add a dummy entry? check for results manifest?
         for name in param_file_ids:
             param_entry = param_file_ids[name]
             self.add_file_list_parameter(name, param_entry)

--- a/scale/job/seed/results/job_results.py
+++ b/scale/job/seed/results/job_results.py
@@ -286,6 +286,8 @@ class JobResults(object):
             file_id_list.append(file_id)
 
         # Create job results
+        # if no files are found for an output, there won't be a data entry for it. this breaks the handshake between jobs in v6
+        # add a dummy entry? check for results manifest?
         for name in param_file_ids:
             param_entry = param_file_ids[name]
             self.add_file_list_parameter(name, param_entry)

--- a/scale/job/serializers.py
+++ b/scale/job/serializers.py
@@ -11,6 +11,7 @@ from job.job_type_serializers import JobTypeSerializerV5
 from job.job_type_serializers import JobTypeRevisionBaseSerializer
 from job.job_type_serializers import JobTypeRevisionSerializerV5, JobTypeRevisionSerializerV6
 from job.job_type_serializers import JobTypeRevisionDetailsSerializerV6
+from storage.models import ScaleFile
 
 from node.serializers import NodeBaseSerializer
 from util.rest import ModelIdSerializer
@@ -192,7 +193,11 @@ class JobDetailsInputSerializer(serializers.Serializer):
             if obj['type'] == 'file':
                 value = ScaleFileSerializerV5().to_representation(obj['value'])
             elif obj['type'] == 'files':
-                value = [ScaleFileSerializerV5().to_representation(v) for v in obj['value']]
+                if isinstance(obj['value'], ScaleFile):
+                    logger.warning('Unexpected single file with type "files": %s' % obj['value'])
+                    value = [ScaleFileSerializerV5().to_representation(obj['value'])]
+                else:
+                    value = [ScaleFileSerializerV5().to_representation(v) for v in obj['value']]
             else:
                 value = obj['value']
         result['value'] = value
@@ -217,7 +222,11 @@ class JobDetailsOutputSerializer(JobDetailsInputSerializer):
             if obj['type'] == 'file':
                 value = ProductFileBaseSerializer().to_representation(obj['value'])
             elif obj['type'] == 'files':
-                value = [ProductFileBaseSerializer().to_representation(v) for v in obj['value']]
+                if isinstance(obj['value'], ScaleFile):
+                    logger.warning('Unexpected single file with type "files": %s' % obj['value'])
+                    value = [ProductFileBaseSerializer().to_representation(obj['value'])]
+                else:
+                    value = [ProductFileBaseSerializer().to_representation(v) for v in obj['value']]
             else:
                 value = obj['value']
         result['value'] = value

--- a/scale/job/serializers.py
+++ b/scale/job/serializers.py
@@ -193,7 +193,10 @@ class JobDetailsInputSerializer(serializers.Serializer):
             if obj['type'] == 'file':
                 value = ScaleFileSerializerV5().to_representation(obj['value'])
             elif obj['type'] == 'files':
-                if isinstance(obj['value'], ScaleFile):
+                if not obj['value']:
+                    logger.warning('Empty file list')
+                    value = []
+                elif isinstance(obj['value'], ScaleFile):
                     logger.warning('Unexpected single file with type "files": %s' % obj['value'])
                     value = [ScaleFileSerializerV5().to_representation(obj['value'])]
                 else:
@@ -222,7 +225,10 @@ class JobDetailsOutputSerializer(JobDetailsInputSerializer):
             if obj['type'] == 'file':
                 value = ProductFileBaseSerializer().to_representation(obj['value'])
             elif obj['type'] == 'files':
-                if isinstance(obj['value'], ScaleFile):
+                if not obj['value']:
+                    logger.warning('Empty file list')
+                    value = []
+                elif isinstance(obj['value'], ScaleFile):
                     logger.warning('Unexpected single file with type "files": %s' % obj['value'])
                     value = [ProductFileBaseSerializer().to_representation(obj['value'])]
                 else:

--- a/scale/job/test/configuration/interface/test_job_interface.py
+++ b/scale/job/test/configuration/interface/test_job_interface.py
@@ -164,34 +164,35 @@ class TestJobInterfacePostSteps(TestCase):
     @patch('product.configuration.product_data_file.ProductDataFileStore._calculate_remote_path')
     @patch('os.path.isfile')
     @patch('os.path.exists')
-    def test_missing_output_file(self, mock_exists, mock_isfile, mock_calculate_remote):
+    @patch('__builtin__.open')
+    @patch('job.configuration.interface.job_interface_1_0.json.loads')
+    def test_missing_output_files(self, mock_loads, mock_open, mock_exists, mock_isfile, mock_calculate_remote):
         mock_calculate_remote.return_value = '/temp/output_file.txt'
         job_interface_dict, job_data_dict = self._get_simple_interface_data()
         job_interface_dict['output_data'] = [{
-            'name': 'output_file',
-            'type': 'file',
+            'name': 'output_files',
+            'type': 'files',
             'required': True,
         }]
         job_data_dict['output_data'].append(
-            { 'name': 'output_file',
-              'file_ids': [5, 7, 23],
+            { 'name': 'output_files',
               'workspace_id': self.workspace.id })
 
         results_manifest = {
             'version': '1.0',
             'files': [{
-                'name': 'output_file',
-                'path': '/some/path/foo.txt',
+                'name': 'output_files',
+                'paths': [],
             }]
         }
-        #mock_loads.return_value = results_manifest
-        mock_exists.return_value = False
+        mock_loads.return_value = results_manifest
+        mock_exists.return_value = True
         mock_isfile.return_value = True
 
         job_exe = MagicMock()
 
         job_interface = JobInterface(job_interface_dict)
-        job_data = JobData(data={})
+        job_data = JobData(data=job_data_dict)
         job_data.save_parse_results = Mock()
         fake_stdout = ''
 

--- a/scale/job/test/configuration/interface/test_job_interface.py
+++ b/scale/job/test/configuration/interface/test_job_interface.py
@@ -161,13 +161,11 @@ class TestJobInterfacePostSteps(TestCase):
 
         self.assertRaises(InvalidResultsManifest, job_interface.perform_post_steps, job_exe, job_data, fake_stdout)
 
-    @patch('product.configuration.product_data_file.ProductDataFileStore._calculate_remote_path')
     @patch('os.path.isfile')
     @patch('os.path.exists')
     @patch('__builtin__.open')
     @patch('job.configuration.interface.job_interface_1_0.json.loads')
-    def test_missing_output_files(self, mock_loads, mock_open, mock_exists, mock_isfile, mock_calculate_remote):
-        mock_calculate_remote.return_value = '/temp/output_file.txt'
+    def test_missing_output_files(self, mock_loads, mock_open, mock_exists, mock_isfile):
         job_interface_dict, job_data_dict = self._get_simple_interface_data()
         job_interface_dict['output_data'] = [{
             'name': 'output_files',

--- a/scale/job/test/messages/test_process_job_input.py
+++ b/scale/job/test/messages/test_process_job_input.py
@@ -395,7 +395,7 @@ class TestProcessJobInput(TransactionTestCase):
                 }
             }
         }
-        job_type_1 = job_test_utils.create_job_type(interface=manifest_1)
+        job_type_1 = job_test_utils.create_seed_job_type(manifest=manifest_1)
         manifest_2 = {
             'seedVersion': '1.0.0',
             'job': {
@@ -418,7 +418,7 @@ class TestProcessJobInput(TransactionTestCase):
                 }
             }
         }
-        job_type_2 = job_test_utils.create_job_type(interface=manifest_2)
+        job_type_2 = job_test_utils.create_seed_job_type(manifest=manifest_2)
         output_dict = {
             'version': '1.0',
             'output_data': [{

--- a/scale/job/test/messages/test_process_job_input.py
+++ b/scale/job/test/messages/test_process_job_input.py
@@ -364,3 +364,130 @@ class TestProcessJobInput(TransactionTestCase):
         # Make sure job input file models are unchanged
         job_input_files = JobInputFile.objects.filter(job_id=job_2.id)
         self.assertEqual(len(job_input_files), 4)
+
+    def test_execute_with_recipe_missing_output(self):
+        """Tests calling ProcessJobInput.execute() when a job has to get its data from its recipe but the previous job didn't provide it's output"""
+
+        workspace = storage_test_utils.create_workspace()
+        file_1 = storage_test_utils.create_file(workspace=workspace, file_size=104857600.0)
+        file_2 = storage_test_utils.create_file(workspace=workspace, file_size=987654321.0)
+        file_3 = storage_test_utils.create_file(workspace=workspace, file_size=65456.0)
+        file_4 = storage_test_utils.create_file(workspace=workspace, file_size=24564165456.0)
+        manifest_1 = {
+            'seedVersion': '1.0.0',
+            'job': {
+                'name': 'job-a',
+                'jobVersion': '1.0.0',
+                'packageVersion': '1.0.0',
+                'title': '',
+                'description': '',
+                'maintainer': {
+                    'name': 'John Doe',
+                    'email': 'jdoe@example.com'
+                },
+                'timeout': 10,
+                'interface': {
+                    'command': '',
+                    'inputs': {'files': [], 'json': []},
+                    'outputs': {
+                        'files': [{'name': 'OUTPUT_A', 'pattern': '*.png'}]
+                    }
+                }
+            }
+        }
+        job_type_1 = job_test_utils.create_job_type(interface=manifest_1)
+        manifest_2 = {
+            'seedVersion': '1.0.0',
+            'job': {
+                'name': 'job-b',
+                'jobVersion': '1.0.0',
+                'packageVersion': '1.0.0',
+                'title': '',
+                'description': '',
+                'maintainer': {
+                    'name': 'John Doe',
+                    'email': 'jdoe@example.com'
+                },
+                'timeout': 10,
+                'interface': {
+                    'command': '',
+                    'inputs': {'files': [{'name': 'INPUT_B', 'multiple': True}]},
+                    'outputs': {
+                        'files': [{'name': 'OUTPUT_B', 'pattern': '*.png'}]
+                    }
+                }
+            }
+        }
+        job_type_2 = job_test_utils.create_job_type(interface=manifest_2)
+        output_dict = {
+            'version': '1.0',
+            'output_data': [{
+            }]
+        }
+        job_1 = job_test_utils.create_job(job_type=job_type_1, num_exes=1, status='COMPLETED', output=output_dict)
+        job_2 = job_test_utils.create_job(job_type=job_type_2, num_exes=0, status='PENDING', input_file_size=None,
+                                          input=None)
+
+        from recipe.definition.definition import RecipeDefinition
+        from recipe.definition.json.definition_v1 import convert_recipe_definition_to_v1_json
+        from recipe.test import utils as recipe_test_utils
+        definition = RecipeDefinition(Interface())
+        definition.add_job_node('node_a', job_type_1.name, job_type_1.version, job_type_1.revision_num)
+        definition.add_job_node('node_b', job_type_2.name, job_type_2.version, job_type_2.revision_num)
+        definition.add_dependency('node_a', 'node_b')
+        definition.add_dependency_input_connection('node_b', 'INPUT_B', 'node_a', 'OUTPUT_A')
+        def_dict = convert_recipe_definition_to_v1_json(definition).get_dict()
+        recipe_type = recipe_test_utils.create_recipe_type_v6(definition=def_dict)
+        recipe_data_dict = {'version': '1.0', 'input_data': [], 'workspace_id': workspace.id}
+        recipe = recipe_test_utils.create_recipe(recipe_type=recipe_type, input=recipe_data_dict)
+        recipe_test_utils.create_recipe_job(recipe=recipe, job_name='node_a', job=job_1)
+        recipe_test_utils.create_recipe_job(recipe=recipe, job_name='node_b', job=job_2)
+        job_1.recipe = recipe
+        job_1.save()
+        job_2.recipe = recipe
+        job_2.save()
+
+        # Create message
+        message = ProcessJobInput()
+        message.job_id = job_2.id
+
+        # Execute message
+        result = message.execute()
+        self.assertTrue(result)
+
+        job_2 = Job.objects.get(id=job_2.id)
+        # Check for queued jobs message
+        self.assertEqual(len(message.new_messages), 1)
+        self.assertEqual(message.new_messages[0].type, 'queued_jobs')
+        self.assertFalse(message.new_messages[0].requeue)
+
+        # Check job for expected input_file_size
+        self.assertEqual(job_2.input_file_size, 24469.0)
+        # Check job for expected input data
+        self.assertSetEqual(set(job_2.get_input_data().values.keys()), {'INPUT_B'})
+        self.assertListEqual(job_2.get_input_data().values['INPUT_B'].file_ids,
+                             [file_1.id, file_2.id, file_3.id, file_4.id])
+
+        # Make sure job input file models are created
+        job_input_files = JobInputFile.objects.filter(job_id=job_2.id)
+        self.assertEqual(len(job_input_files), 4)
+        file_ids = set()
+        for job_input_file in job_input_files:
+            self.assertEqual(job_input_file.job_input, 'INPUT_B')
+            file_ids.add(job_input_file.input_file_id)
+        self.assertSetEqual(file_ids, {file_1.id, file_2.id, file_3.id, file_4.id})
+
+        # Test executing message again
+        message_json_dict = message.to_json()
+        message = ProcessJobInput.from_json(message_json_dict)
+        result = message.execute()
+        self.assertTrue(result)
+
+        # Still should have queued jobs message
+        self.assertEqual(len(message.new_messages), 1)
+        self.assertEqual(message.new_messages[0].type, 'queued_jobs')
+        self.assertFalse(message.new_messages[0].requeue)
+
+        # Make sure job input file models are unchanged
+        job_input_files = JobInputFile.objects.filter(job_id=job_2.id)
+        self.assertEqual(len(job_input_files), 4)

--- a/scale/job/test/messages/test_process_job_input.py
+++ b/scale/job/test/messages/test_process_job_input.py
@@ -458,36 +458,4 @@ class TestProcessJobInput(TransactionTestCase):
         job_2 = Job.objects.get(id=job_2.id)
         # Check for queued jobs message
         self.assertEqual(len(message.new_messages), 1)
-        self.assertEqual(message.new_messages[0].type, 'queued_jobs')
-        self.assertFalse(message.new_messages[0].requeue)
-
-        # Check job for expected input_file_size
-        self.assertEqual(job_2.input_file_size, 24469.0)
-        # Check job for expected input data
-        self.assertSetEqual(set(job_2.get_input_data().values.keys()), {'INPUT_B'})
-        self.assertListEqual(job_2.get_input_data().values['INPUT_B'].file_ids,
-                             [file_1.id, file_2.id, file_3.id, file_4.id])
-
-        # Make sure job input file models are created
-        job_input_files = JobInputFile.objects.filter(job_id=job_2.id)
-        self.assertEqual(len(job_input_files), 4)
-        file_ids = set()
-        for job_input_file in job_input_files:
-            self.assertEqual(job_input_file.job_input, 'INPUT_B')
-            file_ids.add(job_input_file.input_file_id)
-        self.assertSetEqual(file_ids, {file_1.id, file_2.id, file_3.id, file_4.id})
-
-        # Test executing message again
-        message_json_dict = message.to_json()
-        message = ProcessJobInput.from_json(message_json_dict)
-        result = message.execute()
-        self.assertTrue(result)
-
-        # Still should have queued jobs message
-        self.assertEqual(len(message.new_messages), 1)
-        self.assertEqual(message.new_messages[0].type, 'queued_jobs')
-        self.assertFalse(message.new_messages[0].requeue)
-
-        # Make sure job input file models are unchanged
-        job_input_files = JobInputFile.objects.filter(job_id=job_2.id)
-        self.assertEqual(len(job_input_files), 4)
+        self.assertEqual(message.new_messages[0].type, 'cancel_jobs')

--- a/scale/product/urls.py
+++ b/scale/product/urls.py
@@ -7,6 +7,6 @@ urlpatterns = [
     url(r'^products/$', views.ProductsView.as_view(), name='products_view'),
     url(r'^products/updates/$', views.ProductUpdatesView.as_view(), name='product_updates_view'),
     url(r'^products/(?P<product_id>\d+)/$', views.ProductDetailsView.as_view(), name='product_details_view'),
-    url(r'^products/(?P<file_name>[\w.]{0,250})/$', views.ProductDetailsView.as_view(), name='product_details_view'),
+    url(r'^products/(?P<file_name>[\w.-]{0,250})/$', views.ProductDetailsView.as_view(), name='product_details_view'),
     url(r'^products/(?P<product_id>\d+)/sources/$', views.ProductSourcesView.as_view(), name='product_sources_view'),
 ]

--- a/scale/recipe/serializers.py
+++ b/scale/recipe/serializers.py
@@ -1,7 +1,12 @@
 import rest_framework.serializers as serializers
 
+import logging
+
 from util.rest import ModelIdSerializer
 
+from storage.models import ScaleFile
+
+logger = logging.getLogger(__name__)
 
 # Serializers for v6 REST API
 class RecipeTypeBaseSerializerV6(ModelIdSerializer):
@@ -231,7 +236,14 @@ class RecipeDetailsInputSerializer(serializers.Serializer):
             if obj['type'] == 'file':
                 value = ScaleFileSerializerV5().to_representation(obj['value'])
             elif obj['type'] == 'files':
-                value = [ScaleFileSerializerV5().to_representation(v) for v in obj['value']]
+                if not obj['value']:
+                    logger.warning('Empty file list')
+                    value = []
+                elif isinstance(obj['value'], ScaleFile):
+                    logger.warning('Unexpected single file with type "files": %s' % obj['value'])
+                    value = [ScaleFileSerializerV5().to_representation(obj['value'])]
+                else:
+                    value = [ScaleFileSerializerV5().to_representation(v) for v in obj['value']]
             else:
                 value = obj['value']
         result['value'] = value

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -647,7 +647,7 @@ class TestRecipeTypeDetailsViewV6(TransactionTestCase):
         self.main_definition['nodes']['node_c']['node_type']['recipe_type_name'] = self.recipe_type1.name
         self.main_definition['nodes']['node_c']['node_type']['recipe_type_revision'] = self.recipe_type1.revision_num
 
-        self.recipe_type2 = recipe_test_utils.create_recipe_type_v6(definition=self.main_definition)
+        self.recipe_type2 = recipe_test_utils.create_recipe_type_v6(name='test.period', definition=self.main_definition)
 
     def test_not_found(self):
         """Tests calling the recipe type details view with a name that does not exist."""

--- a/scale/recipe/urls.py
+++ b/scale/recipe/urls.py
@@ -10,9 +10,9 @@ urlpatterns = [
     url(r'^recipe-types/(?P<recipe_type_id>\d+)/$', recipe.views.RecipeTypeIDDetailsView.as_view(), name='recipe_type_id_details_view'),
     url(r'^recipe-types/validation/$', recipe.views.RecipeTypesValidationView.as_view(),
         name='recipe_types_validation_view'),
-    url(r'^recipe-types/(?P<name>[\w-]+)/$', recipe.views.RecipeTypeDetailsView.as_view(), name='recipe_type_details_view'),
-    url(r'^recipe-types/(?P<name>[\w-]+)/revisions/$', recipe.views.RecipeTypeRevisionsView.as_view(), name='recipe_type_revisions_view'),
-    url(r'^recipe-types/(?P<name>[\w-]+)/revisions/(?P<revision_num>\d+)/$', recipe.views.RecipeTypeRevisionDetailsView.as_view(), name='recipe_type_revision_details_view'),
+    url(r'^recipe-types/(?P<name>[\w-.]+)/$', recipe.views.RecipeTypeDetailsView.as_view(), name='recipe_type_details_view'),
+    url(r'^recipe-types/(?P<name>[\w-.]+)/revisions/$', recipe.views.RecipeTypeRevisionsView.as_view(), name='recipe_type_revisions_view'),
+    url(r'^recipe-types/(?P<name>[\w-.]+)/revisions/(?P<revision_num>\d+)/$', recipe.views.RecipeTypeRevisionDetailsView.as_view(), name='recipe_type_revision_details_view'),
 
 
     # Recipe views

--- a/scale/recipe/urls.py
+++ b/scale/recipe/urls.py
@@ -10,9 +10,9 @@ urlpatterns = [
     url(r'^recipe-types/(?P<recipe_type_id>\d+)/$', recipe.views.RecipeTypeIDDetailsView.as_view(), name='recipe_type_id_details_view'),
     url(r'^recipe-types/validation/$', recipe.views.RecipeTypesValidationView.as_view(),
         name='recipe_types_validation_view'),
-    url(r'^recipe-types/(?P<name>[\w-.]+)/$', recipe.views.RecipeTypeDetailsView.as_view(), name='recipe_type_details_view'),
-    url(r'^recipe-types/(?P<name>[\w-.]+)/revisions/$', recipe.views.RecipeTypeRevisionsView.as_view(), name='recipe_type_revisions_view'),
-    url(r'^recipe-types/(?P<name>[\w-.]+)/revisions/(?P<revision_num>\d+)/$', recipe.views.RecipeTypeRevisionDetailsView.as_view(), name='recipe_type_revision_details_view'),
+    url(r'^recipe-types/(?P<name>[\w.-]+)/$', recipe.views.RecipeTypeDetailsView.as_view(), name='recipe_type_details_view'),
+    url(r'^recipe-types/(?P<name>[\w.-]+)/revisions/$', recipe.views.RecipeTypeRevisionsView.as_view(), name='recipe_type_revisions_view'),
+    url(r'^recipe-types/(?P<name>[\w.-]+)/revisions/(?P<revision_num>\d+)/$', recipe.views.RecipeTypeRevisionDetailsView.as_view(), name='recipe_type_revision_details_view'),
 
 
     # Recipe views


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
- data
- ingest
- job
- product
- recipe

### Description of change
Fix for serializer bug (#1538), a bug with periods in urls (#1536) and a bug causing jobs to be stuck pending in recipes.  A legacy job type can execute successfully without creating required output.  This leaves jobs connected to such outputs stuck in a pending state, unable to be queued.  This fix cancels any such pending jobs and any future jobs that get in this state.  Also, jobs that finish without creating required output are marked as failed instead of completing successfully.
