### PR TITLE
#1541 - Logstash Docker tag match to Scale on release

### DIFF
--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -314,15 +314,31 @@ def deploy_elasticsearch(client, app_name):
 
 
 def deploy_logstash(client, app_name, es_urls):
-    # attempt to delete an old instance..if it doesn't exists it will error, but we don't care, so we ignore it
+    """
+    Logic must handle 3 deployment cases when LOGSTASH_DOCKER_IMAGE is unset:
+
+    localhost:5000/geoint/scale:5.9.2
+    localhost:5000/geoint/scale
+    geoint/scale:5.9.2
+
+    The most problematic is the 2nd case as we previously we improperly identifying
+    the port colon as the tag colon.
+    """
+
+    # attempt to delete an old instance..if it doesn't exists it will error but we don't care so we ignore it
     delete_marathon_app(client, app_name)
 
-    #default based on MARATHON_APP_DOCKER_IMAGE with repo/scale:tag updated to repo/scale-logstash:tag
+    # default based on MARATHON_APP_DOCKER_IMAGE with repo/scale:tag updated to repo/scale-logstash:tag
     marathon_img_default = os.getenv('MARATHON_APP_DOCKER_IMAGE')
-    if marathon_img_default.endswith(':'):
-        logstash_docker_img_default = marathon_img_default.replace(':', '-logstash:')
-    else:
-        logstash_docker_img_default = marathon_img_default + '-logstash'
+
+    logstash_docker_img_default = marathon_img_default + '-logstash'
+    if ':' in marathon_img_default:
+        # Grab parts to ensure we replace on tag not port
+        parts = marathon_img_default.split('/')
+        last_index = len(parts) - 1
+        if ':' in parts[last_index]:
+            replacement = parts[last_index].replace(':', '-logstash:')
+            logstash_docker_img_default = marathon_img_default.replace(parts[last_index], replacement)
 
     # Load marathon template file
     marathon = initialize_app_template('logstash', app_name, os.getenv(


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
None

### Description of change
<!-- Please provide a description of the change here. -->
Deployments were failing when testing with a tagged release of Scale and no `LOGSTASH_DOCKER_IMAGE` being set. This PR hardens the logic to ensure we are actually suffixing the image name properly when multiple colons exist in the Docker image (port and tag exist). This was only seen when pulling a Scale release from a Docker registry that had a port specified. 