### PR TITLE
#1542 Fixing save_parse_results bug

### DIFF
--- a/scale/job/configuration/data/job_data.py
+++ b/scale/job/configuration/data/job_data.py
@@ -422,7 +422,7 @@ class JobData(object):
         data_file_parse_saver = DATA_FILE_PARSE_SAVER['DATA_FILE_PARSE_SAVER']
         if not data_file_parse_saver:
             raise Exception('No data file parse saver found')
-        data_file_parse_saver.save_parse_results(parse_results, input_file_ids, is_recipe=is_recipe)
+        data_file_parse_saver.save_parse_results(parse_results, input_file_ids)
 
     def setup_job_dir(self, data_files):
         """Sets up the directory structure for a job execution and downloads the given files

--- a/scale/source/apps.py
+++ b/scale/source/apps.py
@@ -15,6 +15,13 @@ class SourceConfig(AppConfig):
         """
         Override this method in subclasses to run code when Django starts.
         """
+
+        # Register source file parse saver
+        from job.configuration.data.data_file import DATA_FILE_PARSE_SAVER
+        from source.configuration.source_data_file import SourceDataFileParseSaver
+
+        DATA_FILE_PARSE_SAVER['DATA_FILE_PARSE_SAVER'] = SourceDataFileParseSaver()
+
         # Register source message types
         from messaging.messages.factory import add_message_type
         from source.messages.purge_source_file import PurgeSourceFile


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `manage.py test` passes

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
job

### Description of change
<!-- Please provide a description of the change here. -->
The job_data.save_parse_results expects a data file parse saver class to be registered. This was incorrectly un-registered/removed from scale/source/apps.py when triggers were fully removed. There was also a leftover is_recipe parameter from the trigger transition that was not removed.