### PR TITLE
added check to verify value is a float before calling is_intiger

### DIFF
--- a/scale/job/seed/manifest.py
+++ b/scale/job/seed/manifest.py
@@ -101,8 +101,9 @@ class SeedManifest(object):
         resources = self.get_scalar_resources()
         for item in resources:
             if item['name'] == "gpus":
-                if not float.is_integer(item['value']):
-                    raise ValidationError("gpu resource not set to whole number")
+                if isinstance(item['value'], float):
+                    if not float.is_integer(item['value']):
+                        raise ValidationError("gpu resource not set to whole number")
 
     def get_name(self):
         """Gets the Job name


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
job
### Description of change
<!-- Please provide a description of the change here. -->
fixed a bug in validate_resources where verifying a float is a whole number would crash if an int was passed in instead.