### PR TITLE
#1552 Fixing bug where ingest.data_type_tags were being saved as a se…

### DIFF
--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -631,7 +631,7 @@ class Ingest(models.Model):
         :type tags: set of string
         """
 
-        self.data_type_tags = tags
+        self.data_type_tags = list(tags)
 
     def get_ingest_source_event(self):
         """Returns the event that triggered the ingest


### PR DESCRIPTION
…t instead of list

<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
ingest

### Description of change
<!-- Please provide a description of the change here. -->
The data_type_tags ingest field was being saved as a `set` during the process_ingest task of a strike.