### PR TITLE
#1555 - Reprocess Recipe Fails (bad merge)

### DIFF
--- a/scale/job/configuration/data/job_data.py
+++ b/scale/job/configuration/data/job_data.py
@@ -423,7 +423,7 @@ class JobData(object):
         data_file_parse_saver = DATA_FILE_PARSE_SAVER['DATA_FILE_PARSE_SAVER']
         if not data_file_parse_saver:
             raise Exception('No data file parse saver found')
-        data_file_parse_saver.save_parse_results(parse_results, input_file_ids)
+        data_file_parse_saver.save_parse_results(parse_results, input_file_ids, is_recipe=is_recipe)
 
     def setup_job_dir(self, data_files):
         """Sets up the directory structure for a job execution and downloads the given files

--- a/scale/job/execution/configuration/configurators.py
+++ b/scale/job/execution/configuration/configurators.py
@@ -104,6 +104,7 @@ class QueuedExecutionConfigurator(object):
             task_workspaces = QueuedExecutionConfigurator._system_job_workspaces(job)
         else:
             # Set any output workspaces needed
+            output_workspaces = {}
             if job.input and 'version' in job.input and job.input['version'] == '1.0':
                 # Set output workspaces using legacy job data
                 self._cache_workspace_names(data.get_output_workspace_ids())
@@ -111,7 +112,7 @@ class QueuedExecutionConfigurator(object):
                 for output, workspace_id in data.get_output_workspaces().items():
                     output_workspaces[output] = self._cached_workspace_names[workspace_id]
                 config.set_output_workspaces(output_workspaces)
-            else:
+            if not output_workspaces:
                 # Set output workspaces from job configuration
                 output_workspaces = {}
                 job_config = job.get_job_configuration()

--- a/scale/job/messages/process_job_input.py
+++ b/scale/job/messages/process_job_input.py
@@ -68,6 +68,10 @@ class ProcessJobInput(CommandMessage):
         from queue.messages.queued_jobs import create_queued_jobs_messages, QueuedJob
 
         job = Job.objects.get_job_with_interfaces(self.job_id)
+        
+        if job.status not in ['PENDING', 'BLOCKED']:
+            logger.warning('Job %d input has already been processed. Message will not re-run', self.job_id)
+            return True
 
         if not job.has_input():
             if not job.recipe:

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -890,7 +890,7 @@ class JobManager(models.Manager):
 
                 # Add workspace for file outputs if needed
                 if sunset_interface.get_file_output_names():
-                    if 'workspace_id' in job.recipe.input:
+                    if 'workspace_id' in job.recipe.input: # MISSING WORKSPACE IDS BECAUSE WE HAVE A V6 RECIPE!
                         workspace_id = job.recipe.input['workspace_id']
                         sunset_interface.add_workspace_to_data(sunset_job_data, workspace_id)
             input_dict = sunset_job_data.get_dict()

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -889,8 +889,11 @@ class JobManager(models.Manager):
                 sunset_interface = JobInterfaceSunset.create(job.job_type_rev.manifest, do_validate=False)
 
                 # Add workspace for file outputs if needed
-                if sunset_interface.get_file_output_names():
-                    if 'workspace_id' in job.recipe.input: # MISSING WORKSPACE IDS BECAUSE WE HAVE A V6 RECIPE!
+                # Workspace needed if we have outputs and one is not defined in the job config
+                jc = job.get_job_configuration()
+                workspace_exists = jc.output_workspaces or jc.default_output_workspace
+                if sunset_interface.get_file_output_names() and not workspace_exists:
+                    if 'workspace_id' in job.recipe.input:
                         workspace_id = job.recipe.input['workspace_id']
                         sunset_interface.add_workspace_to_data(sunset_job_data, workspace_id)
             input_dict = sunset_job_data.get_dict()

--- a/scale/job/test/execution/configuration/test_configurators.py
+++ b/scale/job/test/execution/configuration/test_configurators.py
@@ -76,7 +76,61 @@ class TestQueuedExecutionConfigurator(TestCase):
         self.assertEqual(main_task['type'], 'main')
         self.assertEqual(main_task['args'], expected_args)
         self.assertDictEqual(main_task['env_vars'], expected_env_vars)
-        
+
+    def test_configure_queued_job_empty_output_data(self):
+        """Tests calling configure_queued_job() on a regular (non-system) job with empty output_data"""
+
+        workspace = storage_test_utils.create_workspace()
+        file_1 = storage_test_utils.create_file()
+        file_2 = storage_test_utils.create_file()
+        file_3 = storage_test_utils.create_file()
+        input_files = {file_1.id: file_1, file_2.id: file_2, file_3.id: file_3}
+        interface_dict = {'version': '1.4', 'command': 'foo',
+                          'command_arguments': '${-a :input_1} ${-b :input_2} ${input_3} ${input_4} ${job_output_dir}',
+                          'input_data': [{'name': 'input_1', 'type': 'property'}, {'name': 'input_2', 'type': 'file'},
+                                         {'name': 'input_3', 'type': 'files'}, {'name': 'input_4', 'type': 'files',
+                                         'required': False}],
+                          'output_data': [{'name': 'output_1', 'type': 'file'}]}
+        data_dict = {'input_data': [{'name': 'input_1', 'value': 'my_val'}, {'name': 'input_2', 'file_id': file_1.id},
+                                    {'name': 'input_3', 'file_ids': [file_2.id, file_3.id]}],
+                     'output_data': []}
+
+        job_config = {
+            'version': '6',
+            'output_workspaces': {'default': workspace.name},
+            'priority': 999
+        }
+
+        input_2_val = os.path.join(SCALE_JOB_EXE_INPUT_PATH, 'input_2', file_1.file_name)
+        input_3_val = os.path.join(SCALE_JOB_EXE_INPUT_PATH, 'input_3')
+        expected_args = '-a my_val -b %s %s ${job_output_dir}' % (input_2_val, input_3_val)
+        expected_env_vars = {'INPUT_1': 'my_val', 'INPUT_2': input_2_val, 'INPUT_3': input_3_val}
+        expected_output_workspaces = {'output_1': workspace.name}
+        job_type = job_test_utils.create_job_type(interface=interface_dict)
+        good_job = job_test_utils.create_job(job_type=job_type, input=data_dict, status='QUEUED', job_config=job_config)
+        bad_job = job_test_utils.create_job(job_type=job_type, input=data_dict, status='QUEUED')
+        configurator = QueuedExecutionConfigurator(input_files)
+
+        # Test method
+        good_exe_config = configurator.configure_queued_job(good_job)
+        bad_exe_config = configurator.configure_queued_job(bad_job)
+
+        good_config_dict = good_exe_config.get_dict()
+        bad_config_dict = bad_exe_config.get_dict()
+        # Make sure the dicts validate
+        ExecutionConfiguration(good_config_dict)
+        ExecutionConfiguration(bad_config_dict)
+        self.assertSetEqual(set(good_config_dict['input_files'].keys()), {'input_2', 'input_3'})
+        self.assertEqual(len(good_config_dict['input_files']['input_2']), 1)
+        self.assertEqual(len(good_config_dict['input_files']['input_3']), 2)
+        self.assertDictEqual(good_config_dict['output_workspaces'], expected_output_workspaces)
+        self.assertNotIn('output_workspaces', bad_config_dict)
+        self.assertEqual(len(good_config_dict['tasks']), 1)
+        main_task = good_config_dict['tasks'][0]
+        self.assertEqual(main_task['type'], 'main')
+        self.assertEqual(main_task['args'], expected_args)
+        self.assertDictEqual(main_task['env_vars'], expected_env_vars)
+
     def test_injected_input_file_env_vars(self):
         """
             Tests successfully injecting the proper values for input files regardless

--- a/scale/job/test/utils.py
+++ b/scale/job/test/utils.py
@@ -212,7 +212,7 @@ def create_clock_event(rule=None, occurred=None):
 
 
 def create_job(job_type=None, event=None, status='PENDING', error=None, input=None, num_exes=1, max_tries=None,
-               queued=None, started=None, ended=None, last_status_change=None, priority=100, output=None,
+               queued=None, started=None, ended=None, last_status_change=None, priority=100, output=None, job_config=None,
                superseded_job=None, is_superseded=False, superseded=None, input_file_size=10.0, recipe=None, save=True):
     """Creates a job model for unit testing
 
@@ -237,9 +237,11 @@ def create_job(job_type=None, event=None, status='PENDING', error=None, input=No
     recipe_id = recipe.id if recipe else None
     root_recipe_id = recipe.root_superseded_recipe_id if recipe else None
 
+    job_config = JobConfigurationV6(job_config).get_configuration() if job_config else None
+
     job_type_rev = JobTypeRevision.objects.get_revision(job_type.name, job_type.version, job_type.revision_num)
     job = Job.objects.create_job_v6(job_type_rev, event_id=event.id, superseded_job=superseded_job, recipe_id=recipe_id,
-                                    root_recipe_id=root_recipe_id)
+                                    root_recipe_id=root_recipe_id, job_config=job_config)
     job.priority = priority
     job.input = input
     job.status = status

--- a/scale/recipe/instance/node.py
+++ b/scale/recipe/instance/node.py
@@ -283,6 +283,9 @@ class JobNodeInstance(NodeInstance):
         """See :meth:`recipe.instance.node.NodeInstance.needs_to_process_input`
         """
 
+        if self.job.status not in ['PENDING', 'BLOCKED']:
+            return False
+            
         # Check parent nodes
         can_process_input = super(JobNodeInstance, self).needs_to_process_input()
 

--- a/scale/recipe/test/utils.py
+++ b/scale/recipe/test/utils.py
@@ -8,6 +8,7 @@ import job.test.utils as job_test_utils
 import trigger.test.utils as trigger_test_utils
 from batch.models import Batch
 from data.data.exceptions import InvalidData
+from job.configuration.json.job_config_v6 import JobConfigurationV6
 from job.messages.create_jobs import RecipeJob
 from job.models import Job, JobTypeRevision
 from queue.messages.queued_jobs import QueuedJob
@@ -438,9 +439,10 @@ def create_jobs_for_recipe(recipe_model, recipe_jobs):
         tup = (recipe_job.job_type_name, recipe_job.job_type_version, recipe_job.job_type_rev_num)
         revision = revs_by_tuple[tup]
         superseded_job = superseded_jobs[node_name] if node_name in superseded_jobs else None
+        job_config = JobConfigurationV6(recipe_model.configuration).get_configuration() if recipe_model.configuration else None
         job = Job.objects.create_job_v6(revision, event_id=recipe_model.event_id, root_recipe_id=recipe_model.root_recipe_id,
                                         recipe_id=recipe_model.id, batch_id=recipe_model.batch_id,
-                                        superseded_job=superseded_job)
+                                        superseded_job=superseded_job, job_config=job_config)
         recipe_jobs_map[node_name] = job
 
     Job.objects.bulk_create(recipe_jobs_map.values())


### PR DESCRIPTION
##### Checklist
- [x] `manage.py test` passes
- [x] tests are included

### Affected app(s)
- job
- recipe

### Description of change
Fixing an infinite message loop that occurs when canceling a job due to failing to process input and fixing reprocessing endpoints so legacy recipe workspace information isn't lost.
