### PR TITLE
#1555 - Reprocess Recipe Fails

### DIFF
--- a/scale/cli/management/commands/migratedata.py
+++ b/scale/cli/management/commands/migratedata.py
@@ -11,7 +11,6 @@ from django.utils import timezone
 from ingest.serializers import IngestDetailsSerializerV5
 from ingest.models import Ingest
 from ingest.triggers.ingest_recipe_handler import IngestRecipeHandler
-from ingest.triggers.ingest_trigger_handler import IngestTriggerHandler
 from source.models import SourceFile
 from storage.media_type import get_media_type
 from storage.models import Workspace
@@ -119,10 +118,8 @@ class Command(BaseCommand):
                     ingest.ingest_ended = timezone.now()
                     ingest.source_file = sf
                     ingest.save()
-                    if options['recipe_type']:
-                        IngestRecipeHandler().process_ingested_source_file(ingest.id, ingest.source_file, ingest.ingest_ended, options['recipe_type'])
-                    else:
-                        IngestTriggerHandler().process_ingested_source_file(ingest.source_file, ingest.ingest_ended)
+                    if options['recipe']:
+                        IngestRecipeHandler().process_ingested_source_file(ingest.id, ingest.source_file, ingest.ingest_ended)
 
         logging.info("Ingests processed, monitor the queue for triggered jobs.")
 

--- a/scale/cli/management/commands/migratedata.py
+++ b/scale/cli/management/commands/migratedata.py
@@ -10,7 +10,8 @@ from django.utils import timezone
 
 from ingest.serializers import IngestDetailsSerializerV5
 from ingest.models import Ingest
-from ingest.triggers.ingest_recipe_handler import RecipeTriggerHandler
+from ingest.triggers.ingest_recipe_handler import IngestRecipeHandler
+from ingest.triggers.ingest_trigger_handler import IngestTriggerHandler
 from source.models import SourceFile
 from storage.media_type import get_media_type
 from storage.models import Workspace
@@ -85,7 +86,7 @@ class Command(BaseCommand):
                 ingest.add_data_type_tag(data_type)
             ingest.status = 'TRANSFERRED'
             if options['no_commit']:
-                s = IngestDetailsSerializer()
+                s = IngestDetailsSerializerV5()
                 logger.info(s.to_representation(ingest))
             else:
                 ingest.save()
@@ -118,8 +119,10 @@ class Command(BaseCommand):
                     ingest.ingest_ended = timezone.now()
                     ingest.source_file = sf
                     ingest.save()
-                    if options['recipe']:
-                        RecipeTriggerHandler().process_ingested_source_file(ingest.id, ingest.source_file, ingest.ingest_ended)
+                    if options['recipe_type']:
+                        IngestRecipeHandler().process_ingested_source_file(ingest.id, ingest.source_file, ingest.ingest_ended, options['recipe_type'])
+                    else:
+                        IngestTriggerHandler().process_ingested_source_file(ingest.source_file, ingest.ingest_ended)
 
         logging.info("Ingests processed, monitor the queue for triggered jobs.")
 

--- a/scale/ingest/triggers/ingest_recipe_handler.py
+++ b/scale/ingest/triggers/ingest_recipe_handler.py
@@ -90,7 +90,7 @@ class IngestRecipeHandler(object):
             logger.info('Queuing new recipe of type %s %s', recipe_type.name, recipe_type.version)
             Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data._new_data, event, ingest_event)
         else:
-            logger.info('No recipe type found for %s %s' % (recipe_name, recipe_version))
+            logger.info('No recipe type found for %s %s' % (recipe_name, recipe_revision))
 
     def _create_ingest_event(self, ingest_id, source, source_file, when):
         """Creates in the database and returns a trigger event model for the given ingested source file and recipe type

--- a/scale/job/configuration/data/job_data.py
+++ b/scale/job/configuration/data/job_data.py
@@ -423,7 +423,7 @@ class JobData(object):
         data_file_parse_saver = DATA_FILE_PARSE_SAVER['DATA_FILE_PARSE_SAVER']
         if not data_file_parse_saver:
             raise Exception('No data file parse saver found')
-        data_file_parse_saver.save_parse_results(parse_results, input_file_ids)
+        data_file_parse_saver.save_parse_results(parse_results, input_file_ids, is_recipe=is_recipe)
 
     def setup_job_dir(self, data_files):
         """Sets up the directory structure for a job execution and downloads the given files

--- a/scale/job/configuration/data/job_data.py
+++ b/scale/job/configuration/data/job_data.py
@@ -423,7 +423,7 @@ class JobData(object):
         data_file_parse_saver = DATA_FILE_PARSE_SAVER['DATA_FILE_PARSE_SAVER']
         if not data_file_parse_saver:
             raise Exception('No data file parse saver found')
-        data_file_parse_saver.save_parse_results(parse_results, input_file_ids, is_recipe=is_recipe)
+        data_file_parse_saver.save_parse_results(parse_results, input_file_ids)
 
     def setup_job_dir(self, data_files):
         """Sets up the directory structure for a job execution and downloads the given files

--- a/scale/job/execution/configuration/configurators.py
+++ b/scale/job/execution/configuration/configurators.py
@@ -104,6 +104,7 @@ class QueuedExecutionConfigurator(object):
             task_workspaces = QueuedExecutionConfigurator._system_job_workspaces(job)
         else:
             # Set any output workspaces needed
+            output_workspaces = {}
             if job.input and 'version' in job.input and job.input['version'] == '1.0':
                 # Set output workspaces using legacy job data
                 self._cache_workspace_names(data.get_output_workspace_ids())
@@ -111,7 +112,7 @@ class QueuedExecutionConfigurator(object):
                 for output, workspace_id in data.get_output_workspaces().items():
                     output_workspaces[output] = self._cached_workspace_names[workspace_id]
                 config.set_output_workspaces(output_workspaces)
-            else:
+            if not output_workspaces:
                 # Set output workspaces from job configuration
                 output_workspaces = {}
                 job_config = job.get_job_configuration()

--- a/scale/job/messages/process_job_input.py
+++ b/scale/job/messages/process_job_input.py
@@ -68,6 +68,10 @@ class ProcessJobInput(CommandMessage):
         from queue.messages.queued_jobs import create_queued_jobs_messages, QueuedJob
 
         job = Job.objects.get_job_with_interfaces(self.job_id)
+        
+        if job.status not in ['PENDING', 'BLOCKED']:
+            logger.warning('Job %d input has already been processed. Message will not re-run', self.job_id)
+            return True
 
         if not job.has_input():
             if not job.recipe:

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -890,7 +890,7 @@ class JobManager(models.Manager):
 
                 # Add workspace for file outputs if needed
                 if sunset_interface.get_file_output_names():
-                    if 'workspace_id' in job.recipe.input:
+                    if 'workspace_id' in job.recipe.input: # MISSING WORKSPACE IDS BECAUSE WE HAVE A V6 RECIPE!
                         workspace_id = job.recipe.input['workspace_id']
                         sunset_interface.add_workspace_to_data(sunset_job_data, workspace_id)
             input_dict = sunset_job_data.get_dict()

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -889,8 +889,11 @@ class JobManager(models.Manager):
                 sunset_interface = JobInterfaceSunset.create(job.job_type_rev.manifest, do_validate=False)
 
                 # Add workspace for file outputs if needed
-                if sunset_interface.get_file_output_names():
-                    if 'workspace_id' in job.recipe.input: # MISSING WORKSPACE IDS BECAUSE WE HAVE A V6 RECIPE!
+                # Workspace needed if we have outputs and one is not defined in the job config
+                jc = job.get_job_configuration()
+                workspace_exists = jc.output_workspaces or jc.default_output_workspace
+                if sunset_interface.get_file_output_names() and not workspace_exists:
+                    if 'workspace_id' in job.recipe.input:
                         workspace_id = job.recipe.input['workspace_id']
                         sunset_interface.add_workspace_to_data(sunset_job_data, workspace_id)
             input_dict = sunset_job_data.get_dict()

--- a/scale/job/test/execution/configuration/test_configurators.py
+++ b/scale/job/test/execution/configuration/test_configurators.py
@@ -76,7 +76,61 @@ class TestQueuedExecutionConfigurator(TestCase):
         self.assertEqual(main_task['type'], 'main')
         self.assertEqual(main_task['args'], expected_args)
         self.assertDictEqual(main_task['env_vars'], expected_env_vars)
-        
+
+    def test_configure_queued_job_empty_output_data(self):
+        """Tests calling configure_queued_job() on a regular (non-system) job with empty output_data"""
+
+        workspace = storage_test_utils.create_workspace()
+        file_1 = storage_test_utils.create_file()
+        file_2 = storage_test_utils.create_file()
+        file_3 = storage_test_utils.create_file()
+        input_files = {file_1.id: file_1, file_2.id: file_2, file_3.id: file_3}
+        interface_dict = {'version': '1.4', 'command': 'foo',
+                          'command_arguments': '${-a :input_1} ${-b :input_2} ${input_3} ${input_4} ${job_output_dir}',
+                          'input_data': [{'name': 'input_1', 'type': 'property'}, {'name': 'input_2', 'type': 'file'},
+                                         {'name': 'input_3', 'type': 'files'}, {'name': 'input_4', 'type': 'files',
+                                         'required': False}],
+                          'output_data': [{'name': 'output_1', 'type': 'file'}]}
+        data_dict = {'input_data': [{'name': 'input_1', 'value': 'my_val'}, {'name': 'input_2', 'file_id': file_1.id},
+                                    {'name': 'input_3', 'file_ids': [file_2.id, file_3.id]}],
+                     'output_data': []}
+
+        job_config = {
+            'version': '6',
+            'output_workspaces': {'default': workspace.name},
+            'priority': 999
+        }
+
+        input_2_val = os.path.join(SCALE_JOB_EXE_INPUT_PATH, 'input_2', file_1.file_name)
+        input_3_val = os.path.join(SCALE_JOB_EXE_INPUT_PATH, 'input_3')
+        expected_args = '-a my_val -b %s %s ${job_output_dir}' % (input_2_val, input_3_val)
+        expected_env_vars = {'INPUT_1': 'my_val', 'INPUT_2': input_2_val, 'INPUT_3': input_3_val}
+        expected_output_workspaces = {'output_1': workspace.name}
+        job_type = job_test_utils.create_job_type(interface=interface_dict)
+        good_job = job_test_utils.create_job(job_type=job_type, input=data_dict, status='QUEUED', job_config=job_config)
+        bad_job = job_test_utils.create_job(job_type=job_type, input=data_dict, status='QUEUED')
+        configurator = QueuedExecutionConfigurator(input_files)
+
+        # Test method
+        good_exe_config = configurator.configure_queued_job(good_job)
+        bad_exe_config = configurator.configure_queued_job(bad_job)
+
+        good_config_dict = good_exe_config.get_dict()
+        bad_config_dict = bad_exe_config.get_dict()
+        # Make sure the dicts validate
+        ExecutionConfiguration(good_config_dict)
+        ExecutionConfiguration(bad_config_dict)
+        self.assertSetEqual(set(good_config_dict['input_files'].keys()), {'input_2', 'input_3'})
+        self.assertEqual(len(good_config_dict['input_files']['input_2']), 1)
+        self.assertEqual(len(good_config_dict['input_files']['input_3']), 2)
+        self.assertDictEqual(good_config_dict['output_workspaces'], expected_output_workspaces)
+        self.assertNotIn('output_workspaces', bad_config_dict)
+        self.assertEqual(len(good_config_dict['tasks']), 1)
+        main_task = good_config_dict['tasks'][0]
+        self.assertEqual(main_task['type'], 'main')
+        self.assertEqual(main_task['args'], expected_args)
+        self.assertDictEqual(main_task['env_vars'], expected_env_vars)
+
     def test_injected_input_file_env_vars(self):
         """
             Tests successfully injecting the proper values for input files regardless

--- a/scale/job/test/utils.py
+++ b/scale/job/test/utils.py
@@ -212,7 +212,7 @@ def create_clock_event(rule=None, occurred=None):
 
 
 def create_job(job_type=None, event=None, status='PENDING', error=None, input=None, num_exes=1, max_tries=None,
-               queued=None, started=None, ended=None, last_status_change=None, priority=100, output=None,
+               queued=None, started=None, ended=None, last_status_change=None, priority=100, output=None, job_config=None,
                superseded_job=None, is_superseded=False, superseded=None, input_file_size=10.0, recipe=None, save=True):
     """Creates a job model for unit testing
 
@@ -237,9 +237,11 @@ def create_job(job_type=None, event=None, status='PENDING', error=None, input=No
     recipe_id = recipe.id if recipe else None
     root_recipe_id = recipe.root_superseded_recipe_id if recipe else None
 
+    job_config = JobConfigurationV6(job_config).get_configuration() if job_config else None
+
     job_type_rev = JobTypeRevision.objects.get_revision(job_type.name, job_type.version, job_type.revision_num)
     job = Job.objects.create_job_v6(job_type_rev, event_id=event.id, superseded_job=superseded_job, recipe_id=recipe_id,
-                                    root_recipe_id=root_recipe_id)
+                                    root_recipe_id=root_recipe_id, job_config=job_config)
     job.priority = priority
     job.input = input
     job.status = status

--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -539,7 +539,8 @@ class QueueManager(models.Manager):
         :type recipe_input: :class:`data.data.data.data`
         :param event: The event that triggered the creation of this recipe
         :type event: :class:`trigger.models.TriggerEvent`
-        :param recipe_config: config of the recipe
+        :param recipe_config: config of the recipe, possibly None
+        :type recipe_config: :class:`recipe.configuration.configuration.RecipeConfiguration`
         :param batch_id: The ID of the batch that contains this recipe
         :type batch_id: int
         :param superseded_recipe: The recipe that the created recipe is superseding, possibly None

--- a/scale/queue/test/test_models.py
+++ b/scale/queue/test/test_models.py
@@ -27,6 +27,7 @@ from job.models import Job
 from queue.models import JobLoad, Queue, QUEUE_ORDER_FIFO, QUEUE_ORDER_LIFO
 from recipe.configuration.data.recipe_data import LegacyRecipeData
 from recipe.configuration.definition.recipe_definition import LegacyRecipeDefinition as RecipeDefinition
+from recipe.configuration.json.recipe_config_v6 import RecipeConfigurationV6
 from recipe.models import Recipe, RecipeNode
 from data.data.json.data_v6 import DataV6
 
@@ -468,7 +469,14 @@ class TestQueueManagerQueueNewRecipe(TransactionTestCase):
         }
         data = JobDataV6(data_dict)
 
-        created_recipe = Queue.objects.queue_new_recipe_v6(recipetype1, data._new_data, event)
+        config_dict = {'version': '6',
+                       'output_workspaces': {'default': workspace.name},
+                       'priority': 999}
+        config = RecipeConfigurationV6(config_dict).get_configuration()
+
+        created_recipe = Queue.objects.queue_new_recipe_v6(recipetype1, data._new_data, event, recipe_config=config)
+
+        self.assertDictEqual(created_recipe.configuration, config_dict)
 
     @patch('queue.models.CommandMessageManager')
     def test_successful_ingest(self, mock_msg_mgr):
@@ -492,7 +500,14 @@ class TestQueueManagerQueueNewRecipe(TransactionTestCase):
         }
         data = JobDataV6(data_dict)
 
-        created_strike_recipe = Queue.objects.queue_new_recipe_v6(recipetype1, data._new_data, None, strike_event)
+        config_dict = {'version': '6',
+                       'output_workspaces': {'default': workspace.name},
+                       'priority': 999}
+        config = RecipeConfigurationV6(config_dict).get_configuration()
+
+        created_strike_recipe = Queue.objects.queue_new_recipe_v6(recipetype1, data._new_data, None, strike_event, recipe_config=config)
+
+        self.assertDictEqual(created_strike_recipe.configuration, config_dict)
 
         data_dict = {
             'version': '1.0',
@@ -506,7 +521,9 @@ class TestQueueManagerQueueNewRecipe(TransactionTestCase):
             }]
         }
         data = JobDataV6(data_dict)
-        created_scan_recipe = Queue.objects.queue_new_recipe_v6(recipetype1, data._new_data, None, scan_event)
+        created_scan_recipe = Queue.objects.queue_new_recipe_v6(recipetype1, data._new_data, None, scan_event, recipe_config=config)
+
+        self.assertDictEqual(created_scan_recipe.configuration, config_dict)
 
     def test_successful_legacy(self):
         """Tests calling QueueManager.queue_new_recipe() successfully."""

--- a/scale/recipe/instance/node.py
+++ b/scale/recipe/instance/node.py
@@ -283,6 +283,9 @@ class JobNodeInstance(NodeInstance):
         """See :meth:`recipe.instance.node.NodeInstance.needs_to_process_input`
         """
 
+        if self.job.status not in ['PENDING', 'BLOCKED']:
+            return False
+            
         # Check parent nodes
         can_process_input = super(JobNodeInstance, self).needs_to_process_input()
 

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -16,11 +16,16 @@ import recipe.test.utils as recipe_test_utils
 import storage.test.utils as storage_test_utils
 import trigger.test.utils as trigger_test_utils
 import source.test.utils as source_test_utils
-from messaging.manager import CommandMessageManager
 from recipe.handlers.graph import RecipeGraph
 from recipe.handlers.graph_delta import RecipeGraphDelta
 from recipe.models import Recipe, RecipeNode, RecipeType, RecipeTypeJobLink, RecipeTypeSubLink
 from rest_framework import status
+
+class MockCommandMessageManager():
+    
+    def send_messages(self, commands):
+        for command in commands:
+            command.execute()
 
 class TestRecipeTypesViewV5(TransactionTestCase):
     """Tests related to the recipe-types base endpoint"""
@@ -2297,14 +2302,12 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         legacy_recipe_handler = recipe_test_utils.create_recipe_handler(recipe_type=self.legacy_recipe_type, data=data)
         self.legacy_recipe = legacy_recipe_handler.recipe
 
-    def execute_messages(messages):
-        for msg in messages:
-            msg.execute()
 
-    @patch('recipe.views.CommandMessageManager.send_messages', side_effect=execute_messages)
-    def test_legacy_all_jobs(self, mock_send):
+    @patch('recipe.views.CommandMessageManager')
+    def test_legacy_all_jobs(self, mock_mgr):
         """Tests reprocessing all jobs in an existing legacy recipe with v6 endpoint"""
 
+        mock_mgr.return_value = MockCommandMessageManager()
         json_data = {
             'forced_nodes': {
                 'all': True

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -16,6 +16,7 @@ import recipe.test.utils as recipe_test_utils
 import storage.test.utils as storage_test_utils
 import trigger.test.utils as trigger_test_utils
 import source.test.utils as source_test_utils
+from messaging.manager import CommandMessageManager
 from recipe.handlers.graph import RecipeGraph
 from recipe.handlers.graph_delta import RecipeGraphDelta
 from recipe.models import Recipe, RecipeNode, RecipeType, RecipeTypeJobLink, RecipeTypeSubLink
@@ -2146,6 +2147,8 @@ class TestRecipeReprocessViewV5(TransactionTestCase):
         results = json.loads(response.content)
         self.assertNotEqual(results['id'], self.recipe1.id)
         self.assertEqual(results['recipe_type']['id'], self.recipe1.recipe_type.id)
+        new_recipe = Recipe.objects.get(pk=results['id'])
+        self.assertDictEqual(new_recipe.input, self.recipe1.input)
 
     def test_job(self):
         """Tests reprocessing one job in an existing recipe"""
@@ -2258,6 +2261,63 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         self.recipe_type = recipe_test_utils.create_recipe_type_v6(name='my-type', definition=def_v6_dict)
         self.recipe1 = recipe_test_utils.create_recipe(recipe_type=self.recipe_type, input=self.data)
         recipe_test_utils.process_recipe_inputs([self.recipe1.id])
+
+        legacy_definition = {
+            'version': '1.0',
+            'input_data': [{
+                'media_types': [
+                    'image/x-hdf5-image',
+                ],
+                'type': 'file',
+                'name': 'input_file',
+            }],
+            'jobs': [{
+                'job_type': {
+                    'name': self.job_type1.name,
+                    'version': self.job_type1.version,
+                },
+                'name': 'kml',
+                'recipe_inputs': [{
+                    'job_input': 'input_file',
+                    'recipe_input': 'input_file',
+                }],
+            }],
+        }
+
+        data = {
+            'version': '1.0',
+            'input_data': [{
+                'name': 'input_file',
+                'file_id': self.file1.id,
+            }],
+            'workspace_id': self.workspace.id,
+        }
+
+        self.legacy_recipe_type = recipe_test_utils.create_recipe_type_v5(name='legacy-type', definition=legacy_definition)
+        legacy_recipe_handler = recipe_test_utils.create_recipe_handler(recipe_type=self.legacy_recipe_type, data=data)
+        self.legacy_recipe = legacy_recipe_handler.recipe
+
+    def execute_messages(messages):
+        for msg in messages:
+            msg.execute()
+
+    @patch('recipe.views.CommandMessageManager.send_messages', side_effect=execute_messages)
+    def test_legacy_all_jobs(self, mock_send):
+        """Tests reprocessing all jobs in an existing legacy recipe with v6 endpoint"""
+
+        json_data = {
+            'forced_nodes': {
+                'all': True
+            }
+        }
+
+        url = '/%s/recipes/%i/reprocess/' % (self.api, self.legacy_recipe.id)
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
+
+        new_recipe = Recipe.objects.get(superseded_recipe_id=self.legacy_recipe.id)
+        self.assertEqual(new_recipe.configuration['output_workspaces']['default'], self.workspace.name)
+
 
     @patch('recipe.views.CommandMessageManager')
     @patch('recipe.views.create_reprocess_messages')

--- a/scale/recipe/test/utils.py
+++ b/scale/recipe/test/utils.py
@@ -8,6 +8,7 @@ import job.test.utils as job_test_utils
 import trigger.test.utils as trigger_test_utils
 from batch.models import Batch
 from data.data.exceptions import InvalidData
+from job.configuration.json.job_config_v6 import JobConfigurationV6
 from job.messages.create_jobs import RecipeJob
 from job.models import Job, JobTypeRevision
 from queue.messages.queued_jobs import QueuedJob
@@ -438,9 +439,10 @@ def create_jobs_for_recipe(recipe_model, recipe_jobs):
         tup = (recipe_job.job_type_name, recipe_job.job_type_version, recipe_job.job_type_rev_num)
         revision = revs_by_tuple[tup]
         superseded_job = superseded_jobs[node_name] if node_name in superseded_jobs else None
+        job_config = JobConfigurationV6(recipe_model.configuration).get_configuration() if recipe_model.configuration else None
         job = Job.objects.create_job_v6(revision, event_id=recipe_model.event_id, root_recipe_id=recipe_model.root_recipe_id,
                                         recipe_id=recipe_model.id, batch_id=recipe_model.batch_id,
-                                        superseded_job=superseded_job)
+                                        superseded_job=superseded_job, job_config=job_config)
         recipe_jobs_map[node_name] = job
 
     Job.objects.bulk_create(recipe_jobs_map.values())


### PR DESCRIPTION
##### Checklist
- [x] `manage.py test` passes
- [x] tests are included

### Affected app(s)
- job
- recipe

### Description of change
Fixing an infinite message loop that occurs when canceling a job due to failing to process input and fixing reprocessing endpoints so legacy recipe workspace information isn't lost.

