### PR TITLE
#1559 - Job Configuration Bugs

### DIFF
--- a/scale/job/configuration/configuration.py
+++ b/scale/job/configuration/configuration.py
@@ -338,7 +338,7 @@ class JobConfiguration(object):
             # Remove mounts not used in the interface
             interface_mount_names = [mount['name'] for mount in interface.get_mounts()]
             for mount_config in self.mounts.values():
-                if mount_config.mount_name not in interface_mount_names:
+                if mount_config.name not in interface_mount_names:
                     warning_str = 'Mount %s will be ignored due to no matching interface designation.' % mount_config.mount_name
                     mounts_to_delete.append({'name': mount_config.mount_name, 'warning': warning_str})
 

--- a/scale/job/configuration/data/job_data.py
+++ b/scale/job/configuration/data/job_data.py
@@ -756,13 +756,13 @@ class JobData(object):
         """
 
         workspace_dict = {}  # {Output name: workspace ID}
-
         if job_data.has_workspaces():
             # Do the old way of getting output workspaces from job data
             for name, output_dict in job_data.data_outputs_by_name.items():
                 workspace_id = output_dict['workspace_id']
                 workspace_dict[name] = workspace_id
-        else:
+        config = job_exe.job.get_job_configuration()
+        if config and (config.default_output_workspace or config.output_workspaces):
             workspace_names_dict = {}  # {Output name: workspace name}
             # Do the new way, grabbing output workspaces from job configuration
             config = job_exe.job.get_job_configuration()

--- a/scale/job/configuration/data/job_data.py
+++ b/scale/job/configuration/data/job_data.py
@@ -765,7 +765,6 @@ class JobData(object):
         if config and (config.default_output_workspace or config.output_workspaces):
             workspace_names_dict = {}  # {Output name: workspace name}
             # Do the new way, grabbing output workspaces from job configuration
-            config = job_exe.job.get_job_configuration()
             for name in output_params:
                 if name in config.output_workspaces:
                     workspace_names_dict[name] = config.output_workspaces[name]
@@ -777,6 +776,8 @@ class JobData(object):
             from storage.models import Workspace
             workspace_mapping = {w.name: w.id for w in Workspace.objects.filter(name__in=workspace_names_dict.values())}
             for output_name, workspace_name in workspace_names_dict.items():
+                if workspace_name not in workspace_mapping:
+                    raise Exception('Workspace with name %s does not exist!' % workspace_name)
                 workspace_dict[output_name] = workspace_mapping[workspace_name]
 
         return workspace_dict

--- a/scale/job/test/configuration/data/test_job_data.py
+++ b/scale/job/test/configuration/data/test_job_data.py
@@ -328,6 +328,8 @@ class TestJobDataStoreOutputDataFiles(TestCase):
 
         job_exe = MagicMock()
         job_exe.id = 1
+        job_exe.job.get_job_configuration().default_output_workspace = None
+        job_exe.job.get_job_configuration().output_workspaces = None
         data = {'output_data': [{'name': 'Param1', 'workspace_id': 1},
                                  {'name': 'Param2', 'workspace_id': 2}]}
         file_path_1 = os.path.join('/path', '1', 'my_file.txt')

--- a/scale/recipe/test/messages/test_create_recipes.py
+++ b/scale/recipe/test/messages/test_create_recipes.py
@@ -1369,21 +1369,21 @@ class TestCreateRecipes(TestCase):
         file2 = storage_test_utils.create_file()
         workspace = storage_test_utils.create_workspace()
 
-        interface_1 = {
-            'version': '1.0',
-            'command': 'my_command',
-            'command_arguments': 'args',
-            'input_data': [{
-                'name': 'Test Input 1',
-                'type': 'file',
-                'media_types': ['text/plain'],
-            }],
-            'output_data': [{
-                'name': 'Test Output 1',
-                'type': 'files',
-                'media_type': 'image/png',
-            }]}
-        job_type_1 = job_test_utils.create_job_type(interface=interface_1)
+        interface_1 = {'version': '1.4', 'command': 'foo',
+                          'command_arguments': '${-a :input_file} ${s_1} ${job_output_dir}',
+                          'env_vars': [{'name': 'my_special_env', 'value': '${s_2}'}],
+                          'mounts': [{'name': 'm_1', 'path': '/the/cont/path', 'mode': 'ro'},
+                                     {'name': 'm_2', 'path': '/the/missing/cont/path', 'mode': 'rw'},
+                                     {'name': 'm_3', 'path': '/the/optional/cont/path', 'mode': 'rw',
+                                      'required': True}],
+                          'settings': [{'name': 's_1'}, {'name': 's_2', 'secret': True}, {'name': 's_3'},
+                                       {'name': 's_4', 'required': False}],
+                          'input_data': [{'name': 'input_file', 'type': 'file'}],
+                          'output_data': [{'name': 'output_1', 'type': 'file'}]}
+
+        job_type_config_dict = {'version': '2.0', 'settings': {'s_1': 's_1_value'},
+                                'mounts': {'m_1': {'type': 'host', 'host_path': '/m_1/host_path'}}}
+        job_type_1 = job_test_utils.create_job_type(interface=interface_1, configuration=job_type_config_dict)
 
         interface_2 = {
             'version': '1.0',
@@ -1415,7 +1415,7 @@ class TestCreateRecipes(TestCase):
                 },
                 'recipe_inputs': [{
                     'recipe_input': 'Recipe Input',
-                    'job_input': 'Test Input 1',
+                    'job_input': 'input_file',
                 }]
             }, {
                 'name': 'Job 2',
@@ -1426,7 +1426,7 @@ class TestCreateRecipes(TestCase):
                 'dependencies': [{
                     'name': 'Job 1',
                     'connections': [{
-                        'output': 'Test Output 1',
+                        'output': 'output_1',
                         'input': 'Test Input 2',
                     }]
                 }]

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -24,8 +24,16 @@ from rest_framework import status
 class MockCommandMessageManager():
     
     def send_messages(self, commands):
-        for command in commands:
-            command.execute()
+        new_commands = []
+        while True:
+            for command in commands:
+                command.execute()
+                new_commands.extend(command.new_messages)
+            commands = new_commands
+            if not new_commands:
+                break
+            new_commands = []
+
 
 class TestRecipeTypesViewV5(TransactionTestCase):
     """Tests related to the recipe-types base endpoint"""
@@ -2267,6 +2275,22 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         self.recipe1 = recipe_test_utils.create_recipe(recipe_type=self.recipe_type, input=self.data)
         recipe_test_utils.process_recipe_inputs([self.recipe1.id])
 
+        interface_dict = {'version': '1.4', 'command': 'foo',
+                          'command_arguments': '${-a :input_file} ${s_1} ${job_output_dir}',
+                          'env_vars': [{'name': 'my_special_env', 'value': '${s_2}'}],
+                          'mounts': [{'name': 'm_1', 'path': '/the/cont/path', 'mode': 'ro'},
+                                     {'name': 'm_2', 'path': '/the/missing/cont/path', 'mode': 'rw'},
+                                     {'name': 'm_3', 'path': '/the/optional/cont/path', 'mode': 'rw',
+                                      'required': True}],
+                          'settings': [{'name': 's_1'}, {'name': 's_2', 'secret': True}, {'name': 's_3'},
+                                       {'name': 's_4', 'required': False}],
+                          'input_data': [{'name': 'input_file', 'type': 'file'}],
+                          'output_data': [{'name': 'output_1', 'type': 'file'}]}
+
+        job_type_config_dict = {'version': '2.0', 'settings': {'s_1': 's_1_value'},
+                                'mounts': {'m_1': {'type': 'host', 'host_path': '/m_1/host_path'}}}
+        self.legacy_job_type = job_test_utils.create_job_type(interface=interface_dict, configuration=job_type_config_dict)
+
         legacy_definition = {
             'version': '1.0',
             'input_data': [{
@@ -2278,8 +2302,8 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
             }],
             'jobs': [{
                 'job_type': {
-                    'name': self.job_type1.name,
-                    'version': self.job_type1.version,
+                    'name': self.legacy_job_type.name,
+                    'version': self.legacy_job_type.version,
                 },
                 'name': 'kml',
                 'recipe_inputs': [{
@@ -2301,7 +2325,6 @@ class TestRecipeReprocessViewV6(TransactionTestCase):
         self.legacy_recipe_type = recipe_test_utils.create_recipe_type_v5(name='legacy-type', definition=legacy_definition)
         legacy_recipe_handler = recipe_test_utils.create_recipe_handler(recipe_type=self.legacy_recipe_type, data=data)
         self.legacy_recipe = legacy_recipe_handler.recipe
-
 
     @patch('recipe.views.CommandMessageManager')
     def test_legacy_all_jobs(self, mock_mgr):


### PR DESCRIPTION
##### Checklist

- [x] `manage.py test` passes
- [x] tests are included

### Affected app(s)
- job
- recipe

### Description of change
Fixed invalid property name and changed output workspace code to always attempt to use job configuration workspaces if present.
