### PR TITLE
#1568 - Scale UI unavailable in IE 11

### DIFF
--- a/scale-ui/app/modules/charts/donut/donutController.js
+++ b/scale-ui/app/modules/charts/donut/donutController.js
@@ -54,7 +54,6 @@
                             ALGORITHM: scaleConfig.colors.failure_algorithm,
                             DATA: scaleConfig.colors.failure_data,
                             SYSTEM: scaleConfig.colors.failure_system,
-                            Offline: scaleConfig.colors.chart_red,
                             'High Failure Rate': scaleConfig.colors.chart_orange,
                             Paused: scaleConfig.colors.chart_yellow
                         }


### PR DESCRIPTION
### Description of change
Bugfix that removes a duplicate property which was preventing the UI from loading in IE 11. Fixes #1568 
