### PR TITLE
#1570 - Only Show Current Job Types in Dashboard

### DIFF
--- a/scale-ui/app/modules/overview/controllers/ovController.js
+++ b/scale-ui/app/modules/overview/controllers/ovController.js
@@ -49,10 +49,10 @@
         };
 
         var getJobTypes = function () {
-            jobTypeService.getJobTypes().then(null, null, function (data) {
+            jobService.getRunningJobs().then(null, null, function (data) {
                 if (data.$resolved) {
                     vm.jobError = null;
-                    vm.jobData.data = data.results;
+                    vm.jobData.data = _.map(data.results, 'job_type');
                     redrawGrid();
                 } else {
                     if (data.statusText && data.statusText !== '') {


### PR DESCRIPTION
### Description of change
Changed the jobs grid on the dashboard to pull from the `job-types/running/` endpoint. Closes #1570
