### PR TITLE
#1580 - Batches Taking Too Long

### DIFF
--- a/scale/batch/test/test_views.py
+++ b/scale/batch/test/test_views.py
@@ -115,8 +115,7 @@ class TestBatchesViewV5(TestCase):
             'definition': {
                 'version': '1.0',
                 'all_jobs': True,
-            },
-            'secret': '12345'
+            }
         }
 
         url = '/v5/batches/'
@@ -155,8 +154,7 @@ class TestBatchesViewV5(TestCase):
                         'workspace_name': workspace.name,
                     },
                 },
-            },
-            'secret': '12345'
+            }
         }
 
         url = '/v5/batches/'
@@ -177,8 +175,7 @@ class TestBatchesViewV5(TestCase):
     def test_create_missing_param(self):
         """Tests creating a batch with missing fields."""
         json_data = {
-            'title': 'batch-test',
-            'secret': '12345'
+            'title': 'batch-test'
         }
 
         url = '/v5/batches/'
@@ -195,8 +192,7 @@ class TestBatchesViewV5(TestCase):
             'definition': {
                 'version': '1.0',
                 'all_jobs': True,
-            },
-            'secret': '12345'
+            }
         }
 
         url = '/v5/batches/'
@@ -215,8 +211,7 @@ class TestBatchesViewV5(TestCase):
                 'date_range': {
                     'type': 'BAD',
                 },
-            },
-            'secret': '12345'
+            }
         }
 
         url = '/v5/batches/'
@@ -320,8 +315,7 @@ class TestBatchesViewV6(TransactionTestCase):
             'title': 'batch-title-test',
             'description': 'batch-description-test',
             'recipe_type_id': self.recipe_type_1.id,
-            'definition': {},
-            'secret': '12345'
+            'definition': {}
         }
 
         url = '/v1/batches/'
@@ -340,8 +334,7 @@ class TestBatchesViewV6(TransactionTestCase):
                 'previous_batch': {
                     'root_batch_id': self.batch_1.root_batch_id
                 }
-            },
-            'secret': '12345'
+            }
         }
 
         url = '/v6/batches/'
@@ -360,8 +353,7 @@ class TestBatchesViewV6(TransactionTestCase):
                 'previous_batch': {
                     'bad_definition': 'foo'
                 }
-            },
-            'secret': '12345'
+            }
         }
 
         url = '/v6/batches/'
@@ -383,8 +375,7 @@ class TestBatchesViewV6(TransactionTestCase):
             },
             'configuration': {
                 'bad-config': 'foo'
-            },
-            'secret': '12345'
+            }
         }
 
         url = '/v6/batches/'
@@ -411,8 +402,7 @@ class TestBatchesViewV6(TransactionTestCase):
             },
             'configuration': {
                 'priority': 100
-            },
-            'secret': '12345'
+            }
         }
 
         url = '/v6/batches/'

--- a/scale/batch/views.py
+++ b/scale/batch/views.py
@@ -141,10 +141,6 @@ class BatchesView(ListCreateAPIView):
         recipe_type_id = rest_util.parse_int(request, 'recipe_type_id')
         title = rest_util.parse_string(request, 'title', required=False)
         description = rest_util.parse_string(request, 'description', required=False)
-        # TODO: require an undocumented secret until #1580 is addressed
-        secret = rest_util.parse_string(request, 'secret', required=True)
-        if secret != '12345':
-            raise Http404
 
         # Make sure the recipe type exists
         try:
@@ -189,10 +185,6 @@ class BatchesView(ListCreateAPIView):
         recipe_type_id = rest_util.parse_int(request, 'recipe_type_id')
         definition_dict = rest_util.parse_dict(request, 'definition')
         configuration_dict = rest_util.parse_dict(request, 'configuration', required=False)
-        # TODO: require an undocumented secret until #1580 is addressed so we can test without accidentally breaking things
-        secret = rest_util.parse_string(request, 'secret', required=True)
-        if secret != '12345':
-            raise Http404
 
         # Make sure the recipe type exists
         try:

--- a/scale/recipe/messages/create_recipes.py
+++ b/scale/recipe/messages/create_recipes.py
@@ -74,6 +74,7 @@ def create_reprocess_messages(root_recipe_ids, recipe_type_name, revision_num, e
             message.forced_nodes = forced_nodes
         elif not message.can_fit_more():
             messages.append(message)
+            message = CreateRecipes()
             message.create_recipes_type = REPROCESS_TYPE
             message.recipe_type_name = recipe_type_name
             message.recipe_type_rev_num = revision_num

--- a/scale/recipe/test/messages/test_create_recipes.py
+++ b/scale/recipe/test/messages/test_create_recipes.py
@@ -1599,3 +1599,13 @@ class TestCreateRecipes(TestCase):
         msg_forced_nodes = convert_forced_nodes_to_v6(process_recipe_input_2_msg.forced_nodes).get_dict()
         forced_nodes_dict = convert_forced_nodes_to_v6(forced_nodes).get_dict()
         self.assertDictEqual(msg_forced_nodes, forced_nodes_dict)
+        
+    def test_create_101_recipes(self):
+        """Tests calling create_reprocess_messages() with 101 recipes
+        """
+        
+        ids = [i for i in range(101)]
+        msgs = create_reprocess_messages(ids, 'recipe-name', 1, 1)
+        self.assertEqual(len(msgs), 2)
+        self.assertEqual(len(msgs[0].root_recipe_ids), 100)
+        self.assertEqual(len(msgs[1].root_recipe_ids), 1)


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included

### Affected app(s)
- recipe

### Description of change
Fixing message bomb caused when calling create recipe messages with over 100 recipes.  The message variable was never reset, so if you had 101 recipes you ended up with two messages with the same 101 recipes in both.
