### PR TITLE
#1601 Reprocessing Recipe Doesn't Use Latest Revision

### DIFF
--- a/scale/docs/rest/v6/recipe.rst
+++ b/scale/docs/rest/v6/recipe.rst
@@ -795,7 +795,8 @@ Request: POST http://.../v6/recipes/{id}/reprocess/
 .. code-block:: javascript
 
   {
-    "forced_nodes": :ref:`rest_v6_recipe_json_forced_nodes`
+    "forced_nodes": :ref:`rest_v6_recipe_json_forced_nodes`,
+    "revision_num": 1
   }
 
 Response: 202 ACCEPTED
@@ -814,6 +815,9 @@ Response: 202 ACCEPTED
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | forced_nodes       | JSON Object       | Required | Set of recipe nodes that should be forced to re-process             |
 |                    |                   |          | See :ref:`Recipe Forced Nodes <rest_v6_recipe_json_forced_nodes>`   |
++--------------------+-------------------+----------+---------------------------------------------------------------------+
+| revision_num       | JSON Object       | Optional | Specific revision of the recipe type that should be ran. The latest |
+|                    |                   |          | revision will be used if this parameter is not specified.           |
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+

--- a/scale/docs/rest/v6/recipe.yml
+++ b/scale/docs/rest/v6/recipe.yml
@@ -614,6 +614,10 @@ components:
       properties:
         forced_nodes:
           $ref: '#/components/schemas/forced_nodes'
+        revision_num:
+          type: integer
+          description: Specific revision of the recipe type that should be ran. 
+            The revision will be used if this parameter is not specified.
 
     forced_nodes:
       title: Forced Nodes

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -1498,16 +1498,14 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
-
-    @patch('recipe.models.CommandMessageManager')
-    def test_updated_recipe(self, mock_mgr):
+        
+    @patch('recipe.views.CommandMessageManager')
+    @patch('recipe.views.create_reprocess_messages')
+    def test_updated_recipe(self, mock_create, mock_msg_mgr):
         """Tests reprocessing a recipe that has been updated"""
-    
-        mock_mgr.return_value = MockCommandMessageManager()
         
         # Test old revision number
         json_data = {
-            
             'forced_nodes': {
                 'all': True
             },
@@ -1517,6 +1515,7 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
         url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
+        mock_create.assert_called()
         
     def test_bad_revision_num(self):
         """Tests reprocessing a recipe with an invalid revision number"""

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -1529,6 +1529,8 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
                        }
         }
         recipe_test_utils.edit_recipe_type_v6(definition=def_v6_dict, recipe_type=self.recipe_type, auto_update=True)
+        
+        # Test latest revision number
         json_data = {
             'forced_nodes': {
                 'all': True
@@ -1539,6 +1541,7 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
         
+        # Test old revision number
         json_data = {
             
             'forced_nodes': {
@@ -1550,6 +1553,20 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
         url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
+        
+        # Test bad revision number
+        json_data = {
+            
+            'forced_nodes': {
+                'all': True
+            },
+            'revision_num': 3
+        }
+        
+        url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
+        
 
 
 class TestRecipeInputFilesViewV6(APITestCase):

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -5,7 +5,6 @@ import datetime
 import django
 import json
 
-from django.db import transaction
 import django.utils.timezone as timezone
 from django.utils.timezone import utc
 from mock import patch
@@ -15,9 +14,7 @@ import job.test.utils as job_test_utils
 import recipe.test.utils as recipe_test_utils
 import storage.test.utils as storage_test_utils
 import source.test.utils as source_test_utils
-from job.models import JobType
 from recipe.models import Recipe, RecipeType, RecipeTypeJobLink, RecipeTypeSubLink
-from recipe.definition.json.definition_v6 import RecipeDefinitionV6
 from rest_framework import status
 from rest_framework.test import APITestCase, APITransactionTestCase
 from util import rest

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -1499,10 +1499,8 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
 
-
-    @patch('recipe.views.CommandMessageManager')
     @patch('recipe.views.create_reprocess_messages')
-    def test_updated_recipe(self, mock_create, mock_msg_mgr):
+    def test_updated_recipe(self, mock_create):
         """Tests reprocessing a recipe that has been updated"""
 
         # Update the job input/output names
@@ -1556,7 +1554,10 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
         mock_create.assert_called()
         
-        # Test bad revision number
+        
+    def test_bad_revision_num(self):
+        """Tests reprocessing a recipe with an invalid revision number"""
+        
         json_data = {
             'forced_nodes': {
                 'all': True
@@ -1567,7 +1568,6 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
         url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
-        mock_create.assert_called()
 
 class TestRecipeInputFilesViewV6(APITestCase):
 

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -1504,37 +1504,6 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
         """Tests reprocessing a recipe that has been updated"""
     
         mock_mgr.return_value = MockCommandMessageManager()
-        # Create recipe with two revisions
-        def_rev_v6_dict = {'version': '6',
-                       'input': {'files': [{'name': 'INPUT_FILE', 'media_types': ['image/tiff'], 'required': True,
-                                            'multiple': True}],
-                                 'json': [{'name': 'INPUT_JSON', 'type': 'string', 'required': True}]},
-                       'nodes': {'node_a': {'dependencies': [],
-                                            'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'},
-                                                      'INPUT_JSON': {'type': 'recipe', 'input': 'INPUT_JSON'}},
-                                            'node_type': {'node_type': 'job', 'job_type_name': self.job_type1.name,
-                                                          'job_type_version': self.job_type1.version, 
-                                                          'job_type_revision': 1}}
-                       }
-        }
-        recipe_type_revised = recipe_test_utils.create_recipe_type_v6(name='revise-me-recipe', definition=def_rev_v6_dict)
-        recipe_revised = recipe_test_utils.create_recipe(recipe_type=recipe_type_revised, input=self.data, config=self.config)
-        recipe_test_utils.process_recipe_inputs([recipe_revised.id])
-
-        # Update the recipe
-        def_v6_dict = {'version': '6',
-                       'input': {'files': [{'name': 'INPUT_FILEE', 'media_types': ['image/tiff'], 'required': True,
-                                            'multiple': False}],
-                                 'json': [{'name': 'INPUT_JSON', 'type': 'string', 'required': True}]},
-                       'nodes': {'node_a': {'dependencies': [],
-                                            'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILEE'},
-                                                      'INPUT_JSON': {'type': 'recipe', 'input': 'INPUT_JSON'}},
-                                            'node_type': {'node_type': 'job', 'job_type_name': self.job_type1.name,
-                                                          'job_type_version': self.job_type1.version, 
-                                                          'job_type_revision': 1}}
-                       }
-        }
-        recipe_test_utils.edit_recipe_type_v6(definition=def_v6_dict, recipe_type=recipe_type_revised, auto_update=True)
         
         # Test old revision number
         json_data = {
@@ -1545,7 +1514,7 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
             'revision_num': 1
         }
         
-        url = '/%s/recipes/%i/reprocess/' % (self.api, recipe_revised.id)
+        url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
         

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -1540,6 +1540,7 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
         url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
+        mock_create.assert_called()
         
         # Test old revision number
         json_data = {
@@ -1553,10 +1554,10 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
         url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
+        mock_create.assert_called()
         
         # Test bad revision number
         json_data = {
-            
             'forced_nodes': {
                 'all': True
             },
@@ -1566,8 +1567,7 @@ class TestRecipeReprocessViewV6(APITransactionTestCase):
         url = '/%s/recipes/%i/reprocess/' % (self.api, self.recipe1.id)
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
-        
-
+        mock_create.assert_called()
 
 class TestRecipeInputFilesViewV6(APITestCase):
 

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -640,6 +640,8 @@ class RecipeReprocessView(GenericAPIView):
                 recipe.recipe_type_rev = RecipeTypeRevision.objects.get_revision(recipe.recipe_type.name, recipe.recipe_type.revision_num)
         except Recipe.DoesNotExist:
             raise Http404
+        except RecipeTypeRevision.DoesNotExist:
+            raise Http404
         if recipe.is_superseded:
             raise BadParameter('Cannot reprocess a superseded recipe')
 

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -623,6 +623,7 @@ class RecipeReprocessView(GenericAPIView):
         """
 
         forced_nodes_json = rest_util.parse_dict(request, 'forced_nodes', required=True)
+        revision_num = rest_util.parse_dict(request, 'revision_num', required=False)
 
         try:
             forced_nodes = ForcedNodesV6(forced_nodes_json, do_validate=True)
@@ -631,7 +632,12 @@ class RecipeReprocessView(GenericAPIView):
             raise BadParameter(unicode(ex))
 
         try:
-            recipe = Recipe.objects.select_related('recipe_type', 'recipe_type_rev').get(id=recipe_id)
+            recipe = Recipe.objects.select_related('recipe_type').get(id=recipe_id)
+            if revision_num:
+                recipe.recipe_type_rev = RecipeTypeRevision.objects.get_revision(recipe.recipe_type.name, revision_num)                
+            else:
+                revision_num = recipe.recipe_type.revision_num
+                recipe.recipe_type_rev = RecipeTypeRevision.objects.get_revision(recipe.recipe_type.name, recipe.recipe_type.revision_num)
         except Recipe.DoesNotExist:
             raise Http404
         if recipe.is_superseded:
@@ -647,8 +653,7 @@ class RecipeReprocessView(GenericAPIView):
         event = TriggerEvent.objects.create_trigger_event('USER', None, {'user': 'Anonymous'}, now())
         root_recipe_id = recipe.root_superseded_recipe_id if recipe.root_superseded_recipe_id else recipe.id
         recipe_type_name = recipe.recipe_type.name
-        revision_num = recipe.recipe_type_rev.revision_num
-
+        
         # Execute all of the messages to perform the reprocess
         messages = create_reprocess_messages([root_recipe_id], recipe_type_name, revision_num, event.id,
                                              forced_nodes=forced_nodes.get_forced_nodes())

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,7 +15,7 @@ then
     psql -d scale -U postgres -c "create extension postgis_topology;"
 
     export COVERAGE_FILE=$root/.coverage
-    coverage run --source='.' manage.py test -v 2
+    coverage run --source='.' manage.py test
 fi
 
 if [ "${BUILD_DOCS}" == "true" ]

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,7 +15,7 @@ then
     psql -d scale -U postgres -c "create extension postgis_topology;"
 
     export COVERAGE_FILE=$root/.coverage
-    coverage run --source='.' manage.py test
+    coverage run --source='.' manage.py test -v 2
 fi
 
 if [ "${BUILD_DOCS}" == "true" ]


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
recipe

### Description of change
<!-- Please provide a description of the change here. -->
The recipe reprocessing endpoint was updated to always pull the latest revision of the recipe type, unless 'revision_num' is specified in the incoming json data. If the revision number is not found a 404 is returned (same as if recipe id not found).