### PR TITLE
#1636 Duplicate Recipe Types / #1638 Update legacy job type migration / #1640 Fix system jobs

### DIFF
--- a/scale/metrics/daily_metrics.py
+++ b/scale/metrics/daily_metrics.py
@@ -40,5 +40,5 @@ class DailyMetricsProcessor(ClockEventProcessor):
         # Schedule one job for each required day
         for day in days:
             job_data = Data()
-            job_data.add_value(JsonValue('Day', day.strftime('%Y-%m-%d')))
+            job_data.add_value(JsonValue('DAY', day.strftime('%Y-%m-%d')))
             Queue.objects.queue_new_job_v6(job_type, job_data, event)

--- a/scale/metrics/fixtures/metrics_job_types.json
+++ b/scale/metrics/fixtures/metrics_job_types.json
@@ -24,10 +24,10 @@
                     },
                     "timeout": 3600,
                     "interface": {
-                         "command": "scale_daily_metrics ${:Day}",
+                         "command": "scale_daily_metrics ${DAY}",
                          "inputs": {
                          	"json": [
-                         		{ "name": "Day", "type": "string", "required": true}
+                         		{ "name": "DAY", "type": "string", "required": true}
                      		]
                          }
                     },
@@ -69,10 +69,10 @@
                     },
                     "timeout": 3600,
                     "interface": {
-                         "command": "scale_daily_metrics ${:Day}",
+                         "command": "scale_daily_metrics ${DAY}",
                          "inputs": {
                          	"json": [
-                         		{ "name": "Day", "type": "string", "required": true}
+                         		{ "name": "DAY", "type": "string", "required": true}
                      		]
                          }
                     },

--- a/scale/metrics/test/test_daily_metrics.py
+++ b/scale/metrics/test/test_daily_metrics.py
@@ -33,7 +33,7 @@ class TestDailyMetricsProcessor(TransactionTestCase):
         call_args = mock_Queue.objects.queue_new_job_v6.call_args[0]
         inputs = convert_data_to_v6_json(call_args[1])
         self.assertEqual(self.job_type, call_args[0])
-        self.assertDictEqual({u'files': {}, u'json': {u'Day': '2015-01-09'}, u'version': u'6'}, inputs.get_dict())
+        self.assertDictEqual({u'files': {}, u'json': {u'DAY': '2015-01-09'}, u'version': u'6'}, inputs.get_dict())
         self.assertEqual(event, call_args[2])
 
     @patch('metrics.daily_metrics.Queue')
@@ -48,7 +48,7 @@ class TestDailyMetricsProcessor(TransactionTestCase):
         call_args = mock_Queue.objects.queue_new_job_v6.call_args[0]
         self.assertEqual(self.job_type, call_args[0])
         inputs = convert_data_to_v6_json(call_args[1])
-        self.assertDictEqual({u'files': {}, u'json': {u'Day': '2015-01-09'}, u'version': u'6'}, inputs.get_dict())
+        self.assertDictEqual({u'files': {}, u'json': {u'DAY': '2015-01-09'}, u'version': u'6'}, inputs.get_dict())
         self.assertEqual(event, call_args[2])
 
     @patch('metrics.daily_metrics.Queue')
@@ -68,11 +68,11 @@ class TestDailyMetricsProcessor(TransactionTestCase):
 
             inputs = convert_data_to_v6_json(args[1])
             if i == 1:
-                self.assertDictEqual({u'files': {}, u'json': {u'Day': '2015-01-07'}, u'version': u'6'}, inputs.get_dict())
+                self.assertDictEqual({u'files': {}, u'json': {u'DAY': '2015-01-07'}, u'version': u'6'}, inputs.get_dict())
             if i == 2:
-                self.assertDictEqual({u'files': {}, u'json': {u'Day': '2015-01-08'}, u'version': u'6'}, inputs.get_dict())
+                self.assertDictEqual({u'files': {}, u'json': {u'DAY': '2015-01-08'}, u'version': u'6'}, inputs.get_dict())
             if i == 3:
-                self.assertDictEqual({u'files': {}, u'json': {u'Day': '2015-01-09'}, u'version': u'6'}, inputs.get_dict())
+                self.assertDictEqual({u'files': {}, u'json': {u'DAY': '2015-01-09'}, u'version': u'6'}, inputs.get_dict())
             i += 1
 
         self.assertEqual(mock_Queue.objects.queue_new_job_v6.call_count, 3)

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -235,7 +235,39 @@ class TestCreateRecipeTypeViewV6(APITransactionTestCase):
         back_links = RecipeTypeSubLink.objects.get_recipe_type_ids(subs)
         self.assertEqual(len(back_links), 1)
         self.assertEqual(back_links[0], recipe_type.id)
+        
+    def test_create_existing(self):
+        
+        main_definition = copy.deepcopy(recipe_test_utils.RECIPE_DEFINITION)
+        main_definition['nodes']['node_a']['node_type']['job_type_name'] = self.job_type2.name
+        main_definition['nodes']['node_a']['node_type']['job_type_version'] = self.job_type2.version
+        main_definition['nodes']['node_a']['node_type']['job_type_revision'] = self.job_type2.revision_num
+        main_definition['nodes']['node_b']['node_type']['job_type_name'] = self.job_type2.name
+        main_definition['nodes']['node_b']['node_type']['job_type_version'] = self.job_type2.version
+        main_definition['nodes']['node_b']['node_type']['job_type_revision'] = self.job_type2.revision_num
+        main_definition['nodes']['node_c']['node_type']['recipe_type_name'] = self.recipe_type1.name
+        main_definition['nodes']['node_c']['node_type']['recipe_type_revision'] = self.recipe_type1.revision_num
 
+        json_data = {
+            'title': 'Recipe Type Post Test',
+            'description': 'This is a test.',
+            'definition': main_definition
+        }
+        url = '/%s/recipe-types/' % self.api
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        
+        orig_type = RecipeType.objects.filter(name='recipe-type-post-test').first()
+        
+        json_data = {
+            'title': 'Recipe Type Post Test',
+            'description': 'This is my recipe test.',
+            'definition': main_definition
+        }
+        url = '/%s/recipe-types/' % self.api
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        
     def test_create_bad_param(self):
         """Tests creating a new recipe type with missing fields."""
 

--- a/scale/util/rest.py
+++ b/scale/util/rest.py
@@ -549,9 +549,7 @@ def title_to_name(queryset, title):
     :raises :class:`Exception`: If unable to generate a unique name.
     """
 
-    name = slugify(title)
-    name = name.replace('_', '-')
-    name = name[:30]
+    name = title_to_basename(title)
     basename = name
     
     index = 0
@@ -561,6 +559,23 @@ def title_to_name(queryset, title):
             raise Exception('Unable to find a unique name. Exiting to prevent infinite loop.')
         
     return name
+    
+def title_to_basename(title):
+    """Generates an identifying basename for a model from a human readable title
+
+    :param title: The title to convert
+    :type title: string
+    :returns: The generated identifying name.
+    :rtype: string
+    """
+    
+    name = slugify(title)
+    name = name.replace('_', '-')
+    name = name[:30]
+    basename = name
+    
+    return basename
+    
     
 def strip_schema_version(json_dict):
     """Returns the given JSON dict after stripping its schema version out


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] migrations are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
job/migrations
recipe-types/ POST api call
Scale Daily Metrics system job
Scale Strike system job

### Description of change
<!-- Please provide a description of the change here. -->
#1636 
Added checking to return an error when a duplicate recipe type is detected on POST. An error message will be returned instead of allowing the duplicate recipe type to be created.

#1638 
The migration to convert legacy job types to seed job types neglected to also update any recipe types that referred to those jobs. This was causing a server 500 error to occur at the v6/recipe-types end point.

#1640
The Scale Daily Metrics job was failing to substitute properly due to the command argument definition of `${:Day}` instead of `${DAY}`. Also updated the Scale Strike system job to reference the strike id argument consistently as STRIKE_ID.