### PR TITLE
#1604 - Seed manifest with no output files

### DIFF
--- a/scale/accounts/test/test_views.py
+++ b/scale/accounts/test/test_views.py
@@ -22,7 +22,7 @@ class TestGetUser(APITestCase):
         url = rest_util.get_url('/accounts/profile/')
         response = self.client.get(url)
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED, response.content)
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN], response.content)
 
     def test_get_current_user(self):
         """Tests calling the GetUser view when authenticated as a basic user."""

--- a/scale/job/configuration/configuration.py
+++ b/scale/job/configuration/configuration.py
@@ -241,8 +241,8 @@ class JobConfiguration(object):
         """
 
         warnings = []
-        seed_outputs = {output_dict['name'] for output_dict in manifest.get_outputs()['files']}
-        seed_outputs.update({output_dict['name'] for output_dict in manifest.get_outputs()['files']})
+        seed_outputs = {output_dict['name'] for output_dict in manifest.get_output_files()}
+        seed_outputs.update({output_dict['name'] for output_dict in manifest.get_output_files()})
 
         workspace_names = set(self.output_workspaces.values())
         if self.default_output_workspace:

--- a/scale/job/seed/results/job_results.py
+++ b/scale/job/seed/results/job_results.py
@@ -38,12 +38,12 @@ class JobResults(object):
     @property
     def files(self):
         """Accessor for files in results"""
-        return convert_data_to_v6_json(self._results_data).get_dict()['files']
+        return convert_data_to_v6_json(self._results_data).get_dict().get('files', [])
 
     @property
     def json(self):
         """Accessor for json in results"""
-        return convert_data_to_v6_json(self._results_data).get_dict()['json']
+        return convert_data_to_v6_json(self._results_data).get_dict().get('json', [])
 
     def add_file_list_parameter(self, name, file_ids):
         """Adds a list of files to the job results

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -1665,6 +1665,25 @@ class TestJobTypesValidationViewV6(APITransactionTestCase):
         self.assertTrue(results['is_valid'])
         self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': []})
 
+    def test_empty_output_successful(self):
+        """Tests validating a new job type without outputs"""
+
+        manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
+        manifest['job']['interface']['outputs'] = {}
+
+        json_data = {
+            'manifest': manifest,
+            'configuration': self.configuration
+        }
+
+        url = '/%s/job-types/validation/' % self.api
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        self.assertTrue(results['is_valid'])
+        self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': []})
+
     def test_successful_configuration(self):
         """Tests validating a new job type with a valid configuration."""
         url = '/%s/job-types/validation/' % self.api


### PR DESCRIPTION
##### Checklist
- [x] `manage.py test` passes
- [x] tests are included

### Affected app(s)
- accounts
- job

### Description of change
Switching from accessing 'files' and 'json' directly to instead use get method and return empty lists if they are missing.
