### PR TITLE
#1648 serializer_class missing from RequeueJobsView / #1650 Strike/Scan job updates

### DIFF
--- a/scale/ingest/fixtures/ingest_job_types.json
+++ b/scale/ingest/fixtures/ingest_job_types.json
@@ -268,7 +268,7 @@
         "pk": null,
         "fields": {
             "name": "scale-scan",
-            "version": "1.0",
+            "version": "1.0.0",
             "is_system": true,
             "is_long_running": false,
             "is_active": true,
@@ -291,8 +291,8 @@
                          "command": "scale_scan -i ${SCAN_ID} -d ${DRY_RUN}",
                          "inputs": {
                             "json": [
-                                {"name": "Scan_ID", "type": "integer", "required": true},
-                                {"name": "Dry_Run", "type": "boolean", "required": true}
+                                {"name": "SCAN_ID", "type": "integer", "required": true},
+                                {"name": "DRY_RUN", "type": "boolean", "required": true}
                             ]
                          }
     		         },
@@ -319,7 +319,7 @@
         "model": "job.JobTypeRevision",
         "pk": null,
         "fields": {
-            "job_type": ["scale-scan", "1.0"],
+            "job_type": ["scale-scan", "1.0.0"],
             "revision_num": 1,
             "manifest": {
 			     "seedVersion": "1.0.0",
@@ -338,8 +338,8 @@
                          "command": "scale_scan -i ${SCAN_ID} -d ${DRY_RUN}",
                          "inputs": {
                             "json": [
-                                {"name": "Scan_ID", "type": "integer", "required": true},
-                                {"name": "Dry_Run", "type": "boolean", "required": true}
+                                {"name": "SCAN_ID", "type": "integer", "required": true},
+                                {"name": "DRY_RUN", "type": "boolean", "required": true}
                             ]
                          }
     		         },

--- a/scale/ingest/fixtures/ingest_job_types.json
+++ b/scale/ingest/fixtures/ingest_job_types.json
@@ -201,7 +201,7 @@
                          "command": "scale_strike -i ${STRIKE_ID}",
                          "inputs": {
                              "json": [
-                                 { "name": "Strike_ID", "type": "integer", "required": true}
+                                 { "name": "STRIKE_ID", "type": "integer", "required": true}
                              ]
                          }
     		         },
@@ -247,7 +247,7 @@
                          "command": "scale_strike -i ${STRIKE_ID}",
                          "inputs": {
                              "json": [
-                                 { "name": "Strike_ID", "type": "integer", "required": true}
+                                 { "name": "STRIKE_ID", "type": "integer", "required": true}
                              ]
                          }
     		         },

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -875,7 +875,7 @@ class ScanManager(models.Manager):
         :rtype: :class:`job.models.JobType`
         """
 
-        return JobType.objects.get(name='scale-scan', version='1.0')
+        return JobType.objects.get(name='scale-scan', version='1.0.0')
 
     def get_scans(self, started=None, ended=None, names=None, order=None):
         """Returns a list of Scan processes within the given time range.
@@ -949,8 +949,8 @@ class ScanManager(models.Manager):
         event_description = {'scan_id': scan.id}
 
         job_data = Data()
-        job_data.add_value(JsonValue('Scan_ID', scan.id))
-        job_data.add_value(JsonValue('Dry_Run', dry_run))
+        job_data.add_value(JsonValue('SCAN_ID', scan.id))
+        job_data.add_value(JsonValue('DRY_RUN', dry_run))
 
         if scan.job:
             raise ScanIngestJobAlreadyLaunched

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -1094,7 +1094,7 @@ class StrikeManager(models.Manager):
         strike_type = self.get_strike_job_type()
 
         job_data = Data()
-        job_data.add_value(JsonValue('Strike_ID', strike.id))
+        job_data.add_value(JsonValue('STRIKE_ID', strike.id))
         event_description = {'strike_id': strike.id}
         event = TriggerEvent.objects.create_trigger_event('STRIKE_CREATED', None, event_description, now())
         strike.job = Queue.objects.queue_new_job_v6(strike_type, job_data, event)

--- a/scale/job/execution/configuration/configurators.py
+++ b/scale/job/execution/configuration/configurators.py
@@ -207,7 +207,7 @@ class QueuedExecutionConfigurator(object):
 
         # Configure Scan workspace based on current configuration
         if job.job_type.name == 'scale-scan':
-            scan_id = data.values['Scan_ID'].value
+            scan_id = data.values['SCAN_ID'].value
             from ingest.models import Scan
             scan = Scan.objects.get(id=scan_id)
             workspace_name = scan.get_scan_configuration().get_workspace()

--- a/scale/job/execution/configuration/configurators.py
+++ b/scale/job/execution/configuration/configurators.py
@@ -199,7 +199,7 @@ class QueuedExecutionConfigurator(object):
 
         # Configure Strike workspace based on current configuration
         if job.job_type.name == 'scale-strike':
-            strike_id = data.values['Strike_ID'].value
+            strike_id = data.values['STRIKE_ID'].value
             from ingest.models import Strike
             strike = Strike.objects.get(id=strike_id)
             workspace_name = strike.get_strike_configuration().get_workspace()

--- a/scale/job/migrations/0056_convert_strike_jobs.py
+++ b/scale/job/migrations/0056_convert_strike_jobs.py
@@ -1,0 +1,37 @@
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+def convert_strike_job_inputs(apps, schema_editor):
+    Strike = apps.get_model('ingest', 'Strike')
+    Job = apps.get_model('job', 'Job')
+    
+    strikes = Strike.objects.all().iterator()
+    for strike in strikes:
+        strike_job = Job.objects.get(pk=strike.job_id)
+        
+        # v5 job data
+        changed = False
+        if strike_job.input['version'] == '6':
+            if 'Strike ID' in strike_job.input['json']:
+                strike_job.input['json']['Strike_ID'] = strike_job.input['json']['Strike ID']
+                del strike_job.input['json'][k]
+                changed = True
+        else:
+            for i_data in strike_job.input['input_data']:
+                if i_data['name'] == 'Strike ID':
+                    i_data['name'] = 'Strike_ID'
+                    changed = True
+
+        if changed:
+            strike_job.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('job', '0055_jobtype_v5_deprecation'),
+    ]
+
+    operations = [
+       migrations.RunPython(convert_strike_job_inputs),
+    ]

--- a/scale/job/migrations/0056_convert_strike_jobs.py
+++ b/scale/job/migrations/0056_convert_strike_jobs.py
@@ -9,18 +9,17 @@ def convert_strike_job_inputs(apps, schema_editor):
     strikes = Strike.objects.all().iterator()
     for strike in strikes:
         strike_job = Job.objects.get(pk=strike.job_id)
-        
-        # v5 job data
+
         changed = False
         if strike_job.input['version'] == '6':
             if 'Strike ID' in strike_job.input['json']:
-                strike_job.input['json']['Strike_ID'] = strike_job.input['json']['Strike ID']
-                del strike_job.input['json'][k]
+                strike_job.input['json']['STRIKE_ID'] = strike_job.input['json']['Strike ID']
+                del strike_job.input['json']['Strike ID']
                 changed = True
         else:
             for i_data in strike_job.input['input_data']:
                 if i_data['name'] == 'Strike ID':
-                    i_data['name'] = 'Strike_ID'
+                    i_data['name'] = 'STRIKE_ID'
                     changed = True
 
         if changed:

--- a/scale/job/migrations/0056_convert_strike_jobs.py
+++ b/scale/job/migrations/0056_convert_strike_jobs.py
@@ -3,6 +3,10 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 def convert_strike_job_inputs(apps, schema_editor):
+    """Converts any strike job inputs to contain the new 'STRIKE_ID' key instead
+    of 'Strike ID'
+    """
+    
     Strike = apps.get_model('ingest', 'Strike')
     Job = apps.get_model('job', 'Job')
     
@@ -24,6 +28,34 @@ def convert_strike_job_inputs(apps, schema_editor):
 
         if changed:
             strike_job.save()
+            
+def convert_scan_job_inputs(apps, schema_editor):
+    """Converts any pending/queued/blocked/running scan job inputs to contain the 
+    new 'SCAN_ID' key instead of 'Scan ID'
+    """
+    
+    Scan = apps.get_model('ingest', 'scan')
+    Job = apps.get_model('job', 'Job')
+    
+    scans = Scan.objects.all().iterator()
+    for scan in scans:
+        scan_job = Job.objects.get(pk=scan.job_id)
+        if scan_job.status in ['PENDING', 'QUEUED', 'BLOCKED', 'RUNNING']:
+            changed = False
+            
+            if scan_job.input['version'] == '6':
+                if 'Scan ID' in scan_job.input['json']:
+                    scan_job.input['json']['SCAN_ID'] = scan_job.input['json']['Scan ID']
+                    del scan_job.input['json']['Scan ID']
+                    changed = True
+            else:
+                for i_data in scan_job.input['input_data']:
+                    if i_data['name'] == 'Scan ID':
+                        i_data['name'] = 'SCAN_ID'
+                        changed = True
+    
+            if changed:
+                scan_job.save()
 
 class Migration(migrations.Migration):
 
@@ -33,4 +65,5 @@ class Migration(migrations.Migration):
 
     operations = [
        migrations.RunPython(convert_strike_job_inputs),
+       migrations.RunPython(convert_scan_job_inputs),
     ]

--- a/scale/job/test/execution/configuration/test_configurators.py
+++ b/scale/job/test/execution/configuration/test_configurators.py
@@ -378,7 +378,7 @@ class TestQueuedExecutionConfigurator(TestCase):
                          'files_to_ingest': [{'filename_regex': '.*txt', 'new_workspace': workspace_2.name}]}
         from ingest.test import utils as ingest_test_utils
         strike = ingest_test_utils.create_strike(configuration=configuration)
-        strike.job.input = {'json': {'Strike_ID': str(strike.id)}}
+        strike.job.input = {'json': {'STRIKE_ID': str(strike.id)}}
         strike.job.status = 'QUEUED'
         strike.job.save()
 

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -708,6 +708,8 @@ class RequeueJobsView(GenericAPIView):
     """This view is the endpoint for re-queuing jobs that have failed or been canceled"""
     parser_classes = (JSONParser,)
     queryset = Job.objects.all()
+    
+    serializer_class = JobSerializerV6
 
     def post(self, request):
         """Submit command message to re-queue jobs that fit the given filter criteria


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included
- [x] migrations are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
Strike/Scan system jobs
ingest
job

### Description of change
<!-- Please provide a description of the change here. -->
#1648 
Added serializer_class to RequeueJobsView to fix server 500 error

#1650 
Included migration to update any existing Strike jobs to reference the updated json input ID STRIKE_ID. Also updating migration to update any existing Scan jobs.