### PR TITLE
#1661 - Fix Security Vulnerability

### DIFF
--- a/scale/pip/production.txt
+++ b/scale/pip/production.txt
@@ -6,7 +6,7 @@ boto3>=1.4.0,<2
 cryptography>=2.3,<3
 dj-database-url
 Django>=1.11.0,<1.12.0
-djangorestframework>=3.6.2,<3.7.0
+djangorestframework>=3.9.1,<3.10.0
 django-filter>=1.1,<2
 django-geoaxis>=0.0.2,<1
 django-oauth-toolkit>=1.1.3,<1.2

--- a/scale/pip/requirements.txt
+++ b/scale/pip/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.4.0,<2
 cryptography>=2.3,<3
 dj-database-url
 Django>=1.11.0,<1.12.0
-djangorestframework>=3.9.1
+djangorestframework>=3.9.1,<3.10.0
 django-filter>=1.1,<2
 django-geoaxis>=0.0.2,<1
 django-oauth-toolkit>=1.1.3,<1.2

--- a/scale/pip/requirements.txt
+++ b/scale/pip/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.4.0,<2
 cryptography>=2.3,<3
 dj-database-url
 Django>=1.11.0,<1.12.0
-djangorestframework>=3.6.2,<3.7.0
+djangorestframework>=3.9.1
 django-filter>=1.1,<2
 django-geoaxis>=0.0.2,<1
 django-oauth-toolkit>=1.1.3,<1.2

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -204,7 +204,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES':
         ('util.rest.ScaleAPIPermissions',),
     'DEFAULT_FILTER_BACKENDS': (
-        'rest_framework.filters.DjangoFilterBackend',
+        'django_filters.rest_framework.DjangoFilterBackend',
     ),
     'DEFAULT_PAGINATION_CLASS': 'util.rest.DefaultPagination',
     'DEFAULT_RENDERER_CLASSES': (


### PR DESCRIPTION
### Checklist

- [x] `manage.py test` passes

### Affected app(s)
- all/none

### Description of change
Changed the requirements for DRF to >= 3.9.1 to address xss vulnerability.  We need to check if there is anything in 3.7, 3.8 or 3.9 that breaks our workflow but the tests pass after fixing the new path for the filter backend.
