### PR TITLE
Bug fixes

### DIFF
--- a/scale/diagnostic/fixtures/diagnostic_recipe_types.json
+++ b/scale/diagnostic/fixtures/diagnostic_recipe_types.json
@@ -1,5 +1,5 @@
 [
-   {
+    {
         "model": "recipe.RecipeType",
         "pk": null,
         "fields": {
@@ -37,6 +37,146 @@
                            "roulette-2": {"dependencies":[{"name": "roulette-1"}], "input":{},
                                           "node_type": {"node_type": "job", "job_type_name": "scale-roulette", "job_type_version": "1.0.0", "job_type_revision": 1}},
                            "roulette-3": {"dependencies":[{"name": "roulette-2"}], "input":{},
+                                          "node_type": {"node_type": "job", "job_type_name": "scale-roulette", "job_type_version": "1.0.0", "job_type_revision": 1}}}
+            },
+            "created": "2017-11-13T00:00:00.0Z"
+        }
+    },
+    {
+        "model": "recipe.RecipeType",
+        "pk": null,
+        "fields": {
+            "name": "scale-hello",
+            "title": "Scale Hello",
+            "description": "Runs the Scale Hello job. This recipe type can be useful for testing Scale's handling of simple jobs.",
+            "is_system": true,
+            "is_active": true,
+            "definition": {
+                 "version": "6",
+                 "input_data": [],
+                 "nodes": {"hello-1": {"dependencies":[], "input":{},
+                                          "node_type": {"node_type": "job", "job_type_name": "scale-hello", "job_type_version": "1.0.0", "job_type_revision": 1}}}
+            },
+            "revision_num": 1,
+            "created": "2017-11-13T00:00:00.0Z",
+            "last_modified": "2017-11-13T00:00:00.0Z"
+        }
+    },
+    {
+        "model": "recipe.RecipeTypeRevision",
+        "pk": null,
+        "fields": {
+            "recipe_type": ["scale-hello"],
+            "revision_num": 1,
+            "definition": {
+                 "version": "6",
+                 "input_data": [],
+                 "nodes": {"hello-1": {"dependencies":[], "input":{},
+                                          "node_type": {"node_type": "job", "job_type_name": "scale-hello", "job_type_version": "1.0.0", "job_type_revision": 1}}}
+            },
+            "created": "2017-11-13T00:00:00.0Z"
+        }
+    },
+    {
+        "model": "recipe.RecipeType",
+        "pk": null,
+        "fields": {
+            "name": "scale-count",
+            "title": "Scale Count",
+            "description": "Runs the Scale Count job. This recipe type can be useful for testing Scale's log outputs.",
+            "is_system": true,
+            "is_active": true,
+            "definition": {
+                 "version": "6",
+                 "input_data": [],
+                 "nodes": {"count-1": {"dependencies":[], "input":{},
+                                          "node_type": {"node_type": "job", "job_type_name": "scale-count", "job_type_version": "1.0.0", "job_type_revision": 1}}}
+            },
+            "revision_num": 1,
+            "created": "2017-11-13T00:00:00.0Z",
+            "last_modified": "2017-11-13T00:00:00.0Z"
+        }
+    },
+    {
+        "model": "recipe.RecipeTypeRevision",
+        "pk": null,
+        "fields": {
+            "recipe_type": ["scale-count"],
+            "revision_num": 1,
+            "definition": {
+                 "version": "6",
+                 "input_data": [],
+                 "nodes": {"count-1": {"dependencies":[], "input":{},
+                                          "node_type": {"node_type": "job", "job_type_name": "scale-count", "job_type_version": "1.0.0", "job_type_revision": 1}}}
+            },
+            "created": "2017-11-13T00:00:00.0Z"
+        }
+    },
+    {
+        "model": "recipe.RecipeType",
+        "pk": null,
+        "fields": {
+            "name": "scale-bake",
+            "title": "Scale Bake",
+            "description": "Runs the Scale Count job. This recipe type can be useful for testing Scale's handling of long running jobs.",
+            "is_system": true,
+            "is_active": true,
+            "definition": {
+                 "version": "6",
+                 "input_data": [],
+                 "nodes": {"bake-1": {"dependencies":[], "input":{},
+                                          "node_type": {"node_type": "job", "job_type_name": "scale-bake", "job_type_version": "1.0.0", "job_type_revision": 1}}}
+            },
+            "revision_num": 1,
+            "created": "2017-11-13T00:00:00.0Z",
+            "last_modified": "2017-11-13T00:00:00.0Z"
+        }
+    },
+    {
+        "model": "recipe.RecipeTypeRevision",
+        "pk": null,
+        "fields": {
+            "recipe_type": ["scale-bake"],
+            "revision_num": 1,
+            "definition": {
+                 "version": "6",
+                 "input_data": [],
+                 "nodes": {"bake-1": {"dependencies":[], "input":{},
+                                          "node_type": {"node_type": "job", "job_type_name": "scale-bake", "job_type_version": "1.0.0", "job_type_revision": 1}}}
+            },
+            "created": "2017-11-13T00:00:00.0Z"
+        }
+    },
+    {
+        "model": "recipe.RecipeType",
+        "pk": null,
+        "fields": {
+            "name": "scale-roulette",
+            "title": "Scale Roulette",
+            "description": "Runs the Scale Roulette job. This recipe type can be useful for testing Scale's handling of jobs that fail.",
+            "is_system": true,
+            "is_active": true,
+            "definition": {
+                 "version": "6",
+                 "input_data": [],
+                 "nodes": {"roulette-1": {"dependencies":[], "input":{},
+                                          "node_type": {"node_type": "job", "job_type_name": "scale-roulette", "job_type_version": "1.0.0", "job_type_revision": 1}}}
+            },
+            "revision_num": 1,
+            "created": "2017-11-13T00:00:00.0Z",
+            "last_modified": "2017-11-13T00:00:00.0Z"
+        }
+    },
+    {
+        "model": "recipe.RecipeTypeRevision",
+        "pk": null,
+        "fields": {
+            "recipe_type": ["scale-roulette"],
+            "revision_num": 1,
+            "definition": {
+                 "version": "6",
+                 "input_data": [],
+                 "nodes": {"roulette-1": {"dependencies":[], "input":{},
                                           "node_type": {"node_type": "job", "job_type_name": "scale-roulette", "job_type_version": "1.0.0", "job_type_revision": 1}}}
             },
             "created": "2017-11-13T00:00:00.0Z"

--- a/scale/diagnostic/test/test_views.py
+++ b/scale/diagnostic/test/test_views.py
@@ -14,7 +14,7 @@ from util import rest
 
 class TestQueueScaleBakeView(APITransactionTestCase):
 
-    fixtures = ['diagnostic_job_types.json']
+    fixtures = ['diagnostic_job_types.json', 'diagnostic_recipe_types.json']
 
     def setUp(self):
         django.setup()
@@ -83,7 +83,7 @@ class TestQueueScaleCasinoView(APITransactionTestCase):
 
 class TestQueueScaleHelloView(APITransactionTestCase):
 
-    fixtures = ['diagnostic_job_types.json']
+    fixtures = ['diagnostic_job_types.json', 'diagnostic_recipe_types.json']
 
     def setUp(self):
         django.setup()
@@ -118,7 +118,7 @@ class TestQueueScaleHelloView(APITransactionTestCase):
 
 class TestQueueScaleRouletteView(APITransactionTestCase):
 
-    fixtures = ['diagnostic_job_types.json']
+    fixtures = ['diagnostic_job_types.json', 'diagnostic_recipe_types.json']
 
     def setUp(self):
         django.setup()

--- a/scale/diagnostic/views.py
+++ b/scale/diagnostic/views.py
@@ -77,9 +77,14 @@ class QueueScaleBakeView(GenericAPIView):
             raise BadParameter('num must be at least 1')
 
         # TODO: in the future, send command message to do this asynchronously
-        job_type = JobType.objects.get(name='scale-bake', version='1.0.0')
-        for _ in xrange(num):
-            Queue.objects.queue_new_job_for_user_v6(job_type, {})
+        try:
+            recipe_type = RecipeType.objects.get(name='scale-bake', revision_num='1')
+            for _ in xrange(num):
+                Queue.objects.queue_new_recipe_for_user_v6(recipe_type, Data())
+        except (InvalidData, InvalidRecipeData, InactiveRecipeType) as ex:
+            message = 'Unable to create new recipe'
+            logger.exception(message)
+            raise BadParameter('%s: %s' % (message, unicode(ex)))
 
         return Response(status=status.HTTP_202_ACCEPTED)
 
@@ -206,9 +211,14 @@ class QueueScaleHelloView(GenericAPIView):
             raise BadParameter('num must be at least 1')
 
         # TODO: in the future, send command message to do this asynchronously
-        job_type = JobType.objects.get(name='scale-hello', version='1.0.0')
-        for _ in xrange(num):
-            Queue.objects.queue_new_job_for_user_v6(job_type, {})
+        try:
+            recipe_type = RecipeType.objects.get(name='scale-hello', revision_num='1')
+            for _ in xrange(num):
+                Queue.objects.queue_new_recipe_for_user_v6(recipe_type, Data())
+        except (InvalidData, InvalidRecipeData, InactiveRecipeType) as ex:
+            message = 'Unable to create new recipe'
+            logger.exception(message)
+            raise BadParameter('%s: %s' % (message, unicode(ex)))
 
         return Response(status=status.HTTP_202_ACCEPTED)
 
@@ -259,9 +269,14 @@ class QueueScaleCountView(GenericAPIView):
             raise BadParameter('num must be at least 1')
 
         # TODO: in the future, send command message to do this asynchronously
-        job_type = JobType.objects.get(name='scale-count', version='1.0')
-        for _ in xrange(num):
-            Queue.objects.queue_new_job_for_user_v6(job_type, {})
+        try:
+            recipe_type = RecipeType.objects.get(name='scale-count', revision_num='1')
+            for _ in xrange(num):
+                Queue.objects.queue_new_recipe_for_user_v6(recipe_type, Data())
+        except (InvalidData, InvalidRecipeData, InactiveRecipeType) as ex:
+            message = 'Unable to create new recipe'
+            logger.exception(message)
+            raise BadParameter('%s: %s' % (message, unicode(ex)))
 
         return Response(status=status.HTTP_202_ACCEPTED)
 
@@ -319,8 +334,13 @@ class QueueScaleRouletteView(GenericAPIView):
             raise BadParameter('num must be at least 1')
 
         # TODO: in the future, send command message to do this asynchronously
-        job_type = JobType.objects.get(name='scale-roulette', version='1.0.0')
-        for _ in xrange(num):
-            Queue.objects.queue_new_job_for_user_v6(job_type, {})
+        try:
+            recipe_type = RecipeType.objects.get(name='scale-roulette', revision_num='1')
+            for _ in xrange(num):
+                Queue.objects.queue_new_recipe_for_user_v6(recipe_type, Data())
+        except (InvalidData, InvalidRecipeData, InactiveRecipeType) as ex:
+            message = 'Unable to create new recipe'
+            logger.exception(message)
+            raise BadParameter('%s: %s' % (message, unicode(ex)))
 
         return Response(status=status.HTTP_202_ACCEPTED)

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1507,7 +1507,8 @@ class JobExecution(models.Model):
         :rtype: tuple of (dict, :class:`datetime.datetime`) with the results or None and the last modified timestamp
         """
 
-        if self.status == 'QUEUED':
+        # If job_exe has not started
+        if not self.started:
             return None, timezone.now()
 
         if settings.ELASTICSEARCH_VERSION and settings.ELASTICSEARCH_VERSION.startswith('2.'):

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1195,7 +1195,7 @@ class Job(models.Model):
         :rtype: bool
         """
 
-        return self.status == 'COMPLETED' and self.has_output()
+        return self.status == 'COMPLETED'
 
     def set_input(self, job_input):
         """Validates and sets the input for this job model. No database update is applied. This job should have its

--- a/scale/recipe/definition/definition.py
+++ b/scale/recipe/definition/definition.py
@@ -382,7 +382,7 @@ class RecipeDefinition(object):
         while unmarked_set:
             node_name = unmarked_set.pop()
             node = self.graph[node_name]
-            self._topological_order_visit(node, results, perm_set, temp_set)
+            results = self._topological_order_visit(node, results, perm_set, temp_set)
             unmarked_set = set(self.graph.keys()) - perm_set
 
         self._topological_order = results
@@ -398,6 +398,8 @@ class RecipeDefinition(object):
         :type perm_set: set
         :param temp_set: A temporary set of visited nodes (node names)
         :type temp_set: set
+        :returns: A list of nodes in topological order
+        :rtype: list
 
         :raises :class:`recipe.definition.exceptions.InvalidDefinition`: If the definition contains a circular
             dependency
@@ -414,3 +416,5 @@ class RecipeDefinition(object):
             perm_set.add(node.name)
             temp_set.remove(node.name)
             results.insert(0, node.name)
+
+        return results

--- a/scale/recipe/instance/node.py
+++ b/scale/recipe/instance/node.py
@@ -108,7 +108,7 @@ class NodeInstance(object):
                     needs_to_be_created = False
                     self.children_can_be_created = False
                     break
-                if parent_node.is_accepted() != self.parental_acceptance[name]:
+                if self.parental_acceptance[name] and not parent_node.is_accepted():
                     needs_to_be_created = False
                     self.children_can_be_created = False
                     break


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [ ] tests are included
- [ ] migrations are included
- [ ] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->

- diagnostic
- recipe
- queue
- job

### Description of change
<!-- Please provide a description of the change here. -->

- Wrapped all diagnostic jobs in recipes.
- Fixed bug where a job node with 0 outputs would block children nodes from running.
- Forced the `recipe.pk` into `root_recipe_id` if there is no root or superseded recipe.  If `root_recipe_id` continues on as `None` a recipe will not complete. 
- Fixed a bug where `calculate_topological_order` was doing calculations in place and not persisting the values it was gathering. 
- Fixed a logic check on determining if a `DummyNode` can turn into a real node.  `self.parental_acceptance[name]` is bool that defines if a child node should be blocked from creation based off its status. `parent_node.is_accepted()` is a bool that defines if the parent node has been accepted.  
- Removed reference to field that was remove when trying to get logs.