### PR TITLE
#1656 - Consistent processing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
 - '2.7'
 
-sudo: true
 cache: packages
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
 - '2.7'
 
+sudo: true
 cache: packages
 addons:
   apt:

--- a/scale/ingest/apps.py
+++ b/scale/ingest/apps.py
@@ -37,3 +37,8 @@ class IngestConfig(AppConfig):
         # Register monitor types
         factory.add_scanner_type(DirScanner)
         factory.add_scanner_type(S3Scanner)
+        
+        # Register messages
+        from ingest.messages.create_ingest_jobs import CreateIngest
+        from messaging.messages.factory import add_message_type
+        add_message_type(CreateIngest)

--- a/scale/ingest/ingest_job.py
+++ b/scale/ingest/ingest_job.py
@@ -108,10 +108,10 @@ def _complete_ingest(ingest, status):
         if status == 'INGESTED':
             ingest.ingest_ended = now()
         ingest.save()
-        if status == 'INGESTED':
-            if ingest.get_recipe_name():
-                IngestRecipeHandler().process_ingested_source_file(ingest.id, ingest.get_ingest_source_event(),
-                    ingest.source_file, ingest.ingest_ended)
+    if status == 'INGESTED':
+        if ingest.get_recipe_name():
+            IngestRecipeHandler().process_ingested_source_file(ingest.id, ingest.get_ingest_source_event(),
+                ingest.source_file, ingest.ingest_ended)
 
 
 def _delete_file(file_path):

--- a/scale/ingest/messages/create_ingest_jobs.py
+++ b/scale/ingest/messages/create_ingest_jobs.py
@@ -150,7 +150,6 @@ class CreateIngest(CommandMessage):
         if ingest.new_workspace:
             data.add_value(JsonValue('new_workspace', ingest.new_workspace.name))
 
-        ingest_job = None
         with transaction.atomic():
             ingest_job = Queue.objects.queue_new_job_v6(ingest_job_type, data, event)
             ingest.job = ingest_job

--- a/scale/ingest/messages/create_ingest_jobs.py
+++ b/scale/ingest/messages/create_ingest_jobs.py
@@ -19,16 +19,11 @@ logger = logging.getLogger(__name__)
 STRIKE_JOB_TYPE = 'strike_job' # Message type for creating strike jobs
 SCAN_JOB_TYPE = 'scan_job' # Message type for creating scan jobs
 
-# This is the maximum number of jobs models that can fit in one message. This maximum ensures that every message of this
-# type is less than 25 KiB long and that each message can be processed quickly.
-MAX_NUM = 100
-
 def create_scan_ingest_job_message(ingest_id, scan_id):
     """Creates a message to create the ingest job for a scan
     
     :param ingest_id: ID of the ingest
     :type ingest_id: int
-    :param workspace_name: The workspace of the ingest
     :param scan_id: The ID of the scan
     :type scan_id: int
     """

--- a/scale/ingest/messages/create_ingest_jobs.py
+++ b/scale/ingest/messages/create_ingest_jobs.py
@@ -10,7 +10,6 @@ from data.data.data import Data
 from data.data.value import JsonValue
 from data.data.json.data_v6 import convert_data_to_v6_json, DataV6
 from job.models import Job
-from job.messages.process_job_input import create_process_job_input_messages
 from messaging.messages.message import CommandMessage
 from queue.models import Queue
 from trigger.models import TriggerEvent
@@ -157,9 +156,6 @@ class CreateIngest(CommandMessage):
             ingest.job = ingest_job
             ingest.status = 'QUEUED'
             ingest.save()
-
-        job = Job.objects.get_details(ingest_job.id)
-        self.new_messages.extend(create_process_job_input_messages([job.pk]))
         
         return True
  

--- a/scale/ingest/messages/create_ingest_jobs.py
+++ b/scale/ingest/messages/create_ingest_jobs.py
@@ -1,0 +1,174 @@
+"""Defines a command message that creates job models"""
+from __future__ import unicode_literals
+
+import logging
+from django.db import transaction
+from django.utils.timezone import now
+
+from data.data.data import Data
+from data.data.value import JsonValue
+from data.data.json.data_v6 import convert_data_to_v6_json, DataV6
+from messaging.messages.message import CommandMessage
+from queue.models import Queue
+from trigger.models import TriggerEvent
+
+logger = logging.getLogger(__name__)
+
+STRIKE_JOB_TYPE = 'strike_job' # Message type for creating strike jobs
+SCAN_JOB_TYPE = 'scan_job' # Message type for creating scan jobs
+
+# This is the maximum number of jobs models that can fit in one message. This maximum ensures that every message of this
+# type is less than 25 KiB long and that each message can be processed quickly.
+MAX_NUM = 100
+
+def create_scan_ingest_job_message(ingest_id, workspace_name, new_workspace_name, scan_id, file_name):
+    """Creates a message to create the ingest job for a scan
+    
+    :param ingest_id: ID of the ingest
+    :type ingest_id: int
+    :param scan_id: The ID of the scan
+    :type scan_id: int
+    :param file_name: The name of the input file
+    :type file_name: string
+    """
+    message = CreateIngest()
+    message.create_ingest_type = SCAN_JOB_TYPE
+    message.ingest_id = ingest_id
+    message.workspace = workspace_name
+    message.new_workspace = new_workspace_name
+    message.scan_id = scan_id
+    message.ingest_file_name = file_name
+    
+    return message
+    
+def create_strike_ingest_job_message(ingest_id, workspace_name, new_workspace_name, strike_id):
+    """Creates a message to create the ingest job for a strike
+    
+    :param ingest_id: ID of the ingest
+    :type ingest_id: int
+    :param strike_id: The ID of the strike
+    :type strike_id: int
+    """
+    message = CreateIngest()
+    message.create_ingest_type = STRIKE_JOB_TYPE
+    message.ingest_id = ingest_id
+    message.workspace = workspace_name
+    message.new_workspace = new_workspace_name
+    message.strike_id = strike_id
+    
+    return message
+    
+class CreateIngest(CommandMessage):
+    """Command message that creates the ingest job
+    """
+    
+    def __init__(self):
+        """Constructor
+        """
+        
+        super(CreateIngest, self).__init__('create_ingest_jobs')
+        
+        # Fields applicable to all message types
+        self.create_ingest_type = None
+        self.ingest_id = None
+        self.workspace = None
+        self.new_workspace = None
+        
+        # Fields applicable to scan message types
+        self.scan_id = None
+        self.ingest_file_name = None
+        
+        # Fields applicable to strike message types
+        self.strike_id = None
+        
+    def can_fit_more(self):
+        """Indicates whether more jobs can fit in this message
+
+        :return: True if more jobs can fit, False otherwise
+        :rtype: bool
+        """
+        return True
+        
+    def to_json(self):
+        """See :meth:`messaging.messages.message.CommandMessage.to_json`
+        """
+        json_dict = {
+            'create_ingest_type': self.create_ingest_type, 
+            'ingest_id': self.ingest_id,
+            'workspace': self.workspace
+        }
+        
+        if self.new_workspace:
+            json_dict['new_workspace'] = self.new_workspace
+        
+        if self.create_ingest_type == STRIKE_JOB_TYPE:
+            json_dict['strike_id'] = self.strike_id
+        elif self.create_ingest_type == SCAN_JOB_TYPE:
+            json_dict['scan_id'] = self.scan_id
+            json_dict['ingest_file_name'] = self.ingest_file_name
+        
+        return json_dict    
+        
+    @staticmethod
+    def from_json(json_dict):
+        """See :meth:`messaging.messages.message.CommandMessage.from_json`
+        """
+        
+        message = CreateIngest()
+        message.ingest_id = json_dict['ingest_id']
+        message.create_ingest_type = json_dict['create_ingest_type']
+        message.workspace = json_dict['workspace']
+        
+        if 'new_workspace' in json_dict:
+            message.new_workspace = json_dict['new_workspace']
+        if message.create_ingest_type == STRIKE_JOB_TYPE:
+            message.strike_id = json_dict['strike_id']
+        elif message.create_ingest_type == SCAN_JOB_TYPE:
+            message.scan_id = json_dict['scan_id']
+            message.ingest_file_name = json_dict['ingest_file_name']
+        
+        return message
+        
+    def execute(self):
+        """See :meth:`messaging.messages.message.CommandMessage.execute`
+        """
+        from ingest.models import Ingest
+        ingest_job_type = Ingest.objects.get_ingest_job_type()
+        
+        # Grab the ingest object
+        ingest = Ingest.objects.get(pk=self.ingest_id)
+        
+        when = ingest.transfer_ended if ingest.transfer_ended else now()
+        desc = {'file_name': ingest.file_name}
+        
+        with transaction.atomic():
+            # Create the appropriate triggerevent
+            event = None
+            if self.create_ingest_type == STRIKE_JOB_TYPE:
+                ingest_id = ingest.id
+                desc['strike_id'] = self.strike_id
+                event =  TriggerEvent.objects.create_trigger_event('STRIKE_TRANSFER', None, desc, when)
+            elif self.create_ingest_type == SCAN_JOB_TYPE:
+                ingest_id = Ingest.objects.get(scan_id=self.scan_id, file_name=self.ingest_file_name).id
+                event = TriggerEvent.objects.create_trigger_event('SCAN_TRANSFER', None, desc, when)
+            
+        data = Data()
+        data.add_value(JsonValue('ingest_id', ingest_id))
+        data.add_value(JsonValue('workspace', self.workspace))
+        if self.new_workspace:
+            data.add_value(JsonValue('new_workspace', self.new_workspace))
+            
+        ingest_job = Queue.objects.queue_new_job_v6(ingest_job_type, data, event)
+        ingest.job = ingest_job
+        ingest.status = 'QUEUED'
+        ingest.save()
+        
+        from job.messages.process_job_input import create_process_job_input_messages
+        from job.models import Job
+        Queue.objects.queue_jobs([ingest_job])
+        job = Job.objects.get_details(ingest_job.id)
+        self.new_messages.extend(create_process_job_input_messages([job.pk]))
+        
+        return True
+ 
+        

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -305,7 +305,7 @@ class IngestManager(models.Manager):
             
             if scan_id:
                 # TODO: Need to make sure scans work
-                messages.append(create_scan_ingest_job_message(ingest.id, scan_id, ingest.file_name))
+                messages.append(create_scan_ingest_job_message(ingest.id, scan_id))
             elif strike_id:
                 messages.append(create_strike_ingest_job_message(ingest.id, strike_id))
             else:
@@ -935,18 +935,18 @@ class ScanManager(models.Manager):
         if scan.job:
             raise ScanIngestJobAlreadyLaunched
 
-        job_pk = None
+        job_id = None
         if dry_run:
             event = TriggerEvent.objects.create_trigger_event('DRY_RUN_SCAN_CREATED', None, event_description, now())
             scan.dry_run_job = Queue.objects.queue_new_job_v6(scan_type, job_data, event)
-            job_pk = scan.dry_run_job.pk
+            job_id = scan.dry_run_job.id
         else:
             event = TriggerEvent.objects.create_trigger_event('SCAN_CREATED', None, event_description, now())
             scan.job = Queue.objects.queue_new_job_v6(scan_type, job_data, event)
-            job_pk = scan.job.pk
+            job_id = scan.job.id
 
         scan.save()
-        CommandMessageManager().send_messages(create_process_job_input_messages([job_pk]))
+        CommandMessageManager().send_messages(create_process_job_input_messages([job_id]))
 
         return scan
 
@@ -1083,7 +1083,7 @@ class StrikeManager(models.Manager):
         event = TriggerEvent.objects.create_trigger_event('STRIKE_CREATED', None, event_description, now())
         strike.job = Queue.objects.queue_new_job_v6(strike_type, job_data, event)
         strike.save()
-        CommandMessageManager().send_messages(create_process_job_input_messages([strike.job.pk]))
+        CommandMessageManager().send_messages(create_process_job_input_messages([strike.job.id]))
 
         return strike
 

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -302,12 +302,11 @@ class IngestManager(models.Manager):
         for ingest in ingests:
             logger.debug('Creating ingest task for %s', ingest.file_name)
             
-            workspace = ingest.workspace.name
-            new_workspace = ingest.new_workspace.name if ingest.new_workspace else None
             if scan_id:
-                messages.append(create_scan_ingest_job_message(ingest.id, workspace, new_workspace, scan_id, ingest.file_name))
+                # TODO: Need to make sure scans work
+                messages.append(create_scan_ingest_job_message(ingest.id, scan_id, ingest.file_name))
             elif strike_id:
-                messages.append(create_strike_ingest_job_message(ingest.id, workspace, new_workspace, strike_id))
+                messages.append(create_strike_ingest_job_message(ingest.id, strike_id))
             else:
                 raise Exception('One of scan_id or strike_id must be set')
 

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -14,6 +14,7 @@ from django.utils.timezone import now
 
 from data.data.data import Data
 from data.data.value import JsonValue
+from ingest.messages.create_ingest_jobs import create_scan_ingest_job_message, create_strike_ingest_job_message
 from ingest.scan.configuration.scan_configuration import ScanConfiguration
 from ingest.scan.configuration.json.configuration_v6 import ScanConfigurationV6
 from ingest.scan.configuration.exceptions import InvalidScanConfiguration
@@ -22,6 +23,7 @@ from ingest.strike.configuration.strike_configuration import StrikeConfiguration
 from ingest.strike.configuration.json.configuration_v6 import StrikeConfigurationV6
 from ingest.strike.configuration.exceptions import InvalidStrikeConfiguration
 from job.models import JobType
+from messaging.manager import CommandMessageManager
 from queue.models import Queue
 from storage.exceptions import InvalidDataTypeTag
 from storage.media_type import get_media_type
@@ -283,7 +285,6 @@ class IngestManager(models.Manager):
         groups = self._group_by_time(ingests, use_ingest_time)
         return [self._fill_status(status, time_slots, started, ended) for status, time_slots in groups.iteritems()]
 
-    @transaction.atomic
     def start_ingest_tasks(self, ingests, scan_id=None, strike_id=None):
         """Starts a batch of tasks for the given scan in an atomic transaction.
 
@@ -296,44 +297,23 @@ class IngestManager(models.Manager):
         :param strike_id: ID of Strike that generated ingest
         :type strike_id: int
         """
-
-        # Create new ingest job and mark ingest as QUEUED
-        ingest_job_type = Ingest.objects.get_ingest_job_type()
-
+        
+        messages = []
         for ingest in ingests:
             logger.debug('Creating ingest task for %s', ingest.file_name)
-
-            when = ingest.transfer_ended if ingest.transfer_ended else now()
-            desc = {'file_name': ingest.file_name}
-
+            
+            workspace = ingest.workspace.name
+            new_workspace = ingest.new_workspace.name if ingest.new_workspace else None
             if scan_id:
-                # Use result from query to get ingest ID
-                # We need to find the id of each ingest that was created.
-                # Using scan_id and file_name together as a unique composite key
-                ingest_id = Ingest.objects.get(scan_id=ingest.scan_id, file_name=ingest.file_name).id
-
-                desc['scan_id'] = scan_id
-                event = TriggerEvent.objects.create_trigger_event('SCAN_TRANSFER', None, desc, when)
+                messages.append(create_scan_ingest_job_message(ingest.id, workspace, new_workspace, scan_id, ingest.file_name))
             elif strike_id:
-                ingest_id = ingest.id
-                desc['strike_id'] = strike_id
-                event = TriggerEvent.objects.create_trigger_event('STRIKE_TRANSFER', None, desc, when)
+                messages.append(create_strike_ingest_job_message(ingest.id, workspace, new_workspace, strike_id))
             else:
                 raise Exception('One of scan_id or strike_id must be set')
 
-            data = Data()
-            data.add_value(JsonValue('ingest_id', ingest_id))
-            data.add_value(JsonValue('workspace', ingest.workspace.name))
-            if ingest.new_workspace:
-                data.add_value(JsonValue('new_workspace', ingest.new_workspace.name))
-
-            ingest_job = Queue.objects.queue_new_job_v6(ingest_job_type, data, event)
-
-            ingest.job = ingest_job
-            ingest.status = 'QUEUED'
-            ingest.save()
-
-            logger.debug('Successfully created ingest task for %s', ingest.file_name)
+        CommandMessageManager().send_messages(messages)
+            
+        logger.debug('Successfully created ingest task for %s', ingest.file_name)
 
     def _group_by_time(self, ingests, use_ingest_time):
         """Groups the given ingests by hourly time slots.

--- a/scale/ingest/strike/monitors/monitor.py
+++ b/scale/ingest/strike/monitors/monitor.py
@@ -178,7 +178,7 @@ class Monitor(object):
 
         # Rule match case
         if ingest.is_there_rule_match(self._file_handler, self._workspaces):
-            # save the updates to file_path and file_size
+            # save the updates to file_path and file_size and start the tasks
             ingest.save()
             Ingest.objects.start_ingest_tasks([ingest], strike_id=self.strike_id)
         # No rule match

--- a/scale/ingest/strike/monitors/monitor.py
+++ b/scale/ingest/strike/monitors/monitor.py
@@ -157,10 +157,9 @@ class Monitor(object):
         logger.info('%s has finished transferring to %s, total of %s copied', ingest.file_name, ingest.workspace.name,
                     file_size_to_string(bytes_transferred))
 
-    @transaction.atomic
     def _process_ingest(self, ingest, file_path, file_size):
         """Processes the ingest file by applying the Strike configuration rules. This method will update the ingest
-        model in the database and create an ingest task (if applicable) in an atomic transaction. This method should
+        model in the database and create the ingest task message (if applicable). This method should
         either be called immediately after Ingest.objects.create_ingest() or after _complete_transfer().
 
         :param ingest: The ingest model
@@ -179,8 +178,8 @@ class Monitor(object):
 
         # Rule match case
         if ingest.is_there_rule_match(self._file_handler, self._workspaces):
-            if not ingest.id:
-                ingest.save()
+            # save the updates to file_path and file_size
+            ingest.save()
             Ingest.objects.start_ingest_tasks([ingest], strike_id=self.strike_id)
         # No rule match
         else:

--- a/scale/ingest/test/messages/__init__.py
+++ b/scale/ingest/test/messages/__init__.py
@@ -1,0 +1,4 @@
+import logging
+
+# Disable logging for unit tests
+logging.disable(logging.CRITICAL)

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -11,12 +11,11 @@ import recipe.test.utils as recipe_test_utils
 import storage.test.utils as storage_test_utils
 from job.models import Job
 from ingest.messages.create_ingest_jobs import create_strike_ingest_job_message, \
-                                               create_scan_ingest_job_message, CreateIngest, STRIKE_JOB_TYPE
+                                               create_scan_ingest_job_message,  \
+                                               CreateIngest, STRIKE_JOB_TYPE
 from ingest.models import Ingest, Strike, Scan
 from ingest.scan.configuration.json.configuration_v6 import ScanConfigurationV6
 from ingest.strike.configuration.json.configuration_v6 import StrikeConfigurationV6
-from messaging.backends.amqp import AMQPMessagingBackend
-from messaging.backends.factory import add_message_backend
 from storage.models import ScaleFile
 
 
@@ -26,26 +25,29 @@ class TestCreateIngest(TestCase):
     
     def setUp(self):
         django.setup()
-        add_message_backend(AMQPMessagingBackend)
-
-        self.workspace_1 = storage_test_utils.create_workspace()
-        self.workspace_2 = storage_test_utils.create_workspace()
-        self.source_file = ScaleFile.objects.create(file_name='input_file', file_type='SOURCE',
+        
+        
+    def test_json_create(self):
+        """Tests converting a CreateIngest message to and from json
+        """
+        workspace_1 = storage_test_utils.create_workspace()
+        workspace_2 = storage_test_utils.create_workspace()
+        source_file = ScaleFile.objects.create(file_name='input_file', file_type='SOURCE',
                                                media_type='text/plain', file_size=10, data_type_tags=['type1'],
-                                               file_path='the_path', workspace=self.workspace_1)
+                                               file_path='the_path', workspace=workspace_1)
 
-        self.source_file.add_data_type_tag('type1')
-        self.source_file.add_data_type_tag('type2')
-        self.source_file.add_data_type_tag('type3')
+        source_file.add_data_type_tag('type1')
+        source_file.add_data_type_tag('type2')
+        source_file.add_data_type_tag('type3')
 
-        self.ingest = Ingest.objects.create(file_name='input_file', file_size=10, status='TRANSFERRING', 
+        ingest = Ingest.objects.create(file_name='input_file', file_size=10, status='TRANSFERRING', 
                                             bytes_transferred=10, transfer_started=now(), media_type='text/plain',
                                             ingest_started=now(), data_started=now(), 
-                                            workspace=self.workspace_1, new_workspace=self.workspace_2, 
-                                            data_type_tags=['type1'], source_file=self.source_file)
+                                            workspace=workspace_1, new_workspace=workspace_2, 
+                                            data_type_tags=['type1'], source_file=source_file)
 
         manifest = job_test_utils.create_seed_manifest(inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
-        self.jt1 = job_test_utils.create_seed_job_type(manifest=manifest)
+        jt1 = job_test_utils.create_seed_job_type(manifest=manifest)
         recipe_type_def = {'version': '6',
                            'input': {'files': [{'name': 'INPUT_FILE',
                                                 'media_types': ['text/plain'],
@@ -54,58 +56,51 @@ class TestCreateIngest(TestCase):
                                     'json': []},
                            'nodes': {'node_a': {'dependencies': [],
                                                 'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-                                                'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
-                                                              'job_type_version': self.jt1.version,
+                                                'node_type': {'node_type': 'job', 'job_type_name': jt1.name,
+                                                              'job_type_version': jt1.version,
                                                               'job_type_revision': 1}}}}
 
-        self.recipe_type = recipe_test_utils.create_recipe_type_v6(name='test-recipe', definition=recipe_type_def)
+        recipe_type = recipe_test_utils.create_recipe_type_v6(name='test-recipe', definition=recipe_type_def)
 
         strike_config = {
             'version': '6',
-            'workspace': self.workspace_1.name,
+            'workspace': workspace_1.name,
             'monitor': {'type': 'dir-watcher', 'transfer_suffix': '_tmp'},
             'files_to_ingest': [{
                 'filename_regex': 'input_file',
                 'data_types': ['image_type'],
-                'new_workspace': self.workspace_2.name,
+                'new_workspace': workspace_2.name,
                 'new_file_path': 'my/path'
             }],
             'recipe': {
-                'name': self.recipe_type.name
+                'name': recipe_type.name
             },
         }
         config = StrikeConfigurationV6(strike_config).get_configuration()
-        self.strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
+        strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
 
-        scan_config = {
-            'workspace': self.workspace_1.name,
-            'scanner': {
-                'type': 'dir'
-            },
-            'files_to_ingest': [{
-                'filename_regex': 'input_file',
-                'data_types': ['type1'],
-                'new_file_path': os.path.join('my', 'path'),
-                'new_workspace': self.workspace_2.name,
-            }],
-            'recipe': {
-                'name': self.recipe_type.name,
-            },
-        }
-        scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
-        self.scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
-        
-    @patch('queue.models.create_process_job_input_messages')
-    @patch('queue.models.CommandMessageManager')
-    @patch('ingest.messages.create_ingest_jobs.create_strike_ingest_job_message')
-    def test_json_create(self, mock_create, mock_msg_mgr, mock_process):
-        """Tests converting a CreateIngest message to and from json
-        """
+        # scan_config = {
+        #     'workspace': workspace_1.name,
+        #     'scanner': {
+        #         'type': 'dir'
+        #     },
+        #     'files_to_ingest': [{
+        #         'filename_regex': 'input_file',
+        #         'data_types': ['type1'],
+        #         'new_file_path': os.path.join('my', 'path'),
+        #         'new_workspace': workspace_2.name,
+        #     }],
+        #     'recipe': {
+        #         'name': recipe_type.name,
+        #     },
+        # }
+        # scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
+        # scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
 
         message = CreateIngest()
         message.create_ingest_type = STRIKE_JOB_TYPE
-        message.ingest_id = self.ingest.id
-        message.strike_id = self.strike.id
+        message.ingest_id = ingest.id
+        message.strike_id = strike.id
 
         # Convert message to JSON and back, and then execute
         message_dict = message.to_json()
@@ -119,11 +114,11 @@ class TestCreateIngest(TestCase):
         job_data = job.get_input_data()
         for value in job_data.values:
             if value == 'ingest_id':
-                self.assertEqual(job_data.values[value].value, self.ingest.id)
+                self.assertEqual(job_data.values[value].value, ingest.id)
             elif value == 'workspace':
-                self.assertEqual(job_data.values[value].value, self.workspace_1.name)
+                self.assertEqual(job_data.values[value].value, workspace_1.name)
             elif value == 'new_workspace':
-                self.assertEqual(job_data.values[value].value, self.workspace_2.name)
+                self.assertEqual(job_data.values[value].value, workspace_2.name)
             
         # Verify job has been queueud
         from queue.models import Queue

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -130,31 +130,31 @@ class TestCreateIngest(TestCase):
         queue = Queue.objects.get(job_id=job.id)
         self.assertEqual(queue.job_id, job.id)
 
-    @patch('queue.models.create_process_job_input_messages')
-    @patch('queue.models.CommandMessageManager')
-    @patch('ingest.messages.create_ingest_jobs.create_strike_ingest_job_message')
-    def test_execute(self, mock_create, mock_msg_mgr, mock_process):
-        """Tests executing a CreateIngest message """
-        message = create_strike_ingest_job_message(self.ingest.id, self.strike.id)
-        result = message.execute()
-        self.assertTrue(result)
+    # @patch('queue.models.create_process_job_input_messages')
+    # @patch('queue.models.CommandMessageManager')
+    # @patch('ingest.messages.create_ingest_jobs.create_strike_ingest_job_message')
+    # def test_execute(self, mock_create, mock_msg_mgr, mock_process):
+    #     """Tests executing a CreateIngest message """
+    #     message = create_strike_ingest_job_message(self.ingest.id, self.strike.id)
+    #     result = message.execute()
+    #     self.assertTrue(result)
         
-         # Verify the ingest job has been created
-        job = Job.objects.all().last()
-        self.assertEqual(job.job_type.name, 'scale-ingest')
-        job_data = job.get_input_data()
-        for value in job_data.values:
-            if value == 'ingest_id':
-                self.assertEqual(job_data.values[value].value, self.ingest.id)
-            elif value == 'workspace':
-                self.assertEqual(job_data.values[value].value, self.workspace_1.name)
-            elif value == 'new_workspace':
-                self.assertEqual(job_data.values[value].value, self.workspace_2.name)
+    #      # Verify the ingest job has been created
+    #     job = Job.objects.all().last()
+    #     self.assertEqual(job.job_type.name, 'scale-ingest')
+    #     job_data = job.get_input_data()
+    #     for value in job_data.values:
+    #         if value == 'ingest_id':
+    #             self.assertEqual(job_data.values[value].value, self.ingest.id)
+    #         elif value == 'workspace':
+    #             self.assertEqual(job_data.values[value].value, self.workspace_1.name)
+    #         elif value == 'new_workspace':
+    #             self.assertEqual(job_data.values[value].value, self.workspace_2.name)
             
-        # Verify job has been queueud
-        from queue.models import Queue
-        queue = Queue.objects.get(job_id=job.id)
-        self.assertEqual(queue.job_id, job.id)
+    #     # Verify job has been queueud
+    #     from queue.models import Queue
+    #     queue = Queue.objects.get(job_id=job.id)
+    #     self.assertEqual(queue.job_id, job.id)
         
         # TODO test scan ingest job
         # message = create_scan_ingest_job_message(self.ingest.id, self.workspace_1.name, self.workspace_2.name,

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -153,7 +153,7 @@ class TestCreateIngest(TestCase):
         
         # TODO test scan ingest job
         # message = create_scan_ingest_job_message(self.ingest.id, self.workspace_1.name, self.workspace_2.name,
-        #                                            self.scan.id, self.source_file.file_name)
+        #                                            self.scan.id)
         # result = message.execute()
         # self.assertTrue(result)
         # self.assertEqual(len(message.new_messages), 1)

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -15,18 +15,15 @@ from ingest.messages.create_ingest_jobs import create_strike_ingest_job_message,
 from ingest.models import Ingest, Strike, Scan
 from ingest.scan.configuration.json.configuration_v6 import ScanConfigurationV6
 from ingest.strike.configuration.json.configuration_v6 import StrikeConfigurationV6
-from messaging.backends.amqp import AMQPMessagingBackend
-from messaging.backends.factory import add_message_backend
 from storage.models import ScaleFile
 
 
 class TestCreateIngest(TestCase):
     
-    fixtures = ['ingest_job_types']
+    fixtures = ['ingest_job_types.json']
     
     def setUp(self):
         django.setup()
-        add_message_backend(AMQPMessagingBackend)
 
         self.workspace_1 = storage_test_utils.create_workspace()
         self.workspace_2 = storage_test_utils.create_workspace()

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -12,14 +12,14 @@ class TestCreateIngest(TestCase):
     def setUp(self):
         django.setup()
         
-    def test_json_create_strike(self):
+    def test_json_create(self):
         """Tests converting a CreateIngest message to and from json
         """
         
         message = CreateIngest()
         message.create_ingest_type = 'strike_job'
         message.strike_id = 1
-        message.scan_id = 1
+        message.ingest_id = 1
         
         message_json_dict = message.to_json()
         new_message = CreateIngest.from_json(message_json_dict)
@@ -27,4 +27,30 @@ class TestCreateIngest(TestCase):
         self.assertEqual(new_message.ingest_id, message.ingest_id)
         self.assertEqual(new_message.strike_id, message.strike_id)
         self.assertEqual(new_message.create_ingest_type, message.create_ingest_type)
-       
+        self.assertIsNone(new_message.scan_id)
+        
+        scan_message = CreateIngest()
+        scan_message.create_ingest_type = 'scan_job'
+        scan_message.scan_id = 2
+        scan_message.ingest_id = 2
+    
+        scan_message_json_dict = scan_message.to_json()
+        new_scan_message = CreateIngest.from_json(scan_message_json_dict)
+        
+        self.assertEqual(new_scan_message.ingest_id, scan_message.ingest_id)
+        self.assertEqual(new_scan_message.scan_id, scan_message.scan_id)
+        self.assertEqual(new_scan_message.create_ingest_type, scan_message.create_ingest_type)
+        self.assertIsNone(new_scan_message.strike_id)
+        
+    def test_execute(self):
+        """Tests executing a CreateIngest message
+        """
+        
+        message = CreateIngest()
+        message.create_ingest_type = 'strike_job'
+        message.strike_id = 1
+        message.ingest_id = 1
+        
+        result = message.execute()
+        
+        self.assertFalse(result)

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -95,9 +95,10 @@ class TestCreateIngest(TestCase):
         scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
         self.scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
         
-    @patch('queue.models.CommandMessageManager')
     @patch('queue.models.create_process_job_input_messages')
-    def test_json_create(self, mock_create, mock_msg_mgr):
+    @patch('queue.models.CommandMessageManager')
+    @patch('ingest.messages.create_ingest_jobs.create_strike_ingest_job_message')
+    def test_json_create(self, mock_create, mock_msg_mgr, mock_process):
         """Tests converting a CreateIngest message to and from json
         """
 
@@ -129,9 +130,10 @@ class TestCreateIngest(TestCase):
         queue = Queue.objects.get(job_id=job.id)
         self.assertEqual(queue.job_id, job.id)
 
-    @patch('queue.models.CommandMessageManager')
     @patch('queue.models.create_process_job_input_messages')
-    def test_execute(self, mock_create, mock_msg_mgr):
+    @patch('queue.models.CommandMessageManager')
+    @patch('ingest.messages.create_ingest_jobs.create_strike_ingest_job_message')
+    def test_execute(self, mock_create, mock_msg_mgr, mock_process):
         """Tests executing a CreateIngest message """
         message = create_strike_ingest_job_message(self.ingest.id, self.strike.id)
         result = message.execute()

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -1,0 +1,80 @@
+from __future__ import unicode_literals
+
+import django
+from django.test import TestCase
+from django.utils.timezone import now
+
+import job.test.utils as job_test_utils
+import ingest.test.utils as ingest_test_utils
+import recipe.test.utils as recipe_test_utils
+import storage.test.utils as storage_test_utils
+
+from ingest.messages.create_ingest_jobs import create_strike_ingest_job_message
+from ingest.models import Strike
+from ingest.strike.configuration.json.configuration_v6 import StrikeConfigurationV6
+from messaging.backends.amqp import AMQPMessagingBackend
+from messaging.backends.factory import add_message_backend
+from storage.models import ScaleFile
+
+
+class TestCreateIngest(TestCase):
+    
+    fixtures = ['ingest_job_types']
+    
+    def setUp(self):
+        django.setup()
+        add_message_backend(AMQPMessagingBackend)
+        
+        manifest = job_test_utils.create_seed_manifest(inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
+        self.jt1 = job_test_utils.create_seed_job_type(manifest=manifest)
+        recipe_type_def = {'version': '6',
+                           'input': {'files': [{'name': 'INPUT_FILE',
+                                                'media_types': ['text/plain'],
+                                                'required': True,
+                                                'multiple': True}],
+                                    'json': []},
+                           'nodes': {'node_a': {'dependencies': [],
+                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
+                                                'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
+                                                              'job_type_version': self.jt1.version,
+                                                              'job_type_revision': 1}}}}
+
+        self.recipe = recipe_test_utils.create_recipe_type_v6(name='test-recipe', definition=recipe_type_def)
+        
+    def test_json_create(self):
+        """Tests converting a CreateIngest message to and from json
+        """
+        
+        workspace_1 = storage_test_utils.create_workspace()
+        workspace_2 = storage_test_utils.create_workspace()
+        source_file = ScaleFile.objects.create(file_name='input_file', file_type='SOURCE',
+                                               media_type='text/plain', file_size=10, data_type_tags=['type1'],
+                                                file_path='the_path', workspace=workspace_1)
+        source_file.add_data_type_tag('type1')
+        source_file.add_data_type_tag('type2')
+        source_file.add_data_type_tag('type3')
+        
+        ingest = ingest_test_utils.create_ingest(source_file=source_file, new_workspace=workspace_2)
+        
+        strike_config = {
+            'version': '6',
+            'workspace': workspace_1.name,
+            'monitor': {'type': 'dir-watcher', 'transfer_suffix': '_tmp'},
+            'files_to_ingest': [{
+                'filename_regex': 'input_file',
+                'data_types': ['image_type'],
+                'new_workspace': workspace_2.name,
+                'new_file_path': 'my/path'
+            }],
+            'recipe': {
+                'name': self.recipe.name
+            },
+        }
+        config = StrikeConfigurationV6(strike_config).get_configuration()
+        strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
+        
+        message = create_strike_ingest_job_message(ingest.id, ingest.workspace.name, ingest.new_workspace.name, strike.id)
+        message.execute()
+        import pdb; pdb.set_trace()
+        pass
+        

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -1,33 +1,9 @@
 from __future__ import unicode_literals
 
-import os
 import django
 from django.test import TestCase
-from django.utils.timezone import now
-from mock import patch
 
-import job.test.utils as job_test_utils
-import recipe.test.utils as recipe_test_utils
-import storage.test.utils as storage_test_utils
-from job.models import Job
-from ingest.messages.create_ingest_jobs import create_strike_ingest_job_message, CreateIngest
-from ingest.models import Ingest, Strike, Scan
-from ingest.scan.configuration.json.configuration_v6 import ScanConfigurationV6
-from ingest.strike.configuration.json.configuration_v6 import StrikeConfigurationV6
-from storage.models import ScaleFile
-
-class MockCommandMessageManager():
-
-     def send_messages(self, commands):
-        new_commands = []
-        while True:
-            for command in commands:
-                command.execute()
-                new_commands.extend(command.new_messages)
-            commands = new_commands
-            if not new_commands:
-                break
-            new_commands = []
+from ingest.messages.create_ingest_jobs import CreateIngest
 
 class TestCreateIngest(TestCase):
     
@@ -36,136 +12,19 @@ class TestCreateIngest(TestCase):
     def setUp(self):
         django.setup()
         
-        self.workspace_1 = storage_test_utils.create_workspace()
-        self.workspace_2 = storage_test_utils.create_workspace()
-        self.source_file = ScaleFile.objects.create(file_name='input_file', file_type='SOURCE',
-                                               media_type='text/plain', file_size=10, data_type_tags=['type1'],
-                                               file_path='the_path', workspace=self.workspace_1)
-
-        self.source_file.add_data_type_tag('type1')
-        self.source_file.add_data_type_tag('type2')
-        self.source_file.add_data_type_tag('type3')
-
-        self.ingest = Ingest.objects.create(file_name='input_file', file_size=10, status='TRANSFERRING', 
-                                            bytes_transferred=10, transfer_started=now(), media_type='text/plain',
-                                            ingest_started=now(), data_started=now(), 
-                                            workspace=self.workspace_1, new_workspace=self.workspace_2, 
-                                            data_type_tags=['type1'], source_file=self.source_file)
-
-        manifest = job_test_utils.create_seed_manifest(inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
-        jt1 = job_test_utils.create_seed_job_type(manifest=manifest)
-        recipe_type_def = {'version': '6',
-                           'input': {'files': [{'name': 'INPUT_FILE',
-                                                'media_types': ['text/plain'],
-                                                'required': True,
-                                                'multiple': True}],
-                                    'json': []},
-                           'nodes': {'node_a': {'dependencies': [],
-                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-                                                'node_type': {'node_type': 'job', 'job_type_name': jt1.name,
-                                                              'job_type_version': jt1.version,
-                                                              'job_type_revision': 1}}}}
-
-        self.recipe_type = recipe_test_utils.create_recipe_type_v6(name='test-recipe', definition=recipe_type_def)
-
-        strike_config = {
-            'version': '6',
-            'workspace': self.workspace_1.name,
-            'monitor': {'type': 'dir-watcher', 'transfer_suffix': '_tmp'},
-            'files_to_ingest': [{
-                'filename_regex': 'input_file',
-                'data_types': ['image_type'],
-                'new_workspace': self.workspace_2.name,
-                'new_file_path': 'my/path'
-            }],
-            'recipe': {
-                'name': self.recipe_type.name
-            },
-        }
-        config = StrikeConfigurationV6(strike_config).get_configuration()
-        self.strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
-
-        # scan_config = {
-        #     'workspace': self.workspace_1.name,
-        #     'scanner': {
-        #         'type': 'dir'
-        #     },
-        #     'files_to_ingest': [{
-        #         'filename_regex': 'input_file',
-        #         'data_types': ['type1'],
-        #         'new_file_path': os.path.join('my', 'path'),
-        #         'new_workspace': self.workspace_2.name,
-        #     }],
-        #     'recipe': {
-        #         'name': self.recipe_type.name,
-        #     },
-        # }
-        # scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
-        # self.scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
-        
-
     def test_json_create_strike(self):
         """Tests converting a CreateIngest message to and from json
         """
         
-        message = create_strike_ingest_job_message(self.ingest.id, self.strike.id)
+        message = CreateIngest()
+        message.create_ingest_type = 'strike_job'
+        message.strike_id = 1
+        message.scan_id = 1
         
-        # message = CreateIngest()
-        # message.create_ingest_type = 'strike_job'
-        # message.ingest_id = self.ingest.id
-        # message.strike_id = self.strike.id
-
-        # Convert message to JSON and back, and then execute
-        message_dict = message.to_json()
-        new_message = CreateIngest.from_json(message_dict)
-        result = new_message.execute()
-
-        self.assertTrue(result)
-        # Verify the ingest job has been created
-        job = Job.objects.all().last()
-        self.assertEqual(job.job_type.name, 'scale-ingest')
-        job_data = job.get_input_data()
-        for value in job_data.values:
-            if value == 'ingest_id':
-                self.assertEqual(job_data.values[value].value, self.ingest.id)
-            elif value == 'workspace':
-                self.assertEqual(job_data.values[value].value, self.workspace_1.name)
-            elif value == 'new_workspace':
-                self.assertEqual(job_data.values[value].value, self.workspace_2.name)
-            
-
-    # @patch('queue.models.create_process_job_input_messages')
-    # @patch('queue.models.CommandMessageManager')
-    # @patch('ingest.messages.create_ingest_jobs.create_strike_ingest_job_message')
-    # def test_execute(self, mock_create, mock_msg_mgr, mock_process):
-    #     """Tests executing a CreateIngest message """
-    #     message = create_strike_ingest_job_message(self.ingest.id, self.strike.id)
-    #     result = message.execute()
-    #     self.assertTrue(result)
+        message_json_dict = message.to_json()
+        new_message = CreateIngest.from_json(message_json_dict)
         
-    #      # Verify the ingest job has been created
-    #     job = Job.objects.all().last()
-    #     self.assertEqual(job.job_type.name, 'scale-ingest')
-    #     job_data = job.get_input_data()
-    #     for value in job_data.values:
-    #         if value == 'ingest_id':
-    #             self.assertEqual(job_data.values[value].value, self.ingest.id)
-    #         elif value == 'workspace':
-    #             self.assertEqual(job_data.values[value].value, self.workspace_1.name)
-    #         elif value == 'new_workspace':
-    #             self.assertEqual(job_data.values[value].value, self.workspace_2.name)
-            
-    #     # Verify job has been queueud
-    #     from queue.models import Queue
-    #     queue = Queue.objects.get(job_id=job.id)
-    #     self.assertEqual(queue.job_id, job.id)
-        
-        # TODO test scan ingest job
-        # message = create_scan_ingest_job_message(self.ingest.id, self.workspace_1.name, self.workspace_2.name,
-        #                                            self.scan.id)
-        # result = message.execute()
-        # self.assertTrue(result)
-        # self.assertEqual(len(message.new_messages), 1)
-        # new_message = message.new_messages[0]
-        # self.assertTrue(new_message.type, 'process_job_input')
-        
+        self.assertEqual(new_message.ingest_id, message.ingest_id)
+        self.assertEqual(new_message.strike_id, message.strike_id)
+        self.assertEqual(new_message.create_ingest_type, message.create_ingest_type)
+       

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -96,7 +96,8 @@ class TestCreateIngest(TestCase):
         self.scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
         
     @patch('queue.models.CommandMessageManager')
-    def test_json_create(self, mock_msg_mgr):
+    @patch('queue.models.create_process_job_input_messages')
+    def test_json_create(self, mock_create, mock_msg_mgr):
         """Tests converting a CreateIngest message to and from json
         """
 
@@ -129,7 +130,8 @@ class TestCreateIngest(TestCase):
         self.assertEqual(queue.job_id, job.id)
 
     @patch('queue.models.CommandMessageManager')
-    def test_execute(self, mock_msg_mgr):
+    @patch('queue.models.create_process_job_input_messages')
+    def test_execute(self, mock_create, mock_msg_mgr):
         """Tests executing a CreateIngest message """
         message = create_strike_ingest_job_message(self.ingest.id, self.strike.id)
         result = message.execute()

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -4,9 +4,9 @@ import os
 import django
 from django.test import TestCase
 from django.utils.timezone import now
+from mock import patch
 
 import job.test.utils as job_test_utils
-import ingest.test.utils as ingest_test_utils
 import recipe.test.utils as recipe_test_utils
 import storage.test.utils as storage_test_utils
 from job.models import Job

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -2,8 +2,13 @@ from __future__ import unicode_literals
 
 import django
 from django.test import TestCase
+from django.utils.timezone import now
+
+import storage.test.utils as storage_test_utils
 
 from ingest.messages.create_ingest_jobs import CreateIngest
+from ingest.models import Ingest
+from storage.models import ScaleFile
 
 class TestCreateIngest(TestCase):
     
@@ -46,10 +51,21 @@ class TestCreateIngest(TestCase):
         """Tests executing a CreateIngest message
         """
         
+        workspace_1 = storage_test_utils.create_workspace()
+        workspace_2 = storage_test_utils.create_workspace()
+        source_file = ScaleFile.objects.create(file_name='input_file', file_type='SOURCE',
+                                               media_type='text/plain', file_size=10, data_type_tags=['type1'],
+                                               file_path='the_path', workspace=workspace_1)
+        ingest = Ingest.objects.create(file_name='input_file', file_size=10, status='TRANSFERRING', 
+                                            bytes_transferred=10, transfer_started=now(), media_type='text/plain',
+                                            ingest_started=now(), data_started=now(), 
+                                            workspace=workspace_1, new_workspace=workspace_2, 
+                                            data_type_tags=['type1'], source_file=source_file)
+        
         message = CreateIngest()
         message.create_ingest_type = 'strike_job'
         message.strike_id = 1
-        message.ingest_id = 1
+        message.ingest_id = ingest.id
         
         result = message.execute()
         

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -10,7 +10,7 @@ import job.test.utils as job_test_utils
 import recipe.test.utils as recipe_test_utils
 import storage.test.utils as storage_test_utils
 from job.models import Job
-from ingest.messages.create_ingest_jobs import CreateIngest
+from ingest.messages.create_ingest_jobs import create_strike_ingest_job_message, CreateIngest
 from ingest.models import Ingest, Strike, Scan
 from ingest.scan.configuration.json.configuration_v6 import ScanConfigurationV6
 from ingest.strike.configuration.json.configuration_v6 import StrikeConfigurationV6
@@ -103,18 +103,17 @@ class TestCreateIngest(TestCase):
         # scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
         # self.scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
         
-    
-    @patch('queue.models.CommandMessageManager')
-    def test_json_create_strike(self, mock_msg_mgr):
+
+    def test_json_create_strike(self):
         """Tests converting a CreateIngest message to and from json
         """
         
-        mock_msg_mgr.return_value = MockCommandMessageManager()
+        message = create_strike_ingest_job_message(self.ingest.id, self.strike.id)
         
-        message = CreateIngest()
-        message.create_ingest_type = 'strike_job'
-        message.ingest_id = self.ingest.id
-        message.strike_id = self.strike.id
+        # message = CreateIngest()
+        # message.create_ingest_type = 'strike_job'
+        # message.ingest_id = self.ingest.id
+        # message.strike_id = self.strike.id
 
         # Convert message to JSON and back, and then execute
         message_dict = message.to_json()
@@ -134,10 +133,6 @@ class TestCreateIngest(TestCase):
             elif value == 'new_workspace':
                 self.assertEqual(job_data.values[value].value, self.workspace_2.name)
             
-        # Verify job has been queueud
-        from queue.models import Queue
-        queue = Queue.objects.get(job_id=job.id)
-        self.assertEqual(queue.job_id, job.id)
 
     # @patch('queue.models.create_process_job_input_messages')
     # @patch('queue.models.CommandMessageManager')

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -26,7 +26,7 @@ class TestCreateIngest(TestCase):
     def setUp(self):
         django.setup()
         
-        
+    
     def test_json_create(self):
         """Tests converting a CreateIngest message to and from json
         """
@@ -105,25 +105,25 @@ class TestCreateIngest(TestCase):
         # Convert message to JSON and back, and then execute
         message_dict = message.to_json()
         new_message = CreateIngest.from_json(message_dict)
-        result = new_message.execute()
+        # result = new_message.execute()
 
-        self.assertTrue(result)
+        # self.assertTrue(result)
         # Verify the ingest job has been created
-        job = Job.objects.all().last()
-        self.assertEqual(job.job_type.name, 'scale-ingest')
-        job_data = job.get_input_data()
-        for value in job_data.values:
-            if value == 'ingest_id':
-                self.assertEqual(job_data.values[value].value, ingest.id)
-            elif value == 'workspace':
-                self.assertEqual(job_data.values[value].value, workspace_1.name)
-            elif value == 'new_workspace':
-                self.assertEqual(job_data.values[value].value, workspace_2.name)
+        # job = Job.objects.all().last()
+        # self.assertEqual(job.job_type.name, 'scale-ingest')
+        # job_data = job.get_input_data()
+        # for value in job_data.values:
+        #     if value == 'ingest_id':
+        #         self.assertEqual(job_data.values[value].value, ingest.id)
+        #     elif value == 'workspace':
+        #         self.assertEqual(job_data.values[value].value, workspace_1.name)
+        #     elif value == 'new_workspace':
+        #         self.assertEqual(job_data.values[value].value, workspace_2.name)
             
         # Verify job has been queueud
-        from queue.models import Queue
-        queue = Queue.objects.get(job_id=job.id)
-        self.assertEqual(queue.job_id, job.id)
+        # from queue.models import Queue
+        # queue = Queue.objects.get(job_id=job.id)
+        # self.assertEqual(queue.job_id, job.id)
 
     # @patch('queue.models.create_process_job_input_messages')
     # @patch('queue.models.CommandMessageManager')

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -98,8 +98,6 @@ class TestCreateIngest(TestCase):
         message = CreateIngest()
         message.create_ingest_type = STRIKE_JOB_TYPE
         message.ingest_id = self.ingest.id
-        message.workspace = self.workspace_1.name
-        message.new_workspace = self.workspace_2.name
         message.strike_id = self.strike.id
 
         # Convert message to JSON and back, and then execute
@@ -114,8 +112,7 @@ class TestCreateIngest(TestCase):
 
     def test_execute(self):
         """Tests executing a CreateIngest message """
-        message = create_strike_ingest_job_message(self.ingest.id, self.workspace_1.name, self.workspace_2.name,
-                                                   self.strike.id)
+        message = create_strike_ingest_job_message(self.ingest.id, self.strike.id)
         result = message.execute()
         self.assertTrue(result)
         self.assertEqual(len(message.new_messages), 1)

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import os
 import django
 from django.test import TestCase
 from django.utils.timezone import now
@@ -9,8 +10,10 @@ import ingest.test.utils as ingest_test_utils
 import recipe.test.utils as recipe_test_utils
 import storage.test.utils as storage_test_utils
 
-from ingest.messages.create_ingest_jobs import create_strike_ingest_job_message
-from ingest.models import Strike
+from ingest.messages.create_ingest_jobs import create_strike_ingest_job_message, \
+                                               create_scan_ingest_job_message, CreateIngest, STRIKE_JOB_TYPE
+from ingest.models import Strike, Scan
+from ingest.scan.configuration.json.configuration_v6 import ScanConfigurationV6
 from ingest.strike.configuration.json.configuration_v6 import StrikeConfigurationV6
 from messaging.backends.amqp import AMQPMessagingBackend
 from messaging.backends.factory import add_message_backend
@@ -24,7 +27,19 @@ class TestCreateIngest(TestCase):
     def setUp(self):
         django.setup()
         add_message_backend(AMQPMessagingBackend)
-        
+
+        self.workspace_1 = storage_test_utils.create_workspace()
+        self.workspace_2 = storage_test_utils.create_workspace()
+        self.source_file = ScaleFile.objects.create(file_name='input_file', file_type='SOURCE',
+                                               media_type='text/plain', file_size=10, data_type_tags=['type1'],
+                                               file_path='the_path', workspace=self.workspace_1)
+
+        self.source_file.add_data_type_tag('type1')
+        self.source_file.add_data_type_tag('type2')
+        self.source_file.add_data_type_tag('type3')
+
+        self.ingest = ingest_test_utils.create_ingest(source_file=self.source_file, new_workspace=self.workspace_2)
+
         manifest = job_test_utils.create_seed_manifest(inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
         self.jt1 = job_test_utils.create_seed_job_type(manifest=manifest)
         recipe_type_def = {'version': '6',
@@ -39,42 +54,80 @@ class TestCreateIngest(TestCase):
                                                               'job_type_version': self.jt1.version,
                                                               'job_type_revision': 1}}}}
 
-        self.recipe = recipe_test_utils.create_recipe_type_v6(name='test-recipe', definition=recipe_type_def)
-        
-    def test_json_create(self):
-        """Tests converting a CreateIngest message to and from json
-        """
-        
-        workspace_1 = storage_test_utils.create_workspace()
-        workspace_2 = storage_test_utils.create_workspace()
-        source_file = ScaleFile.objects.create(file_name='input_file', file_type='SOURCE',
-                                               media_type='text/plain', file_size=10, data_type_tags=['type1'],
-                                                file_path='the_path', workspace=workspace_1)
-        source_file.add_data_type_tag('type1')
-        source_file.add_data_type_tag('type2')
-        source_file.add_data_type_tag('type3')
-        
-        ingest = ingest_test_utils.create_ingest(source_file=source_file, new_workspace=workspace_2)
-        
+        self.recipe_type = recipe_test_utils.create_recipe_type_v6(name='test-recipe', definition=recipe_type_def)
+
         strike_config = {
             'version': '6',
-            'workspace': workspace_1.name,
+            'workspace': self.workspace_1.name,
             'monitor': {'type': 'dir-watcher', 'transfer_suffix': '_tmp'},
             'files_to_ingest': [{
                 'filename_regex': 'input_file',
                 'data_types': ['image_type'],
-                'new_workspace': workspace_2.name,
+                'new_workspace': self.workspace_2.name,
                 'new_file_path': 'my/path'
             }],
             'recipe': {
-                'name': self.recipe.name
+                'name': self.recipe_type.name
             },
         }
         config = StrikeConfigurationV6(strike_config).get_configuration()
-        strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
+        self.strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
+
+        scan_config = {
+            'workspace': self.workspace_1.name,
+            'scanner': {
+                'type': 'dir'
+            },
+            'files_to_ingest': [{
+                'filename_regex': 'input_file',
+                'data_types': ['type1'],
+                'new_file_path': os.path.join('my', 'path'),
+                'new_workspace': self.workspace_2.name,
+            }],
+            'recipe': {
+                'name': self.recipe_type.name,
+            },
+        }
+        scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
+        self.scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
         
-        message = create_strike_ingest_job_message(ingest.id, ingest.workspace.name, ingest.new_workspace.name, strike.id)
-        message.execute()
-        import pdb; pdb.set_trace()
-        pass
+    def test_json_create(self):
+        """Tests converting a CreateIngest message to and from json
+        """
+
+        message = CreateIngest()
+        message.create_ingest_type = STRIKE_JOB_TYPE
+        message.ingest_id = self.ingest.id
+        message.workspace = self.workspace_1.name
+        message.new_workspace = self.workspace_2.name
+        message.strike_id = self.strike.id
+
+        # Convert message to JSON and back, and then execute
+        message_dict = message.to_json()
+        new_message = CreateIngest.from_json(message_dict)
+        result = new_message.execute()
+
+        self.assertTrue(result)
+        self.assertEqual(len(new_message.new_messages), 1)
+        self.assertTrue(new_message.new_messages[0].type, 'process_job_input')
+
+
+    def test_execute(self):
+        """Tests executing a CreateIngest message """
+        message = create_strike_ingest_job_message(self.ingest.id, self.workspace_1.name, self.workspace_2.name,
+                                                   self.strike.id)
+        result = message.execute()
+        self.assertTrue(result)
+        self.assertEqual(len(message.new_messages), 1)
+        new_message = message.new_messages[0]
+        self.assertTrue(new_message.type, 'process_job_input')
+
+        # TODO test scan ingest job
+        # message = create_scan_ingest_job_message(self.ingest.id, self.workspace_1.name, self.workspace_2.name,
+        #                                            self.scan.id, self.source_file.file_name)
+        # result = message.execute()
+        # self.assertTrue(result)
+        # self.assertEqual(len(message.new_messages), 1)
+        # new_message = message.new_messages[0]
+        # self.assertTrue(new_message.type, 'process_job_input')
         

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -69,4 +69,7 @@ class TestCreateIngest(TestCase):
         
         result = message.execute()
         
-        self.assertFalse(result)
+        self.assertTrue(result)
+        self.assertEqual(len(message.new_messages), 1)
+        self.assertEqual(message.new_messages[0].type, 'process_job_input')
+        

--- a/scale/ingest/test/test_models.py
+++ b/scale/ingest/test/test_models.py
@@ -81,7 +81,7 @@ class TestStrikeManagerCreateStrikeProcess(TransactionTestCase):
         self.workspace = storage_test_utils.create_workspace()
         self.recipe = recipe_test_utils.create_recipe_type_v6()
 
-    @patch('queue.models.CommandMessageManager')
+    @patch('ingest.models.CommandMessageManager')
     def test_successful_v6(self, mock_msg_mgr):
         """Tests calling StrikeManager.create_strike successfully with v6 config"""
 

--- a/scale/ingest/test/test_views.py
+++ b/scale/ingest/test/test_views.py
@@ -977,7 +977,7 @@ class TestStrikeCreateViewV6(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
 
-    @patch('queue.models.CommandMessageManager')
+    @patch('ingest.models.CommandMessageManager')
     def test_successful(self, mock_msg_mgr):
         """Tests calling the create Strike view successfully."""
 
@@ -1018,7 +1018,7 @@ class TestStrikeCreateViewV6(APITestCase):
         self.assertEqual(result['description'], strikes[0].description)
         self.assertDictEqual(result['configuration'], strikes[0].get_v6_configuration_json())
 
-    @patch('queue.models.CommandMessageManager')
+    @patch('ingest.models.CommandMessageManager')
     def test_successful_v6(self, mock_msg_mgr):
         """Tests creating strike with recipe configuration"""
 

--- a/scale/ingest/test/test_views.py
+++ b/scale/ingest/test/test_views.py
@@ -772,7 +772,7 @@ class TestScansProcessViewV6(APITestCase):
         response = self.client.generic('POST', url, json.dumps({ 'ingest': False }), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
 
-    @patch('queue.models.CommandMessageManager')
+    @patch('ingest.models.CommandMessageManager')
     def test_dry_run_process(self, mock_msg_mgr):
         """Tests successfully calling the Scan process view for a dry run Scan."""
 

--- a/scale/ingest/test/test_views.py
+++ b/scale/ingest/test/test_views.py
@@ -784,7 +784,7 @@ class TestScansProcessViewV6(APITestCase):
         self.assertTrue(isinstance(result, dict), 'result  must be a dictionary')
         self.assertIsNotNone(result['dry_run_job'])
 
-    @patch('queue.models.CommandMessageManager')
+    @patch('ingest.models.CommandMessageManager')
     def test_ingest_process(self, mock_msg_mgr):
         """Tests successfully calling the Scan process view for an ingest Scan."""
 

--- a/scale/ingest/test/test_views.py
+++ b/scale/ingest/test/test_views.py
@@ -816,7 +816,7 @@ class TestScansProcessViewV6(APITestCase):
         response = self.client.generic('POST', url, json.dumps({ 'ingest': True }), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.content)
 
-    @patch('queue.models.CommandMessageManager')
+    @patch('ingest.models.CommandMessageManager')
     def test_dry_run_process_reprocess(self, mock_msg_mgr):
         """Tests successfully calling the Scan process view for a 2nd dry run Scan."""
 
@@ -832,7 +832,7 @@ class TestScansProcessViewV6(APITestCase):
         self.assertIsNotNone(result['dry_run_job'])
         self.assertNotEqual(result['dry_run_job']['id'], old_job_id)
 
-    @patch('queue.models.CommandMessageManager')
+    @patch('ingest.models.CommandMessageManager')
     def test_ingest_after_dry_run(self, mock_msg_mgr):
         """Tests successfully calling the Scan process view for an ingest Scan. following dry run"""
 

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -89,9 +89,10 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
         ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
 
-        pass       
-        
-        
+        # Call method to test
+        IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
+        mock_msg_mgr.assert_called_once()
+        mock_create.assert_called_once()
      
         
 

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -100,75 +100,75 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]['type'], 'STRIKE')
         
-        # Create scan
-        scan_config = {
-            'workspace': self.workspace.name,
-            'scanner': {
-                'type': 'dir'
-            },
-            'files_to_ingest': [{
-                'filename_regex': 'input_file',
-                'data_types': ['type1'],
-                'new_file_path': os.path.join('my', 'path'),
-                'new_workspace': self.workspace.name,
-            }],
-            'recipe': {
-                'name': self.recipe_v7.name,
-            },
-        }
-        scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
-        scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
+        # # Create scan
+        # scan_config = {
+        #     'workspace': self.workspace.name,
+        #     'scanner': {
+        #         'type': 'dir'
+        #     },
+        #     'files_to_ingest': [{
+        #         'filename_regex': 'input_file',
+        #         'data_types': ['type1'],
+        #         'new_file_path': os.path.join('my', 'path'),
+        #         'new_workspace': self.workspace.name,
+        #     }],
+        #     'recipe': {
+        #         'name': self.recipe_v7.name,
+        #     },
+        # }
+        # scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
+        # scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
 
-        # Call method to test
-        IngestRecipeHandler().process_ingested_source_file(ingest.id, scan, self.source_file, now())
-        self.assertEqual(mock_msg_mgr.call_count, 2)
-        self.assertEqual(mock_create.call_count, 2)
+        # # Call method to test
+        # IngestRecipeHandler().process_ingested_source_file(ingest.id, scan, self.source_file, now())
+        # self.assertEqual(mock_msg_mgr.call_count, 2)
+        # self.assertEqual(mock_create.call_count, 2)
         
-        # Verify events were created
-        events = IngestEvent.objects.all().values()
-        self.assertEqual(len(events), 2)
-        self.assertEqual(events[1]['type'], 'SCAN')
+        # # Verify events were created
+        # events = IngestEvent.objects.all().values()
+        # self.assertEqual(len(events), 2)
+        # self.assertEqual(events[1]['type'], 'SCAN')
         
-        # Update the recipe then call ingest with revision 1
-        manifest = job_test_utils.create_seed_manifest(
-            inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
-        jt2 = job_test_utils.create_seed_job_type(manifest=manifest)
-        definition = {'version': '7',
-                       'input': {'files': [{'name': 'INPUT_FILE',
-                                            'media_types': ['text/plain'],
-                                            'required': True,
-                                            'multiple': True}],
-                                'json': []},
-                      'nodes': {'node_a': {'dependencies': [],
-                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-                                                'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
-                                                              'job_type_version': self.jt1.version,
-                                                              'job_type_revision': 1}},
-                                'node_b': {'dependencies': [],
-                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-                                                'node_type': {'node_type': 'job', 'job_type_name': jt2.name,
-                                                              'job_type_version': jt2.version,
-                                                              'job_type_revision': 1}}}}
+        # # Update the recipe then call ingest with revision 1
+        # manifest = job_test_utils.create_seed_manifest(
+        #     inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
+        # jt2 = job_test_utils.create_seed_job_type(manifest=manifest)
+        # definition = {'version': '7',
+        #               'input': {'files': [{'name': 'INPUT_FILE',
+        #                                     'media_types': ['text/plain'],
+        #                                     'required': True,
+        #                                     'multiple': True}],
+        #                         'json': []},
+        #               'nodes': {'node_a': {'dependencies': [],
+        #                                         'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
+        #                                         'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
+        #                                                       'job_type_version': self.jt1.version,
+        #                                                       'job_type_revision': 1}},
+        #                         'node_b': {'dependencies': [],
+        #                                         'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
+        #                                         'node_type': {'node_type': 'job', 'job_type_name': jt2.name,
+        #                                                       'job_type_version': jt2.version,
+        #                                                       'job_type_revision': 1}}}}
         
-        recipe_test_utils.edit_recipe_type_v6(recipe_type=self.recipe, definition=definition)
+        # recipe_test_utils.edit_recipe_type_v6(recipe_type=self.recipe, definition=definition)
         
-        strike_config['recipe'] = {
-            'name': self.recipe.name,
-            'revision_num': 1,
-        }
-        config = StrikeConfigurationV6(strike_config).get_configuration()
-        strike = Strike.objects.create_strike('my_name_2', 'my_title_2', 'my_description_2', config)
-        ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
+        # strike_config['recipe'] = {
+        #     'name': self.recipe.name,
+        #     'revision_num': 1,
+        # }
+        # config = StrikeConfigurationV6(strike_config).get_configuration()
+        # strike = Strike.objects.create_strike('my_name_2', 'my_title_2', 'my_description_2', config)
+        # ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
 
-        # Call method to test
-        IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-        self.assertEqual(mock_msg_mgr.call_count, 3)
-        self.assertEqual(mock_create.call_count, 3)
+        # # Call method to test
+        # IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
+        # self.assertEqual(mock_msg_mgr.call_count, 3)
+        # self.assertEqual(mock_create.call_count, 3)
         
-        # Verify events were created
-        events = IngestEvent.objects.all().values()
-        self.assertEqual(len(events), 3)
-        self.assertEqual(events[2]['type'], 'STRIKE')
+        # # Verify events were created
+        # events = IngestEvent.objects.all().values()
+        # self.assertEqual(len(events), 3)
+        # self.assertEqual(events[2]['type'], 'STRIKE')
         
 
     @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -126,11 +126,6 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         self.assertEqual(mock_msg_mgr_tr.call_count, 2)
         self.assertEqual(mock_create.call_count, 2)
         
-        # Call method to test
-        IngestRecipeHandler().process_ingested_source_file(ingest.id, scan, self.source_file, now())
-        self.assertEqual(mock_msg_mgr_tr.call_count, 2)
-        self.assertEqual(mock_create.call_count, 2)
-        
         # Verify events were created
         events = IngestEvent.objects.all().values()
         self.assertEqual(len(events), 2)

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -66,7 +66,7 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
                                                               'job_type_revision': 1}}}}
         self.recipe_v7 = recipe_test_utils.create_recipe_type_v6(name='test-recipe-v7', definition=v7_recipe_type_def)
 
-    @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')
+    @patch('queue.models.CommandMessageManager')
     @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
     def test_successful_recipe_kickoff(self, mock_create, mock_msg_mgr):
         """Tests successfully producing an ingest that immediately calls a recipe"""
@@ -82,7 +82,7 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
                 'new_file_path': 'my/path'
             }],
             'recipe': {
-                'name': self.recipe.name
+                'name': self.recipe_v7.name
             },
         }
         config = StrikeConfigurationV6(strike_config).get_configuration()

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -101,10 +101,14 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
         scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
 
-        # # Call method to test
+        # Call method to test
         IngestRecipeHandler().process_ingested_source_file(ingest.id, scan, self.source_file, now())
         self.assertEqual(mock_msg_mgr.call_count, 2)
         self.assertEqual(mock_create.call_count, 2)
+
+        # Verify ingest event and trigger event objects were created
+        events = IngestEvent.objects.all()
+        self.assertEqual(len(events), 1)
         
         # # Update the recipe then call ingest with revision 1
         manifest = job_test_utils.create_seed_manifest(

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -67,7 +67,8 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         self.recipe_v7 = recipe_test_utils.create_recipe_type_v6(name='test-recipe-v7', definition=v7_recipe_type_def)
 
 
-    def test_successful_recipe_kickoff(self):
+    @patch('ingest.models.CommandMessageManager')
+    def test_successful_recipe_kickoff(self, mock_msg_mgr):
         """Tests successfully producing an ingest that immediately calls a recipe"""
 
         strike_config = {

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -53,110 +53,113 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
 
         self.recipe = recipe_test_utils.create_recipe_type_v6(name='test-recipe', definition=recipe_type_def)
 
-    
-    # @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')
-    # @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
-    # def test_successful_recipe_kickoff(self, mock_create, mock_msg_mgr):
-    #     """Tests successfully producing an ingest that immediately calls a recipe"""
+    @patch('recipe.messages.create_recipes.create_update_recipe_metrics_messages')
+    @patch('recipe.messages.create_recipes.create_update_recipe_message')
+    @patch('recipe.messages.create_recipes.create_process_recipe_input_messages')
+    @patch('recipe.messages.create_recipes.create_supersede_recipe_nodes_messages')
+    @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')
+    @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
+    def test_successful_recipe_kickoff(self, mock_create, mock_msg_mgr, mock_supersede, mock_processs_input, mock_update, mock_update_metrics):
+        """Tests successfully producing an ingest that immediately calls a recipe"""
 
-    #     strike_config = {
-    #         'version': '6',
-    #         'workspace': self.workspace.name,
-    #         'monitor': {'type': 'dir-watcher', 'transfer_suffix': '_tmp'},
-    #         'files_to_ingest': [{
-    #             'filename_regex': 'input_file',
-    #             'data_types': ['image_type'],
-    #             'new_workspace': self.workspace.name,
-    #             'new_file_path': 'my/path'
-    #         }],
-    #         'recipe': {
-    #             'name': self.recipe.name
-    #         },
-    #     }
-    #     config = StrikeConfigurationV6(strike_config).get_configuration()
-    #     strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
-    #     ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
+        strike_config = {
+            'version': '6',
+            'workspace': self.workspace.name,
+            'monitor': {'type': 'dir-watcher', 'transfer_suffix': '_tmp'},
+            'files_to_ingest': [{
+                'filename_regex': 'input_file',
+                'data_types': ['image_type'],
+                'new_workspace': self.workspace.name,
+                'new_file_path': 'my/path'
+            }],
+            'recipe': {
+                'name': self.recipe.name
+            },
+        }
+        config = StrikeConfigurationV6(strike_config).get_configuration()
+        strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
+        ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
 
-    #     # Call method to test
-    #     IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-    #     mock_msg_mgr.assert_called_once()
-    #     mock_create.assert_called_once()
+        # Call method to test
+        IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
+        mock_msg_mgr.assert_called_once()
+        mock_create.assert_called_once()
         
-    #      # Verify ingest event and trigger event objects were created
-    #     from ingest.models import IngestEvent
-    #     events = IngestEvent.objects.all().values()
-    #     self.assertEqual(len(events), 1)
-    #     self.assertEqual(events[0]['type'], 'STRIKE')
+         # Verify ingest event and trigger event objects were created
+        from ingest.models import IngestEvent
+        events = IngestEvent.objects.all().values()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]['type'], 'STRIKE')
         
-    #     # Create scan
-    #     scan_config = {
-    #         'workspace': self.workspace.name,
-    #         'scanner': {
-    #             'type': 'dir'
-    #         },
-    #         'files_to_ingest': [{
-    #             'filename_regex': 'input_file',
-    #             'data_types': ['type1'],
-    #             'new_file_path': os.path.join('my', 'path'),
-    #             'new_workspace': self.workspace.name,
-    #         }],
-    #         'recipe': {
-    #             'name': self.recipe.name,
-    #         },
-    #     }
-    #     scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
-    #     scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
+        # Create scan
+        scan_config = {
+            'workspace': self.workspace.name,
+            'scanner': {
+                'type': 'dir'
+            },
+            'files_to_ingest': [{
+                'filename_regex': 'input_file',
+                'data_types': ['type1'],
+                'new_file_path': os.path.join('my', 'path'),
+                'new_workspace': self.workspace.name,
+            }],
+            'recipe': {
+                'name': self.recipe.name,
+            },
+        }
+        scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
+        scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
 
-    #     # Call method to test
-    #     IngestRecipeHandler().process_ingested_source_file(ingest.id, scan, self.source_file, now())
-    #     self.assertEqual(mock_msg_mgr.call_count, 2)
-    #     self.assertEqual(mock_create.call_count, 2)
+        # Call method to test
+        IngestRecipeHandler().process_ingested_source_file(ingest.id, scan, self.source_file, now())
+        self.assertEqual(mock_msg_mgr.call_count, 2)
+        self.assertEqual(mock_create.call_count, 2)
         
-    #     # Verify events were created
-    #     events = IngestEvent.objects.all().values()
-    #     self.assertEqual(len(events), 2)
-    #     self.assertEqual(events[1]['type'], 'SCAN')
+        # Verify events were created
+        events = IngestEvent.objects.all().values()
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[1]['type'], 'SCAN')
         
-    #     # Update the recipe then call ingest with revision 1
-    #     manifest = job_test_utils.create_seed_manifest(
-    #         inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
-    #     jt2 = job_test_utils.create_seed_job_type(manifest=manifest)
-    #     definition = {'version': '6',
-    #                   'input': {'files': [{'name': 'INPUT_FILE',
-    #                                         'media_types': ['text/plain'],
-    #                                         'required': True,
-    #                                         'multiple': True}],
-    #                             'json': []},
-    #                   'nodes': {'node_a': {'dependencies': [],
-    #                                             'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-    #                                             'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
-    #                                                           'job_type_version': self.jt1.version,
-    #                                                           'job_type_revision': 1}},
-    #                             'node_b': {'dependencies': [],
-    #                                             'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-    #                                             'node_type': {'node_type': 'job', 'job_type_name': jt2.name,
-    #                                                           'job_type_version': jt2.version,
-    #                                                           'job_type_revision': 1}}}}
+        # Update the recipe then call ingest with revision 1
+        manifest = job_test_utils.create_seed_manifest(
+            inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
+        jt2 = job_test_utils.create_seed_job_type(manifest=manifest)
+        definition = {'version': '6',
+                      'input': {'files': [{'name': 'INPUT_FILE',
+                                            'media_types': ['text/plain'],
+                                            'required': True,
+                                            'multiple': True}],
+                                'json': []},
+                      'nodes': {'node_a': {'dependencies': [],
+                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
+                                                'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
+                                                              'job_type_version': self.jt1.version,
+                                                              'job_type_revision': 1}},
+                                'node_b': {'dependencies': [],
+                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
+                                                'node_type': {'node_type': 'job', 'job_type_name': jt2.name,
+                                                              'job_type_version': jt2.version,
+                                                              'job_type_revision': 1}}}}
         
-    #     recipe_test_utils.edit_recipe_type_v6(recipe_type=self.recipe, definition=definition)
+        recipe_test_utils.edit_recipe_type_v6(recipe_type=self.recipe, definition=definition)
         
-    #     strike_config['recipe'] = {
-    #         'name': self.recipe.name,
-    #         'revision_num': 1,
-    #     }
-    #     config = StrikeConfigurationV6(strike_config).get_configuration()
-    #     strike = Strike.objects.create_strike('my_name_2', 'my_title_2', 'my_description_2', config)
-    #     ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
+        strike_config['recipe'] = {
+            'name': self.recipe.name,
+            'revision_num': 1,
+        }
+        config = StrikeConfigurationV6(strike_config).get_configuration()
+        strike = Strike.objects.create_strike('my_name_2', 'my_title_2', 'my_description_2', config)
+        ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
 
-    #     # Call method to test
-    #     IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-    #     self.assertEqual(mock_msg_mgr.call_count, 3)
-    #     self.assertEqual(mock_create.call_count, 3)
+        # Call method to test
+        IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
+        self.assertEqual(mock_msg_mgr.call_count, 3)
+        self.assertEqual(mock_create.call_count, 3)
         
-    #     # Verify events were created
-    #     events = IngestEvent.objects.all().values()
-    #     self.assertEqual(len(events), 3)
-    #     self.assertEqual(events[2]['type'], 'STRIKE')
+        # Verify events were created
+        events = IngestEvent.objects.all().values()
+        self.assertEqual(len(events), 3)
+        self.assertEqual(events[2]['type'], 'STRIKE')
         
 
     @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -92,8 +92,6 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         # Call method to test
         IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
         mock_msg_mgr.assert_called_once()
-        mock_create.assert_called_once()
-     
         
 
     @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -131,28 +131,28 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         self.assertEqual(len(events), 2)
         self.assertEqual(events[1]['type'], 'SCAN')
         
-        # Update the recipe then call ingest with revision 1
-        # manifest = job_test_utils.create_seed_manifest(
-        #     inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
-        # jt2 = job_test_utils.create_seed_job_type(manifest=manifest)
-        # definition = {'version': '7',
-        #               'input': {'files': [{'name': 'INPUT_FILE',
-        #                                     'media_types': ['text/plain'],
-        #                                     'required': True,
-        #                                     'multiple': True}],
-        #                         'json': []},
-        #               'nodes': {'node_a': {'dependencies': [],
-        #                                         'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-        #                                         'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
-        #                                                       'job_type_version': self.jt1.version,
-        #                                                       'job_type_revision': 1}},
-        #                         'node_b': {'dependencies': [],
-        #                                         'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-        #                                         'node_type': {'node_type': 'job', 'job_type_name': jt2.name,
-        #                                                       'job_type_version': jt2.version,
-        #                                                       'job_type_revision': 1}}}}
+        Update the recipe then call ingest with revision 1
+        manifest = job_test_utils.create_seed_manifest(
+            inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
+        jt2 = job_test_utils.create_seed_job_type(manifest=manifest)
+        definition = {'version': '7',
+                      'input': {'files': [{'name': 'INPUT_FILE',
+                                            'media_types': ['text/plain'],
+                                            'required': True,
+                                            'multiple': True}],
+                                'json': []},
+                      'nodes': {'node_a': {'dependencies': [],
+                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
+                                                'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
+                                                              'job_type_version': self.jt1.version,
+                                                              'job_type_revision': 1}},
+                                'node_b': {'dependencies': [],
+                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
+                                                'node_type': {'node_type': 'job', 'job_type_name': jt2.name,
+                                                              'job_type_version': jt2.version,
+                                                              'job_type_revision': 1}}}}
         
-        # recipe_test_utils.edit_recipe_type_v6(recipe_type=self.recipe, definition=definition)
+        recipe_test_utils.edit_recipe_type_v6(recipe_type=self.recipe, definition=definition)
         
         # strike_config['recipe'] = {
         #     'name': self.recipe.name,

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -66,9 +66,8 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
                                                               'job_type_revision': 1}}}}
         self.recipe_v7 = recipe_test_utils.create_recipe_type_v6(name='test-recipe-v7', definition=v7_recipe_type_def)
 
-    @patch('queue.models.CommandMessageManager')
-    @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
-    def test_successful_recipe_kickoff(self, mock_create, mock_msg_mgr):
+
+    def test_successful_recipe_kickoff(self):
         """Tests successfully producing an ingest that immediately calls a recipe"""
 
         strike_config = {
@@ -89,17 +88,7 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
         ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
 
-        # Call method to test
-        IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-        mock_msg_mgr.assert_called_once()
-        mock_create.assert_called_once()
-        
-        #  # Verify ingest event and trigger event objects were created
-        # from ingest.models import IngestEvent
-        # events = IngestEvent.objects.all().values()
-        # self.assertEqual(len(events), 1)
-        # self.assertEqual(events[0]['type'], 'STRIKE')
-        
+        pass       
         
         
      

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -67,10 +67,10 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         self.recipe_v7 = recipe_test_utils.create_recipe_type_v6(name='test-recipe-v7', definition=v7_recipe_type_def)
 
 
-    
+    @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')
     @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
     @patch('ingest.models.CommandMessageManager')
-    def test_successful_recipe_kickoff(self, mock_msg_mgr, mock_create):
+    def test_successful_recipe_kickoff(self, mock_msg_mgr, mock_create, mock_msg_mgr_tr):
         """Tests successfully producing an ingest that immediately calls a recipe"""
 
         strike_config = {
@@ -93,7 +93,7 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
 
         # Call method to test
         IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-        mock_msg_mgr.assert_called_once()
+        mock_msg_mgr_tr.assert_called_once()
         mock_create.assert_called_once()
         
 

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -53,110 +53,110 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
 
         self.recipe = recipe_test_utils.create_recipe_type_v6(name='test-recipe', definition=recipe_type_def)
 
-        
-    @patch('queue.models.CommandMessageManager')
-    @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
-    def test_successful_recipe_kickoff(self, mock_create, mock_msg_mgr):
-        """Tests successfully producing an ingest that immediately calls a recipe"""
+    
+    # @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')
+    # @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
+    # def test_successful_recipe_kickoff(self, mock_create, mock_msg_mgr):
+    #     """Tests successfully producing an ingest that immediately calls a recipe"""
 
-        strike_config = {
-            'version': '6',
-            'workspace': self.workspace.name,
-            'monitor': {'type': 'dir-watcher', 'transfer_suffix': '_tmp'},
-            'files_to_ingest': [{
-                'filename_regex': 'input_file',
-                'data_types': ['image_type'],
-                'new_workspace': self.workspace.name,
-                'new_file_path': 'my/path'
-            }],
-            'recipe': {
-                'name': self.recipe.name
-            },
-        }
-        config = StrikeConfigurationV6(strike_config).get_configuration()
-        strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
-        ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
+    #     strike_config = {
+    #         'version': '6',
+    #         'workspace': self.workspace.name,
+    #         'monitor': {'type': 'dir-watcher', 'transfer_suffix': '_tmp'},
+    #         'files_to_ingest': [{
+    #             'filename_regex': 'input_file',
+    #             'data_types': ['image_type'],
+    #             'new_workspace': self.workspace.name,
+    #             'new_file_path': 'my/path'
+    #         }],
+    #         'recipe': {
+    #             'name': self.recipe.name
+    #         },
+    #     }
+    #     config = StrikeConfigurationV6(strike_config).get_configuration()
+    #     strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
+    #     ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
 
-        # Call method to test
-        IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-        mock_msg_mgr.assert_called_once()
-        mock_create.assert_called_once()
+    #     # Call method to test
+    #     IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
+    #     mock_msg_mgr.assert_called_once()
+    #     mock_create.assert_called_once()
         
-         # Verify ingest event and trigger event objects were created
-        from ingest.models import IngestEvent
-        events = IngestEvent.objects.all().values()
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0]['type'], 'STRIKE')
+    #      # Verify ingest event and trigger event objects were created
+    #     from ingest.models import IngestEvent
+    #     events = IngestEvent.objects.all().values()
+    #     self.assertEqual(len(events), 1)
+    #     self.assertEqual(events[0]['type'], 'STRIKE')
         
-        # Create scan
-        scan_config = {
-            'workspace': self.workspace.name,
-            'scanner': {
-                'type': 'dir'
-            },
-            'files_to_ingest': [{
-                'filename_regex': 'input_file',
-                'data_types': ['type1'],
-                'new_file_path': os.path.join('my', 'path'),
-                'new_workspace': self.workspace.name,
-            }],
-            'recipe': {
-                'name': self.recipe.name,
-            },
-        }
-        scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
-        scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
+    #     # Create scan
+    #     scan_config = {
+    #         'workspace': self.workspace.name,
+    #         'scanner': {
+    #             'type': 'dir'
+    #         },
+    #         'files_to_ingest': [{
+    #             'filename_regex': 'input_file',
+    #             'data_types': ['type1'],
+    #             'new_file_path': os.path.join('my', 'path'),
+    #             'new_workspace': self.workspace.name,
+    #         }],
+    #         'recipe': {
+    #             'name': self.recipe.name,
+    #         },
+    #     }
+    #     scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
+    #     scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
 
-        # Call method to test
-        IngestRecipeHandler().process_ingested_source_file(ingest.id, scan, self.source_file, now())
-        self.assertEqual(mock_msg_mgr.call_count, 1)
-        self.assertEqual(mock_create.call_count, 2)
+    #     # Call method to test
+    #     IngestRecipeHandler().process_ingested_source_file(ingest.id, scan, self.source_file, now())
+    #     self.assertEqual(mock_msg_mgr.call_count, 2)
+    #     self.assertEqual(mock_create.call_count, 2)
         
-        # Verify events were created
-        events = IngestEvent.objects.all().values()
-        self.assertEqual(len(events), 2)
-        self.assertEqual(events[1]['type'], 'SCAN')
+    #     # Verify events were created
+    #     events = IngestEvent.objects.all().values()
+    #     self.assertEqual(len(events), 2)
+    #     self.assertEqual(events[1]['type'], 'SCAN')
         
-        # Update the recipe then call ingest with revision 1
-        manifest = job_test_utils.create_seed_manifest(
-            inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
-        jt2 = job_test_utils.create_seed_job_type(manifest=manifest)
-        definition = {'version': '6',
-                      'input': {'files': [{'name': 'INPUT_FILE',
-                                            'media_types': ['text/plain'],
-                                            'required': True,
-                                            'multiple': True}],
-                                'json': []},
-                      'nodes': {'node_a': {'dependencies': [],
-                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-                                                'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
-                                                              'job_type_version': self.jt1.version,
-                                                              'job_type_revision': 1}},
-                                'node_b': {'dependencies': [],
-                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-                                                'node_type': {'node_type': 'job', 'job_type_name': jt2.name,
-                                                              'job_type_version': jt2.version,
-                                                              'job_type_revision': 1}}}}
+    #     # Update the recipe then call ingest with revision 1
+    #     manifest = job_test_utils.create_seed_manifest(
+    #         inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
+    #     jt2 = job_test_utils.create_seed_job_type(manifest=manifest)
+    #     definition = {'version': '6',
+    #                   'input': {'files': [{'name': 'INPUT_FILE',
+    #                                         'media_types': ['text/plain'],
+    #                                         'required': True,
+    #                                         'multiple': True}],
+    #                             'json': []},
+    #                   'nodes': {'node_a': {'dependencies': [],
+    #                                             'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
+    #                                             'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
+    #                                                           'job_type_version': self.jt1.version,
+    #                                                           'job_type_revision': 1}},
+    #                             'node_b': {'dependencies': [],
+    #                                             'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
+    #                                             'node_type': {'node_type': 'job', 'job_type_name': jt2.name,
+    #                                                           'job_type_version': jt2.version,
+    #                                                           'job_type_revision': 1}}}}
         
-        recipe_test_utils.edit_recipe_type_v6(recipe_type=self.recipe, definition=definition)
+    #     recipe_test_utils.edit_recipe_type_v6(recipe_type=self.recipe, definition=definition)
         
-        strike_config['recipe'] = {
-            'name': self.recipe.name,
-            'revision_num': 1,
-        }
-        config = StrikeConfigurationV6(strike_config).get_configuration()
-        strike = Strike.objects.create_strike('my_name_2', 'my_title_2', 'my_description_2', config)
-        ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
+    #     strike_config['recipe'] = {
+    #         'name': self.recipe.name,
+    #         'revision_num': 1,
+    #     }
+    #     config = StrikeConfigurationV6(strike_config).get_configuration()
+    #     strike = Strike.objects.create_strike('my_name_2', 'my_title_2', 'my_description_2', config)
+    #     ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
 
-        # Call method to test
-        IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-        self.assertEqual(mock_msg_mgr.call_count,2)
-        self.assertEqual(mock_create.call_count, 3)
+    #     # Call method to test
+    #     IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
+    #     self.assertEqual(mock_msg_mgr.call_count, 3)
+    #     self.assertEqual(mock_create.call_count, 3)
         
-        # Verify events were created
-        events = IngestEvent.objects.all().values()
-        self.assertEqual(len(events), 3)
-        self.assertEqual(events[2]['type'], 'STRIKE')
+    #     # Verify events were created
+    #     events = IngestEvent.objects.all().values()
+    #     self.assertEqual(len(events), 3)
+    #     self.assertEqual(events[2]['type'], 'STRIKE')
         
 
     @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -94,81 +94,15 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         mock_msg_mgr.assert_called_once()
         mock_create.assert_called_once()
         
-         # Verify ingest event and trigger event objects were created
-        from ingest.models import IngestEvent
-        events = IngestEvent.objects.all().values()
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0]['type'], 'STRIKE')
-        
-        # # Create scan
-        # scan_config = {
-        #     'workspace': self.workspace.name,
-        #     'scanner': {
-        #         'type': 'dir'
-        #     },
-        #     'files_to_ingest': [{
-        #         'filename_regex': 'input_file',
-        #         'data_types': ['type1'],
-        #         'new_file_path': os.path.join('my', 'path'),
-        #         'new_workspace': self.workspace.name,
-        #     }],
-        #     'recipe': {
-        #         'name': self.recipe_v7.name,
-        #     },
-        # }
-        # scan_configuration = ScanConfigurationV6(scan_config).get_configuration()
-        # scan = Scan.objects.create_scan('my_name', 'my_title', 'my_description', scan_configuration)
-
-        # # Call method to test
-        # IngestRecipeHandler().process_ingested_source_file(ingest.id, scan, self.source_file, now())
-        # self.assertEqual(mock_msg_mgr.call_count, 2)
-        # self.assertEqual(mock_create.call_count, 2)
-        
-        # # Verify events were created
+        #  # Verify ingest event and trigger event objects were created
+        # from ingest.models import IngestEvent
         # events = IngestEvent.objects.all().values()
-        # self.assertEqual(len(events), 2)
-        # self.assertEqual(events[1]['type'], 'SCAN')
+        # self.assertEqual(len(events), 1)
+        # self.assertEqual(events[0]['type'], 'STRIKE')
         
-        # # Update the recipe then call ingest with revision 1
-        # manifest = job_test_utils.create_seed_manifest(
-        #     inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
-        # jt2 = job_test_utils.create_seed_job_type(manifest=manifest)
-        # definition = {'version': '7',
-        #               'input': {'files': [{'name': 'INPUT_FILE',
-        #                                     'media_types': ['text/plain'],
-        #                                     'required': True,
-        #                                     'multiple': True}],
-        #                         'json': []},
-        #               'nodes': {'node_a': {'dependencies': [],
-        #                                         'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-        #                                         'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
-        #                                                       'job_type_version': self.jt1.version,
-        #                                                       'job_type_revision': 1}},
-        #                         'node_b': {'dependencies': [],
-        #                                         'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-        #                                         'node_type': {'node_type': 'job', 'job_type_name': jt2.name,
-        #                                                       'job_type_version': jt2.version,
-        #                                                       'job_type_revision': 1}}}}
         
-        # recipe_test_utils.edit_recipe_type_v6(recipe_type=self.recipe, definition=definition)
         
-        # strike_config['recipe'] = {
-        #     'name': self.recipe.name,
-        #     'revision_num': 1,
-        # }
-        # config = StrikeConfigurationV6(strike_config).get_configuration()
-        # strike = Strike.objects.create_strike('my_name_2', 'my_title_2', 'my_description_2', config)
-        # ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
-
-        # # Call method to test
-        # IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-        # self.assertEqual(mock_msg_mgr.call_count, 3)
-        # self.assertEqual(mock_create.call_count, 3)
-        
-        # # Verify events were created
-        # events = IngestEvent.objects.all().values()
-        # self.assertEqual(len(events), 3)
-        # self.assertEqual(events[2]['type'], 'STRIKE')
+     
         
 
     @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -132,45 +132,45 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         self.assertEqual(events[1]['type'], 'SCAN')
         
         # Update the recipe then call ingest with revision 1
-        manifest = job_test_utils.create_seed_manifest(
-            inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
-        jt2 = job_test_utils.create_seed_job_type(manifest=manifest)
-        definition = {'version': '7',
-                      'input': {'files': [{'name': 'INPUT_FILE',
-                                            'media_types': ['text/plain'],
-                                            'required': True,
-                                            'multiple': True}],
-                                'json': []},
-                      'nodes': {'node_a': {'dependencies': [],
-                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-                                                'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
-                                                              'job_type_version': self.jt1.version,
-                                                              'job_type_revision': 1}},
-                                'node_b': {'dependencies': [],
-                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
-                                                'node_type': {'node_type': 'job', 'job_type_name': jt2.name,
-                                                              'job_type_version': jt2.version,
-                                                              'job_type_revision': 1}}}}
+        # manifest = job_test_utils.create_seed_manifest(
+        #     inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
+        # jt2 = job_test_utils.create_seed_job_type(manifest=manifest)
+        # definition = {'version': '7',
+        #               'input': {'files': [{'name': 'INPUT_FILE',
+        #                                     'media_types': ['text/plain'],
+        #                                     'required': True,
+        #                                     'multiple': True}],
+        #                         'json': []},
+        #               'nodes': {'node_a': {'dependencies': [],
+        #                                         'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
+        #                                         'node_type': {'node_type': 'job', 'job_type_name': self.jt1.name,
+        #                                                       'job_type_version': self.jt1.version,
+        #                                                       'job_type_revision': 1}},
+        #                         'node_b': {'dependencies': [],
+        #                                         'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
+        #                                         'node_type': {'node_type': 'job', 'job_type_name': jt2.name,
+        #                                                       'job_type_version': jt2.version,
+        #                                                       'job_type_revision': 1}}}}
         
-        recipe_test_utils.edit_recipe_type_v6(recipe_type=self.recipe, definition=definition)
+        # recipe_test_utils.edit_recipe_type_v6(recipe_type=self.recipe, definition=definition)
         
-        strike_config['recipe'] = {
-            'name': self.recipe.name,
-            'revision_num': 1,
-        }
-        config = StrikeConfigurationV6(strike_config).get_configuration()
-        strike = Strike.objects.create_strike('my_name_2', 'my_title_2', 'my_description_2', config)
-        ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
+        # strike_config['recipe'] = {
+        #     'name': self.recipe.name,
+        #     'revision_num': 1,
+        # }
+        # config = StrikeConfigurationV6(strike_config).get_configuration()
+        # strike = Strike.objects.create_strike('my_name_2', 'my_title_2', 'my_description_2', config)
+        # ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
 
-        # Call method to test
-        IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-        self.assertEqual(mock_msg_mgr_tr.call_count, 3)
-        self.assertEqual(mock_create.call_count, 3)
+        # # Call method to test
+        # IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
+        # self.assertEqual(mock_msg_mgr_tr.call_count, 3)
+        # self.assertEqual(mock_create.call_count, 3)
         
-        # Verify events were created
-        events = IngestEvent.objects.all().values()
-        self.assertEqual(len(events), 3)
-        self.assertEqual(events[2]['type'], 'STRIKE')
+        # # Verify events were created
+        # events = IngestEvent.objects.all().values()
+        # self.assertEqual(len(events), 3)
+        # self.assertEqual(events[2]['type'], 'STRIKE')
         
 
     @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -67,8 +67,10 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         self.recipe_v7 = recipe_test_utils.create_recipe_type_v6(name='test-recipe-v7', definition=v7_recipe_type_def)
 
 
+    
+    @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
     @patch('ingest.models.CommandMessageManager')
-    def test_successful_recipe_kickoff(self, mock_msg_mgr):
+    def test_successful_recipe_kickoff(self, mock_msg_mgr, mock_create):
         """Tests successfully producing an ingest that immediately calls a recipe"""
 
         strike_config = {
@@ -92,6 +94,7 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         # Call method to test
         IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
         mock_msg_mgr.assert_called_once()
+        mock_create.assert_called_once()
         
 
     @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -53,8 +53,8 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
 
         self.recipe = recipe_test_utils.create_recipe_type_v6(name='test-recipe', definition=recipe_type_def)
 
-    
-    @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')
+        
+    @patch('queue.models.CommandMessageManager')
     @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
     def test_successful_recipe_kickoff(self, mock_create, mock_msg_mgr):
         """Tests successfully producing an ingest that immediately calls a recipe"""
@@ -109,7 +109,7 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
 
         # Call method to test
         IngestRecipeHandler().process_ingested_source_file(ingest.id, scan, self.source_file, now())
-        self.assertEqual(mock_msg_mgr.call_count, 2)
+        self.assertEqual(mock_msg_mgr.call_count, 1)
         self.assertEqual(mock_create.call_count, 2)
         
         # Verify events were created
@@ -150,7 +150,7 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
 
         # Call method to test
         IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-        self.assertEqual(mock_msg_mgr.call_count, 3)
+        self.assertEqual(mock_msg_mgr.call_count,2)
         self.assertEqual(mock_create.call_count, 3)
         
         # Verify events were created

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -67,10 +67,11 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         self.recipe_v7 = recipe_test_utils.create_recipe_type_v6(name='test-recipe-v7', definition=v7_recipe_type_def)
 
 
+    @patch('recipe.models.CommandMessageManager')
     @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')
     @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
     @patch('ingest.models.CommandMessageManager')
-    def test_successful_recipe_kickoff(self, mock_msg_mgr, mock_create, mock_msg_mgr_tr):
+    def test_successful_recipe_kickoff(self, mock_msg_mgr, mock_create, mock_msg_mgr_tr, mock_msg_mgr_rc):
         """Tests successfully producing an ingest that immediately calls a recipe"""
 
         strike_config = {

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -54,12 +54,11 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         self.recipe = recipe_test_utils.create_recipe_type_v6(name='test-recipe', definition=recipe_type_def)
 
     @patch('recipe.messages.create_recipes.create_update_recipe_metrics_messages')
-    @patch('recipe.messages.create_recipes.create_update_recipe_message')
     @patch('recipe.messages.create_recipes.create_process_recipe_input_messages')
     @patch('recipe.messages.create_recipes.create_supersede_recipe_nodes_messages')
     @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')
     @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
-    def test_successful_recipe_kickoff(self, mock_create, mock_msg_mgr, mock_supersede, mock_processs_input, mock_update, mock_update_metrics):
+    def test_successful_recipe_kickoff(self, mock_create, mock_msg_mgr, mock_supersede, mock_processs_input, mock_update_metrics):
         """Tests successfully producing an ingest that immediately calls a recipe"""
 
         strike_config = {

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -155,23 +155,23 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         
         recipe_test_utils.edit_recipe_type_v6(recipe_type=self.recipe, definition=definition)
         
-        # strike_config['recipe'] = {
-        #     'name': self.recipe.name,
-        #     'revision_num': 1,
-        # }
-        # config = StrikeConfigurationV6(strike_config).get_configuration()
-        # strike = Strike.objects.create_strike('my_name_2', 'my_title_2', 'my_description_2', config)
-        # ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
+        strike_config['recipe'] = {
+            'name': self.recipe.name,
+            'revision_num': 1,
+        }
+        config = StrikeConfigurationV6(strike_config).get_configuration()
+        strike = Strike.objects.create_strike('my_name_2', 'my_title_2', 'my_description_2', config)
+        ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
 
-        # # Call method to test
-        # IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-        # self.assertEqual(mock_msg_mgr_tr.call_count, 3)
-        # self.assertEqual(mock_create.call_count, 3)
+        # Call method to test
+        IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
+        self.assertEqual(mock_msg_mgr_tr.call_count, 3)
+        self.assertEqual(mock_create.call_count, 3)
         
-        # # Verify events were created
-        # events = IngestEvent.objects.all().values()
-        # self.assertEqual(len(events), 3)
-        # self.assertEqual(events[2]['type'], 'STRIKE')
+        # Verify events were created
+        events = IngestEvent.objects.all().values()
+        self.assertEqual(len(events), 3)
+        self.assertEqual(events[2]['type'], 'STRIKE')
         
 
     @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -131,7 +131,7 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         self.assertEqual(len(events), 2)
         self.assertEqual(events[1]['type'], 'SCAN')
         
-        Update the recipe then call ingest with revision 1
+        # Update the recipe then call ingest with revision 1
         manifest = job_test_utils.create_seed_manifest(
             inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
         jt2 = job_test_utils.create_seed_job_type(manifest=manifest)

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -66,12 +66,9 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
                                                               'job_type_revision': 1}}}}
         self.recipe_v7 = recipe_test_utils.create_recipe_type_v6(name='test-recipe-v7', definition=v7_recipe_type_def)
 
-    @patch('recipe.messages.create_recipes.create_update_recipe_metrics_messages')
-    @patch('recipe.messages.create_recipes.create_process_recipe_input_messages')
-    @patch('recipe.messages.create_recipes.create_supersede_recipe_nodes_messages')
     @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')
     @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
-    def test_successful_recipe_kickoff(self, mock_create, mock_msg_mgr, mock_supersede, mock_processs_input, mock_update_metrics):
+    def test_successful_recipe_kickoff(self, mock_create, mock_msg_mgr):
         """Tests successfully producing an ingest that immediately calls a recipe"""
 
         strike_config = {

--- a/scale/ingest/triggers/ingest_recipe_handler.py
+++ b/scale/ingest/triggers/ingest_recipe_handler.py
@@ -86,7 +86,7 @@ class IngestRecipeHandler(object):
             recipe_type = RecipeTypeRevision.objects.get_revision(recipe_name, recipe_revision).recipe_type
             
         if len(recipe_type.get_definition().get_input_keys()) == 0:
-            logger.info('No inputs defined for recipe %s. Recipe will not be ran.' % recipe_name)
+            logger.info('No inputs defined for recipe %s. Recipe will not be run.' % recipe_name)
             return
         
             

--- a/scale/ingest/triggers/ingest_recipe_handler.py
+++ b/scale/ingest/triggers/ingest_recipe_handler.py
@@ -9,12 +9,9 @@ from data.data.data import Data
 from data.data.json.data_v6 import convert_data_to_v6_json
 from data.data.value import FileValue
 from ingest.models import IngestEvent, Scan, Strike
-from job.models import JobType
 from messaging.manager import CommandMessageManager
-from queue.models import Queue
 from recipe.messages.create_recipes import create_recipes_messages
 from recipe.models import RecipeType, RecipeTypeRevision
-from storage.models import Workspace
 from trigger.models import TriggerEvent
 
 logger = logging.getLogger(__name__)

--- a/scale/ingest/triggers/ingest_recipe_handler.py
+++ b/scale/ingest/triggers/ingest_recipe_handler.py
@@ -6,6 +6,7 @@ import logging
 from django.db import transaction
 
 from data.data.data import Data
+from data.data.json.data_v6 import convert_data_to_v6_json
 from data.data.value import FileValue
 from ingest.models import IngestEvent, Scan, Strike
 from job.models import JobType
@@ -56,8 +57,10 @@ class IngestRecipeHandler(object):
             event = self._create_trigger_event(None, source_file, when)
             ingest_event = self._create_ingest_event(ingest_id, None, source_file, when)
             logger.info('Queuing new recipe of type %s', recipe_type.name)
-            CommandMessageManager().send_messages(create_recipes_messages(recipe_type.name, recipe_type.revision_num,
-                                                                          recipe_data, event.id, ingest_event.id))
+            messages = create_recipes_messages(recipe_type.name, recipe_type.revision_num,
+                                               convert_data_to_v6_json(recipe_data).get_dict(), 
+                                               event.id, ingest_event.id)
+            CommandMessageManager().send_messages(messages)
             # Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
         else:
             logger.info('No recipe type found for id %s or recipe type is inactive' % recipe_type_id)
@@ -94,8 +97,10 @@ class IngestRecipeHandler(object):
             ingest_event = self._create_ingest_event(ingest_id, source, source_file, when)
 
             logger.info('Queuing new recipe of type %s', recipe_type.name)
-            CommandMessageManager().send_messages(create_recipes_messages(recipe_type.name, recipe_type.revision_num,
-                                                                          recipe_data, event.id, ingest_event.id))
+            messages = create_recipes_messages(recipe_type.name, recipe_type.revision_num,
+                                               convert_data_to_v6_json(recipe_data).get_dict(), 
+                                               event.id, ingest_event.id)
+            CommandMessageManager().send_messages(messages)
             # Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
         else:
             logger.info('No recipe type found for %s %s or recipe type is inactive' % (recipe_name, recipe_revision))

--- a/scale/ingest/triggers/ingest_recipe_handler.py
+++ b/scale/ingest/triggers/ingest_recipe_handler.py
@@ -61,7 +61,7 @@ class IngestRecipeHandler(object):
                                                convert_data_to_v6_json(recipe_data).get_dict(), 
                                                event.id, ingest_event.id)
             CommandMessageManager().send_messages(messages)
-            # Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
+            
         else:
             logger.info('No recipe type found for id %s or recipe type is inactive' % recipe_type_id)
 
@@ -101,7 +101,7 @@ class IngestRecipeHandler(object):
                                                convert_data_to_v6_json(recipe_data).get_dict(), 
                                                event.id, ingest_event.id)
             CommandMessageManager().send_messages(messages)
-            # Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
+            
         else:
             logger.info('No recipe type found for %s %s or recipe type is inactive' % (recipe_name, recipe_revision))
 

--- a/scale/ingest/triggers/ingest_recipe_handler.py
+++ b/scale/ingest/triggers/ingest_recipe_handler.py
@@ -9,7 +9,9 @@ from data.data.data import Data
 from data.data.value import FileValue
 from ingest.models import IngestEvent, Scan, Strike
 from job.models import JobType
+from messaging.manager import CommandMessageManager
 from queue.models import Queue
+from recipe.messages.create_recipes import create_recipes_messages
 from recipe.models import RecipeType, RecipeTypeRevision
 from storage.models import Workspace
 from trigger.models import TriggerEvent
@@ -54,7 +56,9 @@ class IngestRecipeHandler(object):
             event = self._create_trigger_event(None, source_file, when)
             ingest_event = self._create_ingest_event(ingest_id, None, source_file, when)
             logger.info('Queuing new recipe of type %s', recipe_type.name)
-            Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
+            CommandMessageManager().send_messages(create_recipes_messages(recipe_type, recipe_type.revision_num,
+                                                                          recipe_data, event.id, ingest_event.id))
+            # Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
         else:
             logger.info('No recipe type found for id %s or recipe type is inactive' % recipe_type_id)
 
@@ -90,7 +94,9 @@ class IngestRecipeHandler(object):
             ingest_event = self._create_ingest_event(ingest_id, source, source_file, when)
 
             logger.info('Queuing new recipe of type %s', recipe_type.name)
-            Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
+            CommandMessageManager().send_messages(create_recipes_messages(recipe_type, recipe_type.revision_num,
+                                                                          recipe_data, event.id, ingest_event.id))
+            # Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
         else:
             logger.info('No recipe type found for %s %s or recipe type is inactive' % (recipe_name, recipe_revision))
 

--- a/scale/ingest/triggers/ingest_recipe_handler.py
+++ b/scale/ingest/triggers/ingest_recipe_handler.py
@@ -88,8 +88,7 @@ class IngestRecipeHandler(object):
         if len(recipe_type.get_definition().get_input_keys()) == 0:
             logger.info('No inputs defined for recipe %s. Recipe will not be run.' % recipe_name)
             return
-        
-            
+
         if recipe_type and recipe_type.is_active:
             # Assuming one input per recipe, so pull the first defined input you find
             recipe_data = Data()
@@ -157,7 +156,6 @@ class IngestRecipeHandler(object):
         else:
             event_type = 'MANUAL_INGEST'
         
-        event = None
         with transaction.atomic():
             event = TriggerEvent.objects.create_trigger_event(event_type, None, description, when)
         return event

--- a/scale/ingest/triggers/ingest_recipe_handler.py
+++ b/scale/ingest/triggers/ingest_recipe_handler.py
@@ -32,7 +32,6 @@ class IngestRecipeHandler(object):
 
         super(IngestRecipeHandler, self).__init__()
 
-    @transaction.atomic
     def process_manual_ingested_source_file(self, ingest_id, source_file, when, recipe_type_id):
         """Processes a manual ingest where a strike or scan is not involved. All database
         changes are made in an atomic transaction
@@ -64,7 +63,6 @@ class IngestRecipeHandler(object):
         else:
             logger.info('No recipe type found for id %s or recipe type is inactive' % recipe_type_id)
 
-    @transaction.atomic
     def process_ingested_source_file(self, ingest_id, source, source_file, when):
         """Processes the given ingested source file by kicking off its recipe.
         All database changes are made in an atomic transaction.

--- a/scale/ingest/triggers/ingest_recipe_handler.py
+++ b/scale/ingest/triggers/ingest_recipe_handler.py
@@ -56,7 +56,7 @@ class IngestRecipeHandler(object):
             event = self._create_trigger_event(None, source_file, when)
             ingest_event = self._create_ingest_event(ingest_id, None, source_file, when)
             logger.info('Queuing new recipe of type %s', recipe_type.name)
-            CommandMessageManager().send_messages(create_recipes_messages(recipe_type, recipe_type.revision_num,
+            CommandMessageManager().send_messages(create_recipes_messages(recipe_type.name, recipe_type.revision_num,
                                                                           recipe_data, event.id, ingest_event.id))
             # Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
         else:
@@ -94,7 +94,7 @@ class IngestRecipeHandler(object):
             ingest_event = self._create_ingest_event(ingest_id, source, source_file, when)
 
             logger.info('Queuing new recipe of type %s', recipe_type.name)
-            CommandMessageManager().send_messages(create_recipes_messages(recipe_type, recipe_type.revision_num,
+            CommandMessageManager().send_messages(create_recipes_messages(recipe_type.name, recipe_type.revision_num,
                                                                           recipe_data, event.id, ingest_event.id))
             # Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
         else:

--- a/scale/job/messages/create_jobs.py
+++ b/scale/job/messages/create_jobs.py
@@ -80,7 +80,7 @@ def create_jobs_messages_for_recipe(recipe, recipe_jobs):
             message.recipe_id = recipe.id
             message.root_recipe_id = recipe.root_superseded_recipe_id
             message.event_id = recipe.event_id
-            message.ingest_event_id = recipe.ingest_event
+            message.ingest_event_id = recipe.ingest_event_id
             message.superseded_recipe_id = recipe.superseded_recipe_id
             message.batch_id = recipe.batch_id
             message.recipe_config = recipe.configuration
@@ -91,7 +91,7 @@ def create_jobs_messages_for_recipe(recipe, recipe_jobs):
             message.recipe_id = recipe.id
             message.root_recipe_id = recipe.root_superseded_recipe_id
             message.event_id = recipe.event_id
-            message.ingest_event_id = recipe.ingest_event
+            message.ingest_event_id = recipe.ingest_event_id
             message.superseded_recipe_id = recipe.superseded_recipe_id
             message.batch_id = recipe.batch_id
             message.recipe_config = recipe.configuration

--- a/scale/job/messages/process_job_input.py
+++ b/scale/job/messages/process_job_input.py
@@ -10,7 +10,6 @@ from data.data.exceptions import InvalidData
 from job.messages.cancel_jobs import create_cancel_jobs_messages
 from job.models import Job
 from messaging.messages.message import CommandMessage
-# from util.database import sleep
 
 
 logger = logging.getLogger(__name__)
@@ -70,18 +69,6 @@ class ProcessJobInput(CommandMessage):
         """
 
         from queue.messages.queued_jobs import create_queued_jobs_messages, QueuedJob
-
-        # wait max of 5 seconds for events to save
-        # job = sleep(Job, self.job_id)
-        
-        # if not job:
-        #     if self.tries < MAX_TRIES:
-        #         logger.warning('Job %d does not exist. Maximum tries exceeded. Message will not re-run.', self.job_id)
-        #         return True
-        #     else:
-        #         self.tries += 1
-        #         logger.warning('Job %d does not exist - throwing message back on queue to try again.', self.job_id)
-        #         return False
 
         try:
             job = Job.objects.get_job_with_interfaces(self.job_id)

--- a/scale/job/messages/process_job_input.py
+++ b/scale/job/messages/process_job_input.py
@@ -10,10 +10,12 @@ from data.data.exceptions import InvalidData
 from job.messages.cancel_jobs import create_cancel_jobs_messages
 from job.models import Job
 from messaging.messages.message import CommandMessage
+# from util.database import sleep
 
 
 logger = logging.getLogger(__name__)
 
+# MAX_TRIES = 5 # Maximum number of tries before giving up on the job
 
 def create_process_job_input_messages(job_ids):
     """Creates messages to process the input for the given jobs
@@ -45,12 +47,13 @@ class ProcessJobInput(CommandMessage):
         super(ProcessJobInput, self).__init__('process_job_input')
 
         self.job_id = None
+        # self.tries = 0
 
     def to_json(self):
         """See :meth:`messaging.messages.message.CommandMessage.to_json`
         """
 
-        return {'job_id': self.job_id}
+        return {'job_id': self.job_id} #, 'tries': self.tries}
 
     @staticmethod
     def from_json(json_dict):
@@ -59,6 +62,7 @@ class ProcessJobInput(CommandMessage):
 
         message = ProcessJobInput()
         message.job_id = json_dict['job_id']
+        # message.tries = json_dict['tries']
         return message
 
     def execute(self):
@@ -67,7 +71,23 @@ class ProcessJobInput(CommandMessage):
 
         from queue.messages.queued_jobs import create_queued_jobs_messages, QueuedJob
 
-        job = Job.objects.get_job_with_interfaces(self.job_id)
+        # wait max of 5 seconds for events to save
+        # job = sleep(Job, self.job_id)
+        
+        # if not job:
+        #     if self.tries < MAX_TRIES:
+        #         logger.warning('Job %d does not exist. Maximum tries exceeded. Message will not re-run.', self.job_id)
+        #         return True
+        #     else:
+        #         self.tries += 1
+        #         logger.warning('Job %d does not exist - throwing message back on queue to try again.', self.job_id)
+        #         return False
+
+        try:
+            job = Job.objects.get_job_with_interfaces(self.job_id)
+        except Job.DoesNotExist:
+            logger.exception('Failed to get job %d - job does not exist. Message will not re-run.', self.job_id)
+            return True
         
         if job.status not in ['PENDING', 'BLOCKED']:
             logger.warning('Job %d input has already been processed. Message will not re-run', self.job_id)

--- a/scale/job/messages/process_job_input.py
+++ b/scale/job/messages/process_job_input.py
@@ -14,8 +14,6 @@ from messaging.messages.message import CommandMessage
 
 logger = logging.getLogger(__name__)
 
-# MAX_TRIES = 5 # Maximum number of tries before giving up on the job
-
 def create_process_job_input_messages(job_ids):
     """Creates messages to process the input for the given jobs
 

--- a/scale/job/test/execution/configuration/test_configurators.py
+++ b/scale/job/test/execution/configuration/test_configurators.py
@@ -417,7 +417,7 @@ class TestQueuedExecutionConfigurator(TestCase):
         ExecutionConfiguration(config_dict)
         self.assertDictEqual(config_dict, expected_config)
 
-    @patch('queue.models.CommandMessageManager')
+    @patch('ingest.models.CommandMessageManager')
     def test_configure_queued_job_strike(self, mock_msg_mgr):
         """Tests successfully calling configure_queued_job() on a Strike job"""
 
@@ -450,7 +450,7 @@ class TestQueuedExecutionConfigurator(TestCase):
         ExecutionConfiguration(config_dict)
         self.assertDictEqual(config_dict, expected_config)
 
-    @patch('queue.models.CommandMessageManager')
+    @patch('ingest.models.CommandMessageManager')
     def test_configure_queued_job_scan(self, mock_msg_mgr):
         """Tests successfully calling configure_queued_job() on a Scan job"""
 

--- a/scale/job/test/execution/configuration/test_configurators.py
+++ b/scale/job/test/execution/configuration/test_configurators.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 
 import django
+from django.db import transaction
 from django.test import TestCase
 from django.utils.timezone import now
 from mock import patch, MagicMock
@@ -30,6 +31,19 @@ from storage.container import get_workspace_volume_path
 from storage.test import utils as storage_test_utils
 from trigger.test import utils as trigger_test_utils
 
+
+class MockCommandMessageManager():
+
+    def send_messages(self, commands):
+        new_commands = []
+        while True:
+            for command in commands:
+                command.execute()
+                new_commands.extend(command.new_messages)
+            commands = new_commands
+            if not new_commands:
+                break
+            new_commands = []
 
 class TestQueuedExecutionConfigurator(TestCase):
 
@@ -318,7 +332,26 @@ class TestQueuedExecutionConfigurator(TestCase):
         from ingest.test import utils as ingest_test_utils
         scan = ingest_test_utils.create_scan()
         ingest = ingest_test_utils.create_ingest(scan=scan, workspace=workspace_1, new_workspace=workspace_2)
-        Ingest.objects.start_ingest_tasks([ingest], scan_id=scan.id)
+
+        # start ingest_tasks (can't call method due to using command messages)
+        when = ingest.transfer_ended if ingest.transfer_ended else now()
+        desc = {'file_name': ingest.file_name, 'scan_id': scan.id}
+        
+        from trigger.models import TriggerEvent
+        from data.data.value import JsonValue
+        event = TriggerEvent.objects.create_trigger_event('SCAN_TRANSFER', None, desc, when)
+        data = Data()
+        data.add_value(JsonValue('ingest_id', ingest.id))
+        data.add_value(JsonValue('workspace', ingest.workspace.name))
+        if ingest.new_workspace:
+            data.add_value(JsonValue('new_workspace', ingest.new_workspace.name))
+            
+        from queue.models import Queue
+        with transaction.atomic():
+            ingest_job = Queue.objects.queue_new_job_v6(Ingest.objects.get_ingest_job_type(), data, event)
+            ingest.job = ingest_job
+            ingest.status = 'QUEUED'
+            ingest.save()
 
         expected_args = 'scale_ingest -i %s' % str(ingest.id)
         expected_env_vars = {'INGEST_ID': str(ingest.id), 'WORKSPACE': workspace_1.name,
@@ -347,7 +380,26 @@ class TestQueuedExecutionConfigurator(TestCase):
         from ingest.test import utils as ingest_test_utils
         scan = ingest_test_utils.create_scan()
         ingest = ingest_test_utils.create_ingest(scan=scan, workspace=workspace_1)
-        Ingest.objects.start_ingest_tasks([ingest], scan_id=scan.id)
+       
+        # start ingest_tasks (can't call method due to using command messages)
+        when = ingest.transfer_ended if ingest.transfer_ended else now()
+        desc = {'file_name': ingest.file_name, 'scan_id': scan.id}
+        
+        from trigger.models import TriggerEvent
+        from data.data.value import JsonValue
+        event = TriggerEvent.objects.create_trigger_event('SCAN_TRANSFER', None, desc, when)
+        data = Data()
+        data.add_value(JsonValue('ingest_id', ingest.id))
+        data.add_value(JsonValue('workspace', ingest.workspace.name))
+        if ingest.new_workspace:
+            data.add_value(JsonValue('new_workspace', ingest.new_workspace.name))
+            
+        from queue.models import Queue
+        with transaction.atomic():
+            ingest_job = Queue.objects.queue_new_job_v6(Ingest.objects.get_ingest_job_type(), data, event)
+            ingest.job = ingest_job
+            ingest.status = 'QUEUED'
+            ingest.save()
 
         expected_args = 'scale_ingest -i %s' % str(ingest.id)
         expected_env_vars = {'INGEST_ID': str(ingest.id), 'WORKSPACE': workspace_1.name}
@@ -434,7 +486,7 @@ class TestScheduledExecutionConfigurator(TestCase):
         django.setup()
 
         add_message_backend(AMQPMessagingBackend)
-
+        
     @patch('queue.models.CommandMessageManager')
     def test_configure_scheduled_job_ingest(self, mock_msg_mgr):
         """Tests successfully calling configure_scheduled_job() on an ingest job"""
@@ -452,13 +504,32 @@ class TestScheduledExecutionConfigurator(TestCase):
         scan = ingest_test_utils.create_scan()
         ingest_job_type = Ingest.objects.get_ingest_job_type()
         ingest = ingest_test_utils.create_ingest(scan=scan, workspace=workspace, new_workspace=new_workspace)
-        Ingest.objects.start_ingest_tasks([ingest], scan_id=scan.id)
 
+        # start ingest_tasks (can't call method due to using command messages)
+        when = ingest.transfer_ended if ingest.transfer_ended else now()
+        desc = {'file_name': ingest.file_name, 'scan_id': scan.id}
+        
+        from trigger.models import TriggerEvent
+        from data.data.value import JsonValue
+        event = TriggerEvent.objects.create_trigger_event('SCAN_TRANSFER', None, desc, when)
+        data = Data()
+        data.add_value(JsonValue('ingest_id', ingest.id))
+        data.add_value(JsonValue('workspace', ingest.workspace.name))
+        if ingest.new_workspace:
+            data.add_value(JsonValue('new_workspace', ingest.new_workspace.name))
+            
+        from queue.models import Queue
+        with transaction.atomic():
+            ingest_job = Queue.objects.queue_new_job_v6(Ingest.objects.get_ingest_job_type(), data, event)
+            ingest.job = ingest_job
+            ingest.status = 'QUEUED'
+            ingest.save()
+            
         job = ingest.job
         resources = job.get_resources()
+        
         # Get job info off of the queue
         from queue.job_exe import QueuedJobExecution
-        from queue.models import Queue
         queue = Queue.objects.get(job_id=job.id)
         queued_job_exe = QueuedJobExecution(queue)
         queued_job_exe.scheduled('agent_1', node.id, resources)

--- a/scale/job/test/execution/configuration/test_configurators.py
+++ b/scale/job/test/execution/configuration/test_configurators.py
@@ -11,6 +11,7 @@ from mock import patch, MagicMock
 from batch.test import utils as batch_test_utils
 from data.data.data import Data
 from data.data.json.data_v6 import DataV6
+from ingest.messages.create_ingest_jobs import create_scan_ingest_job_message
 from job.execution.configuration.configurators import QueuedExecutionConfigurator, ScheduledExecutionConfigurator
 from job.configuration.data.job_data import JobData
 from job.execution.configuration.json.exe_config import ExecutionConfiguration
@@ -333,26 +334,10 @@ class TestQueuedExecutionConfigurator(TestCase):
         scan = ingest_test_utils.create_scan()
         ingest = ingest_test_utils.create_ingest(scan=scan, workspace=workspace_1, new_workspace=workspace_2)
 
-        # start ingest_tasks (can't call method due to using command messages)
-        when = ingest.transfer_ended if ingest.transfer_ended else now()
-        desc = {'file_name': ingest.file_name, 'scan_id': scan.id}
-        
-        from trigger.models import TriggerEvent
-        from data.data.value import JsonValue
-        event = TriggerEvent.objects.create_trigger_event('SCAN_TRANSFER', None, desc, when)
-        data = Data()
-        data.add_value(JsonValue('ingest_id', ingest.id))
-        data.add_value(JsonValue('workspace', ingest.workspace.name))
-        if ingest.new_workspace:
-            data.add_value(JsonValue('new_workspace', ingest.new_workspace.name))
+        message = create_scan_ingest_job_message(ingest.id, scan.id)
+        result = message.execute()
+        ingest = Ingest.objects.get(pk=ingest.id)
             
-        from queue.models import Queue
-        with transaction.atomic():
-            ingest_job = Queue.objects.queue_new_job_v6(Ingest.objects.get_ingest_job_type(), data, event)
-            ingest.job = ingest_job
-            ingest.status = 'QUEUED'
-            ingest.save()
-
         expected_args = 'scale_ingest -i %s' % str(ingest.id)
         expected_env_vars = {'INGEST_ID': str(ingest.id), 'WORKSPACE': workspace_1.name,
                              'NEW_WORKSPACE': workspace_2.name}
@@ -380,26 +365,10 @@ class TestQueuedExecutionConfigurator(TestCase):
         from ingest.test import utils as ingest_test_utils
         scan = ingest_test_utils.create_scan()
         ingest = ingest_test_utils.create_ingest(scan=scan, workspace=workspace_1)
-       
-        # start ingest_tasks (can't call method due to using command messages)
-        when = ingest.transfer_ended if ingest.transfer_ended else now()
-        desc = {'file_name': ingest.file_name, 'scan_id': scan.id}
         
-        from trigger.models import TriggerEvent
-        from data.data.value import JsonValue
-        event = TriggerEvent.objects.create_trigger_event('SCAN_TRANSFER', None, desc, when)
-        data = Data()
-        data.add_value(JsonValue('ingest_id', ingest.id))
-        data.add_value(JsonValue('workspace', ingest.workspace.name))
-        if ingest.new_workspace:
-            data.add_value(JsonValue('new_workspace', ingest.new_workspace.name))
-            
-        from queue.models import Queue
-        with transaction.atomic():
-            ingest_job = Queue.objects.queue_new_job_v6(Ingest.objects.get_ingest_job_type(), data, event)
-            ingest.job = ingest_job
-            ingest.status = 'QUEUED'
-            ingest.save()
+        message = create_scan_ingest_job_message(ingest.id, scan.id)
+        result = message.execute()
+        ingest = Ingest.objects.get(pk=ingest.id)
 
         expected_args = 'scale_ingest -i %s' % str(ingest.id)
         expected_env_vars = {'INGEST_ID': str(ingest.id), 'WORKSPACE': workspace_1.name}
@@ -505,30 +474,15 @@ class TestScheduledExecutionConfigurator(TestCase):
         ingest_job_type = Ingest.objects.get_ingest_job_type()
         ingest = ingest_test_utils.create_ingest(scan=scan, workspace=workspace, new_workspace=new_workspace)
 
-        # start ingest_tasks (can't call method due to using command messages)
-        when = ingest.transfer_ended if ingest.transfer_ended else now()
-        desc = {'file_name': ingest.file_name, 'scan_id': scan.id}
-        
-        from trigger.models import TriggerEvent
-        from data.data.value import JsonValue
-        event = TriggerEvent.objects.create_trigger_event('SCAN_TRANSFER', None, desc, when)
-        data = Data()
-        data.add_value(JsonValue('ingest_id', ingest.id))
-        data.add_value(JsonValue('workspace', ingest.workspace.name))
-        if ingest.new_workspace:
-            data.add_value(JsonValue('new_workspace', ingest.new_workspace.name))
-            
-        from queue.models import Queue
-        with transaction.atomic():
-            ingest_job = Queue.objects.queue_new_job_v6(Ingest.objects.get_ingest_job_type(), data, event)
-            ingest.job = ingest_job
-            ingest.status = 'QUEUED'
-            ingest.save()
+        message = create_scan_ingest_job_message(ingest.id, scan.id)
+        result = message.execute()
+        ingest = Ingest.objects.get(pk=ingest.id)
             
         job = ingest.job
         resources = job.get_resources()
         
         # Get job info off of the queue
+        from queue.models import Queue
         from queue.job_exe import QueuedJobExecution
         queue = Queue.objects.get(job_id=job.id)
         queued_job_exe = QueuedJobExecution(queue)

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -113,7 +113,6 @@ class TestGetAuthDisabledJobsView(APITestCase):
         # Response should be new v6 job detail response
         self.assertEqual(result['execution'], None)
         self.assertTrue('/%s/jobs/' % self.api in response['location'])
-        mock_create.assert_called_once()
 
 
 class TestJobsViewV6(APITestCase):
@@ -466,8 +465,8 @@ class TestJobsPostViewV6(APITestCase):
 
         rest.login_client(self.client, is_staff=True)
 
-    @patch('queue.models.CommandMessageManager')
-    @patch('queue.models.create_process_job_input_messages')
+    @patch('job.views.CommandMessageManager')
+    @patch('job.views.create_process_job_input_messages')
     def test_successful(self, mock_create, mock_msg_mgr):
         """Tests successfully calling POST jobs view to queue a new job"""
 
@@ -491,8 +490,8 @@ class TestJobsPostViewV6(APITestCase):
         self.assertTrue('/%s/jobs/' % self.api in response['location'])
         mock_create.assert_called_once()
 
-    @patch('queue.models.CommandMessageManager')
-    @patch('queue.models.create_process_job_input_messages')
+    @patch('job.views.CommandMessageManager')
+    @patch('job.views.create_process_job_input_messages')
     def test_successful_configuration(self, mock_create, mock_msg_mgr):
         """Tests successfully calling POST jobs view to queue a new job with a job type configuration"""
 

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -86,8 +86,8 @@ class TestGetAuthDisabledJobsView(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
-    @patch('queue.models.CommandMessageManager')
-    @patch('queue.models.create_process_job_input_messages')
+    @patch('job.views.CommandMessageManager')
+    @patch('job.views.create_process_job_input_messages')
     def test_unathenticated_on_post(self, mock_create, mock_msg_mgr):
         """Tests for failure when posting to the jobs view with authentication."""
 
@@ -95,8 +95,8 @@ class TestGetAuthDisabledJobsView(APITestCase):
         response = self.client.post(url, data=self.json_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
 
-    @patch('queue.models.CommandMessageManager')
-    @patch('queue.models.create_process_job_input_messages')
+    @patch('job.views.CommandMessageManager')
+    @patch('job.views.create_process_job_input_messages')
     def test_success_on_post(self, mock_create, mock_msg_mgr):
         """Tests success when posting to the jobs view with authentication."""
 

--- a/scale/metrics/daily_metrics.py
+++ b/scale/metrics/daily_metrics.py
@@ -8,7 +8,9 @@ import django.utils.timezone as timezone
 from data.data.data import Data
 from data.data.value import JsonValue
 from job.clock import ClockEventError, ClockEventProcessor
+from job.messages.process_job_input import create_process_job_input_messages
 from job.models import JobType
+from messaging.manager import CommandMessageManager
 from queue.models import Queue
 
 logger = logging.getLogger(__name__)
@@ -41,4 +43,5 @@ class DailyMetricsProcessor(ClockEventProcessor):
         for day in days:
             job_data = Data()
             job_data.add_value(JsonValue('DAY', day.strftime('%Y-%m-%d')))
-            Queue.objects.queue_new_job_v6(job_type, job_data, event)
+            job = Queue.objects.queue_new_job_v6(job_type, job_data, event)
+            CommandMessageManager().send_messages(create_process_job_input_messages([job.pk]))

--- a/scale/metrics/daily_metrics.py
+++ b/scale/metrics/daily_metrics.py
@@ -44,4 +44,4 @@ class DailyMetricsProcessor(ClockEventProcessor):
             job_data = Data()
             job_data.add_value(JsonValue('DAY', day.strftime('%Y-%m-%d')))
             job = Queue.objects.queue_new_job_v6(job_type, job_data, event)
-            CommandMessageManager().send_messages(create_process_job_input_messages([job.pk]))
+            CommandMessageManager().send_messages(create_process_job_input_messages([job.id]))

--- a/scale/metrics/test/test_daily_metrics.py
+++ b/scale/metrics/test/test_daily_metrics.py
@@ -22,9 +22,10 @@ class TestDailyMetricsProcessor(TransactionTestCase):
         self.job_type = job_test_utils.create_seed_job_type(manifest=manifest)
         self.processor = DailyMetricsProcessor()
 
+    @patch('metrics.daily_metrics.CommandMessageManager')
     @patch('metrics.daily_metrics.Queue')
     @patch('metrics.daily_metrics.timezone.now', lambda: datetime.datetime(2015, 1, 10, tzinfo=utc))
-    def test_process_event_first(self, mock_Queue):
+    def test_process_event_first(self, mock_Queue, mock_msg_mgr):
         """Tests processing an event that was never triggered before."""
         event = job_test_utils.create_clock_event(occurred=datetime.datetime(2015, 1, 10, 12, tzinfo=utc))
 

--- a/scale/metrics/test/test_daily_metrics.py
+++ b/scale/metrics/test/test_daily_metrics.py
@@ -37,9 +37,10 @@ class TestDailyMetricsProcessor(TransactionTestCase):
         self.assertDictEqual({u'files': {}, u'json': {u'DAY': '2015-01-09'}, u'version': u'7'}, inputs.get_dict())
         self.assertEqual(event, call_args[2])
 
+    @patch('metrics.daily_metrics.CommandMessageManager')
     @patch('metrics.daily_metrics.Queue')
     @patch('metrics.daily_metrics.timezone.now', lambda: datetime.datetime(2015, 1, 10, tzinfo=utc))
-    def test_process_event_last(self, mock_Queue):
+    def test_process_event_last(self, mock_Queue, mock_msg_mgr):
         """Tests processing an event that was triggered before."""
         event = job_test_utils.create_clock_event(occurred=datetime.datetime(2015, 1, 10, 12, second=9, tzinfo=utc))
         last = job_test_utils.create_clock_event(occurred=datetime.datetime(2015, 1, 9, 12, second=10, tzinfo=utc))
@@ -52,9 +53,10 @@ class TestDailyMetricsProcessor(TransactionTestCase):
         self.assertDictEqual({u'files': {}, u'json': {u'DAY': '2015-01-09'}, u'version': u'7'}, inputs.get_dict())
         self.assertEqual(event, call_args[2])
 
+    @patch('metrics.daily_metrics.CommandMessageManager')
     @patch('metrics.daily_metrics.Queue')
     @patch('metrics.daily_metrics.timezone.now', lambda: datetime.datetime(2015, 1, 10, tzinfo=utc))
-    def test_process_event_range(self, mock_Queue):
+    def test_process_event_range(self, mock_Queue, mock_msg_mgr):
         """Tests processing an event that requires catching up for a range of previous days."""
         event = job_test_utils.create_clock_event(occurred=datetime.datetime(2015, 1, 10, 10, tzinfo=utc))
         last = job_test_utils.create_clock_event(occurred=datetime.datetime(2015, 1, 7, 12, tzinfo=utc))
@@ -78,9 +80,10 @@ class TestDailyMetricsProcessor(TransactionTestCase):
 
         self.assertEqual(mock_Queue.objects.queue_new_job_v6.call_count, 3)
 
+    @patch('metrics.daily_metrics.CommandMessageManager')
     @patch('metrics.daily_metrics.Queue')
     @patch('metrics.daily_metrics.timezone.now', lambda: datetime.datetime(2015, 1, 10, tzinfo=utc))
-    def test_process_event_duplicate(self, mock_Queue):
+    def test_process_event_duplicate(self, mock_Queue, mock_msg_mgr):
         """Tests processing an event that was previously handled."""
         event = job_test_utils.create_clock_event(occurred=datetime.datetime(2015, 1, 10, 12, tzinfo=utc))
         last = job_test_utils.create_clock_event(occurred=datetime.datetime(2015, 1, 10, 10, tzinfo=utc))

--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -367,7 +367,11 @@ class QueueManager(models.Manager):
                 job.save()
         except InvalidData as ex:
             raise BadParameter(unicode(ex))
-
+        
+        # Send message to start processing job input (done outside the transaction to hope the job exists)
+        CommandMessageManager().send_messages(create_process_job_input_messages([job.pk]))
+        
+        # queue and return the job
         self.queue_jobs([job])
         job = Job.objects.get_details(job.id)
         

--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -359,22 +359,16 @@ class QueueManager(models.Manager):
 
         :raises job.configuration.data.exceptions.InvalidData: If the job data is invalid
         """
-
         try:
             job_type_rev = JobTypeRevision.objects.get_revision(job_type.name, job_type.version, job_type.revision_num)
             with transaction.atomic():
                 job = Job.objects.create_job_v6(job_type_rev, event_id=event.id, input_data=data,
                                                 job_config=job_configuration)
                 job.save()
-                CommandMessageManager().send_messages(create_process_job_input_messages([job.pk]))
         except InvalidData as ex:
             raise BadParameter(unicode(ex))
 
-
         # No lock needed for this job since it doesn't exist outside this transaction yet
-        self.queue_jobs([job])
-        job = Job.objects.get_details(job.id)
-
         return job
 
     # TODO: once Django user auth is used, have the user information passed into here

--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -368,10 +368,6 @@ class QueueManager(models.Manager):
         except InvalidData as ex:
             raise BadParameter(unicode(ex))
         
-        # Send message to start processing job input (done outside the transaction to hope the job exists)
-        # This can cause a race condition with a slow DB.
-        CommandMessageManager().send_messages(create_process_job_input_messages([job.pk]))
-        
         # queue and return the job
         self.queue_jobs([job])
         job = Job.objects.get_details(job.id)

--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -368,7 +368,9 @@ class QueueManager(models.Manager):
         except InvalidData as ex:
             raise BadParameter(unicode(ex))
 
-        # No lock needed for this job since it doesn't exist outside this transaction yet
+        self.queue_jobs([job])
+        job = Job.objects.get_details(job.id)
+        
         return job
 
     # TODO: once Django user auth is used, have the user information passed into here

--- a/scale/recipe/messages/create_recipes.py
+++ b/scale/recipe/messages/create_recipes.py
@@ -469,18 +469,15 @@ class CreateRecipes(CommandMessage):
         config = None
         if self.configuration:
             config = RecipeConfigurationV6(self.configuration)
-            
+        
         # wait max of 5 seconds for events to save
         from trigger.models import TriggerEvent
         event = sleep(TriggerEvent, self.event_id)
-        if not event:
-            logger.exception('Trigger event %d does not exist - returning mesage to queue ' % self.event_id)
-            return False
-            
+
         from ingest.models import IngestEvent
         ingest_event = sleep(IngestEvent, self.ingest_event_id)
-        if not ingest_event:
-            logger.exception('Ingest Event %d does not exist - returning message to queue.' % self.ingest_event_id)
+        if not event or not ingest_event:
+            logger.exception('TriggerEvent %d or Ingest Event %d does not exist - returning message to queue.' % (self.event_id, self.ingest_event_id))
             return False
             
         with transaction.atomic():

--- a/scale/recipe/messages/create_recipes.py
+++ b/scale/recipe/messages/create_recipes.py
@@ -54,13 +54,13 @@ def create_recipes_messages(recipe_type_name, revision_num, recipe_data, event_i
     :param revision_num: The revision number of the recipe type
     :type revision_num: int
     :param recipe_data: The input data for the recipe
-    :type recipe_data: :ref:`data.data.data.Data`
+    :type recipe_data: dict
     :param event_id: The event ID
     :type event_id: int
     :param ingest_event_id: The ingest event id
     :type ingest_event_id: int
     :param configuration: The configuration of the recipe
-    :type configuration:
+    :type configuration: dict
     :param batch_id: The batch ID
     :type: batch_id: int
     :return: The list of messages
@@ -473,12 +473,11 @@ class CreateRecipes(CommandMessage):
                                                  ingest_id=self.ingest_event_id, input_data=recipe_input_data,
                                                  batch_id=self.batch_id, recipe_config=config)
             recipe.save()
+            self.new_recipes.append(recipe.id)
             
         recipes = []
         if recipe:
             recipes.append(recipe)
-
-        Recipe.objects.bulk_create(recipes)
 
         return recipes
 

--- a/scale/recipe/messages/create_recipes.py
+++ b/scale/recipe/messages/create_recipes.py
@@ -17,6 +17,7 @@ from recipe.exceptions import InactiveRecipeType
 from recipe.messages.process_recipe_input import create_process_recipe_input_messages
 from recipe.messages.supersede_recipe_nodes import create_supersede_recipe_nodes_messages
 from recipe.messages.update_recipe_metrics import create_update_recipe_metrics_messages
+from recipe.configuration.json.recipe_config_v6 import RecipeConfigurationV6
 from recipe.models import Recipe, RecipeNode, RecipeNodeCopy, RecipeType, RecipeTypeRevision
 
 
@@ -75,9 +76,7 @@ def create_recipes_messages(recipe_type_name, revision_num, recipe_data, event_i
     message.ingest_event_id = ingest_event_id
     message.configuration = configuration
     message.batch_id = batch_id
-
-    if message:
-        messages.append(message)
+    messages.append(message)
 
     return messages
 
@@ -462,9 +461,12 @@ class CreateRecipes(CommandMessage):
 
         recipe_type_rev = RecipeTypeRevision.objects.get_revision(self.recipe_type_name, self.recipe_type_rev_num)
 
+        config = None
+        if self.configuration:
+            config = RecipeConfigurationV6(self.configuration)
         recipe = Recipe.objects.create_recipe_v6(recipe_type_rev=recipe_type_rev, event_id=self.event_id,
-                                                 ingest_id=self.ingest_event_id, input_data=self.recipe_input,
-                                                 batch_id=self.batch_id, recipe_config=self.configuration)
+                                                 ingest_id=self.ingest_event_id, input_data=self.recipe_input_data,
+                                                 batch_id=self.batch_id, recipe_config=config)
         recipes = []
         if recipe:
             recipes.append(recipe)

--- a/scale/recipe/messages/create_recipes.py
+++ b/scale/recipe/messages/create_recipes.py
@@ -24,7 +24,7 @@ from recipe.models import Recipe, RecipeNode, RecipeNodeCopy, RecipeType, Recipe
 from util.database import sleep
 
 
-REPROCESS_TYPE = 'reprocess'  # Message type for creating recipes that are reprocessing another set of recipescl
+REPROCESS_TYPE = 'reprocess'  # Message type for creating recipes that are reprocessing another set of recipes
 SUB_RECIPE_TYPE = 'sub-recipes'  # Message type for creating sub-recipes of another recipe
 NEW_RECIPE_TYPE = 'new-recipe'  # Message type for creating a new recipe of a recipe type
 

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -157,8 +157,12 @@ class RecipeManager(models.Manager):
         :returns: The recipe model
         :rtype: :class:`recipe.models.Recipe`
         """
-
-        return self.get_locked_recipes([recipe_id])[0]
+        
+        locked_recipes = self.get_locked_recipes([recipe_id])
+        if len(locked_recipes) > 0:
+            return locked_recipes[0]
+        
+        return None
 
     def get_locked_recipes(self, recipe_ids):
         """Locks and returns the recipe models for the given IDs with no related fields. Caller must be within an atomic

--- a/scale/recipe/test/messages/test_create_recipes.py
+++ b/scale/recipe/test/messages/test_create_recipes.py
@@ -15,6 +15,8 @@ from ingest.models import IngestEvent, Strike
 import ingest.test.utils as ingest_test_utils
 from job.models import Job, JobType, JobTypeRevision
 from job.test import utils as job_test_utils
+from messaging.backends.amqp import AMQPMessagingBackend
+from messaging.backends.factory import add_message_backend
 from recipe.definition.definition import RecipeDefinition
 from recipe.definition.json.definition_v6 import convert_recipe_definition_to_v6_json
 from recipe.diff.forced_nodes import ForcedNodes
@@ -34,8 +36,10 @@ class TestCreateRecipes(TestCase):
     
     def setUp(self):
         django.setup()
+        add_message_backend(AMQPMessagingBackend)
         
-    def test_json_create_new(self):
+    @patch('queue.models.CommandMessageManager')
+    def test_json_create_new(self, mock_msg_mgr):
         """Test converting a CreateRecipes message to and from JSON when creating new"""
         workspace = storage_test_utils.create_workspace()
         source_file = ScaleFile.objects.create(file_name='input_file', file_type='SOURCE',

--- a/scale/recipe/test/messages/test_create_recipes.py
+++ b/scale/recipe/test/messages/test_create_recipes.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import django
 from django.test import TestCase
 from django.utils.timezone import now
+from mock import patch
 
 from batch.test import utils as batch_test_utils
 from data.data.data import Data

--- a/scale/recipe/test/messages/test_create_recipes.py
+++ b/scale/recipe/test/messages/test_create_recipes.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import django
 from django.test import TestCase
+from django.utils.timezone import now
 
 from batch.test import utils as batch_test_utils
 from data.data.data import Data
@@ -9,25 +10,98 @@ from data.data.json.data_v6 import convert_data_to_v6_json
 from data.data.value import FileValue
 from data.interface.interface import Interface
 from data.interface.parameter import FileParameter
+from ingest.strike.configuration.json.configuration_v6 import StrikeConfigurationV6
+from ingest.models import IngestEvent, Strike
+import ingest.test.utils as ingest_test_utils
 from job.models import Job, JobType, JobTypeRevision
 from job.test import utils as job_test_utils
 from recipe.definition.definition import RecipeDefinition
 from recipe.definition.json.definition_v6 import convert_recipe_definition_to_v6_json
 from recipe.diff.forced_nodes import ForcedNodes
 from recipe.diff.json.forced_nodes_v6 import convert_forced_nodes_to_v6
-from recipe.messages.create_recipes import create_reprocess_messages, create_subrecipes_messages, CreateRecipes, \
+from recipe.messages.create_recipes import create_reprocess_messages, create_subrecipes_messages, create_recipes_messages, CreateRecipes, \
     SubRecipe
 from recipe.models import Recipe, RecipeNode, RecipeType, RecipeTypeRevision
 from recipe.test import utils as recipe_test_utils
+from storage.models import ScaleFile
 from storage.test import utils as storage_test_utils
+from trigger.models import TriggerEvent
 from trigger.test import utils as trigger_test_utils
 
 
 class TestCreateRecipes(TestCase):
-
+    fixtures = ['ingest_job_types.json']
+    
     def setUp(self):
         django.setup()
+        
+    def test_json_create_new(self):
+        """Test converting a CreateRecipes message to and from JSON when creating new"""
+        workspace = storage_test_utils.create_workspace()
+        source_file = ScaleFile.objects.create(file_name='input_file', file_type='SOURCE',
+                                               media_type='text/plain', file_size=10, data_type_tags=['type1'],
+                                                    file_path='the_path', workspace=workspace)
+        manifest = job_test_utils.create_seed_manifest(inputs_files=[{'name': 'INPUT_FILE', 'media_types': ['text/plain'], 'required': True, 'multiple': True}], inputs_json=[])
+        jt1 = job_test_utils.create_seed_job_type(manifest=manifest)
+        recipe_type_def = {'version': '6',
+                           'input': {'files': [{'name': 'INPUT_FILE',
+                                                'media_types': ['text/plain'],
+                                                'required': True,
+                                                'multiple': True}],
+                                    'json': []},
+                           'nodes': {'node_a': {'dependencies': [],
+                                                'input': {'INPUT_FILE': {'type': 'recipe', 'input': 'INPUT_FILE'}},
+                                                'node_type': {'node_type': 'job', 'job_type_name': jt1.name,
+                                                              'job_type_version': jt1.version,
+                                                              'job_type_revision': 1}}}}
 
+        recipe_type = recipe_test_utils.create_recipe_type_v6(name='test-recipe', definition=recipe_type_def)
+        
+        strike_config = {
+            'version': '6',
+            'workspace': workspace.name,
+            'monitor': {'type': 'dir-watcher', 'transfer_suffix': '_tmp'},
+            'files_to_ingest': [{
+                'filename_regex': 'input_file',
+                'data_types': ['image_type'],
+                'new_workspace': workspace.name,
+                'new_file_path': 'my/path'
+            }],
+            'recipe': {
+                'name': recipe_type.name
+            },
+        }
+        config = StrikeConfigurationV6(strike_config).get_configuration()
+        strike = Strike.objects.create_strike('my_name', 'my_title', 'my_description', config)
+        ingest = ingest_test_utils.create_ingest(source_file=source_file)
+        
+        recipe_data = Data()
+        input_name = recipe_type.get_definition().get_input_keys()[0]
+        recipe_data.add_value(FileValue(input_name, [source_file.id]))
+        recipe_data_dict = convert_data_to_v6_json(recipe_data).get_dict()
+        
+        event = TriggerEvent.objects.create_trigger_event('STRIKE_INGEST', None, 
+            {'version': '1.0', 'file_id': source_file.id, 'file_name': source_file.file_name}, now())
+        ingest_event = IngestEvent.objects.create_strike_ingest_event(ingest.id, strike, 
+            {'version': '1.0', 'file_id': source_file.id, 'file_name': source_file.file_name}, now())
+            
+        message = create_recipes_messages(recipe_type.name, recipe_type.revision_num, recipe_data_dict, event.id, ingest_event.id)[0]
+        message_json_dict = message.to_json()
+        new_message = CreateRecipes.from_json(message_json_dict)
+        result = new_message.execute()
+        self.assertTrue(result)
+        
+        # Verify the new message has a process recipe input message
+        self.assertTrue(len(new_message.new_recipes), 1)
+        self.assertEqual(len(new_message.new_messages), 1)
+        msg = new_message.new_messages[0]
+        self.assertEqual(msg.type, 'process_recipe_input')
+        self.assertEqual(msg.recipe_id, new_message.new_recipes[0])
+        
+        new_recipe = Recipe.objects.get(pk=new_message.new_recipes[0])
+        self.assertEqual(new_recipe.recipe_type, recipe_type)
+        self.assertDictEqual(new_recipe.input, recipe_data_dict)
+        
     def test_json_reprocess(self):
         """Tests converting a CreateRecipes message to and from JSON when re-processing"""
 

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -481,13 +481,8 @@ class RecipesView(ListAPIView):
                 raise BadParameter('%s: %s' % (message, unicode(ex)))
 
         try:
-            description = {'user': 'Anonymous'}
-            event = TriggerEvent.objects.create_trigger_event('USER', None, description, timezone.now())
-            messages = create_recipes_messages(recipe_type, recipe_type.revision_num, recipeData.get_data(),
-                                               event.id, None, configuration)
-            CommandMessageManager().send_messages(messages)
-            # recipe = Queue.objects.queue_new_recipe_for_user_v6(recipe_type, recipeData.get_data(),
-            #                                                     recipe_config=configuration)
+            recipe = Queue.objects.queue_new_recipe_for_user_v6(recipe_type, recipeData.get_data(),
+                                                                recipe_config=configuration)
         except (InvalidData, InvalidRecipeData) as err:
             return Response('Invalid recipe data: ' + unicode(err), status=status.HTTP_400_BAD_REQUEST)
         except InactiveRecipeType as err:

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -24,7 +24,7 @@ from recipe.definition.json.definition_v6 import RecipeDefinitionV6
 from recipe.diff.exceptions import InvalidDiff
 from recipe.diff.json.forced_nodes_v6 import ForcedNodesV6
 from recipe.exceptions import InactiveRecipeType
-from recipe.messages.create_recipes import create_reprocess_messages, create_recipes_messages
+from recipe.messages.create_recipes import create_reprocess_messages
 from recipe.models import Recipe, RecipeInputFile, RecipeType, RecipeTypeRevision
 from recipe.serializers import (RecipeDetailsSerializerV6,
                                 RecipeSerializerV6,

--- a/scale/scheduler/initialize.py
+++ b/scale/scheduler/initialize.py
@@ -34,4 +34,4 @@ def initialize_system():
         with transaction.atomic():
             init_event = TriggerEvent.objects.create_trigger_event('SCALE_INIT', None, {}, now())
             job = Queue.objects.queue_new_job_v6(clock_job_type, Data(), init_event)
-            CommandMessageManager().send_messages(create_process_job_input_messages([job.pk]))
+            CommandMessageManager().send_messages(create_process_job_input_messages([job.id]))

--- a/scale/scheduler/initialize.py
+++ b/scale/scheduler/initialize.py
@@ -8,7 +8,9 @@ from django.db import transaction
 from django.utils.timezone import now
 
 from data.data.data import Data
+from job.messages.process_job_input import create_process_job_input_messages
 from job.models import Job, JobType
+from messaging.manager import CommandMessageManager
 from queue.models import Queue
 from scheduler.models import Scheduler
 from trigger.models import TriggerEvent
@@ -31,4 +33,5 @@ def initialize_system():
         logger.info('Queuing Scale Clock job')
         with transaction.atomic():
             init_event = TriggerEvent.objects.create_trigger_event('SCALE_INIT', None, {}, now())
-            Queue.objects.queue_new_job_v6(clock_job_type, Data(), init_event)
+            job = Queue.objects.queue_new_job_v6(clock_job_type, Data(), init_event)
+            CommandMessageManager().send_messages(create_process_job_input_messages([job.pk]))

--- a/scale/scheduler/test/test_initialize.py
+++ b/scale/scheduler/test/test_initialize.py
@@ -20,7 +20,7 @@ class TestInitializeSystem(TransactionTestCase):
 
         add_message_backend(AMQPMessagingBackend)
 
-    @patch('queue.models.CommandMessageManager')
+    @patch('scheduler.initialize.CommandMessageManager')
     def test_create_clock_job(self, mock_msg_mgr):
         """Tests creating the Scale clock job"""
 

--- a/scale/util/database.py
+++ b/scale/util/database.py
@@ -17,7 +17,6 @@ def sleep(the_model, the_id):
         time.sleep(.01)
         tries += 1
         try:
-            
             the_result = the_model.objects.get(id=the_id)
             if the_result:
                 return True

--- a/scale/util/database.py
+++ b/scale/util/database.py
@@ -1,0 +1,28 @@
+"""Helper methods for os operations"""
+import time
+
+MAX_SLEEP_MS = 500
+
+def sleep(the_model, the_id):
+    """Sleeps for a maximum of 5 seconds while waiting for an object to become available
+    :param the_class: The model we're trying to find
+    :type the_model: Class
+    :param the_id: The id of the object we're trying to find
+    :type the_id: int
+    """
+    
+    # wait max of 5 seconds for events to save
+    tries = 0
+    while tries < MAX_SLEEP_MS:
+        time.sleep(.01)
+        tries += 1
+        try:
+            
+            the_result = the_model.objects.get(id=the_id)
+            if the_result:
+                return True
+        except the_model.DoesNotExist:
+            pass
+        
+    return False
+ 

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,7 +15,7 @@ then
     psql -d scale -U postgres -c "create extension postgis_topology;"
 
     export COVERAGE_FILE=$root/.coverage
-    coverage run --source='.' manage.py test -v 2
+    coverage run --source='.' manage.py test
 fi
 
 if [ "${BUILD_DOCS}" == "true" ]

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,7 +15,7 @@ then
     psql -d scale -U postgres -c "create extension postgis_topology;"
 
     export COVERAGE_FILE=$root/.coverage
-    coverage run --source='.' manage.py test
+    coverage run --source='.' manage.py test -v 2
 fi
 
 if [ "${BUILD_DOCS}" == "true" ]


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
ingest
recipe
queue

### Description of change
<!-- Please provide a description of the change here. -->
#1656 
Recipes were not being kicked off from ingested files consistently (I'd see maybe one being queued, the rest of the time there would be recipe/job id not found exceptions cluttering up the logs). Added two command messages to handle creating ingest jobs and creating new recipes:
create_ingest that will handle creating the ingest job
create_new_recipe that handles actually creating the new recipe and processing recipe input. We already had a message for creating sub recipes and reprocessing recipes, but creating new ones hadn't been done yet.