### PR TITLE
#1631 - Fixes for Silo deploy

### DIFF
--- a/dockerfiles/framework/scale/app-templates/silo.json
+++ b/dockerfiles/framework/scale/app-templates/silo.json
@@ -6,7 +6,7 @@
     "instances": 1,
     "container": {
         "docker": {
-            "image": "geoint/seed-silo:0.7.0",
+            "image": "geoint/seed-silo:0.8.0",
             "network": "BRIDGE",
             "portMappings": [
                 {

--- a/dockerfiles/framework/scale/app-templates/silo.json
+++ b/dockerfiles/framework/scale/app-templates/silo.json
@@ -6,7 +6,7 @@
     "instances": 1,
     "container": {
         "docker": {
-            "image": "geoint/seed-silo:0.6.0",
+            "image": "geoint/seed-silo:0.7.0",
             "network": "BRIDGE",
             "portMappings": [
                 {

--- a/dockerfiles/framework/scale/app-templates/ui.json
+++ b/dockerfiles/framework/scale/app-templates/ui.json
@@ -21,10 +21,7 @@
     "env": {
         "API_BACKEND": "http://scale-webserver.marathon.l4lb.thisdcos.directory:80/",
         "SILO_BACKEND": "http://scale-silo.marathon.l4lb.thisdcos.directory:9000/",
-        "CONTEXTS": "/service/scale",
-        "DCOS_PACKAGE_FRAMEWORK_NAME": "scale",
-        "SILO_URL": "/silo"
-
+        "CONTEXTS": "/service/scale"
     },
     "labels": {
         "HAPROXY_GROUP": "internal,external",

--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -327,13 +327,13 @@ def deploy_silo(client, app_name, db_url):
                                            os.getenv('SILO_DOCKER_IMAGE'))
 
         env_map = {
-            'SILO_ADMIN_PASSWORD': 'ADMIN_PASSWORD'
+            'ADMIN_PASSWORD': 'SILO_ADMIN_PASSWORD'
         }
 
         apply_set_envs(marathon, env_map)
 
         arbitrary_env = {
-            'DATABASE_URL': db_url
+            'DATABASE_URL': db_url.replace('postgis', 'postgres') + '?sslmode=disable'
         }
         # For all environment variable that are set add to marathon json.
         for env in arbitrary_env:

--- a/scale/README.md
+++ b/scale/README.md
@@ -261,8 +261,9 @@ below for reference.
 | SECRETS_TOKEN               | None                            | Authentication token for secrets service   |
 | SECRETS_URL                 | None                            | API endpoint for a secrets service         |
 | SESSION_COOKIE_SECURE       | True                            | Should cookies be served only over HTTPS   |
-| SILO_ADDRESS                | None                            | Address to Silo, deployed if None          |
 | SILO_DOCKER_IMAGE           | 'geoint/seed-scale:0.6.0'       | Silo docker image name                     |
+| SILO_HUB_ORG                | 'geointseed'                    | Docker Hub public org to scan              |
+| SILO_URL                    | None                            | Address to Silo, deployed if None          |
 | SYSTEM_LOGGING_LEVEL        | None                            | System wide logging level. INFO-CRITICAL   |
 | UI_DOCKER_IMAGE             | 'geoint/scale-ui'               | Docker image for Scale UI                  |
 

--- a/scale/README.md
+++ b/scale/README.md
@@ -237,7 +237,7 @@ below for reference.
 | DCOS_PACKAGE_FRAMEWORK_NAME | None                            | Unique name for Scale cluster framework    |
 | DEPLOY_WEBSERVER            | 'true'                          | Should UI and API be installed?            |
 | DJANGO_DEBUG                | ''                              | Change to '1' to enable debugging in DJANGO|
-| ELASTICSEARCH_DOCKER_IMAGE  | 'elasticsearch:2.4-alpine'      | Docker image for Elasticsearch             |
+| ELASTICSEARCH_DOCKER_IMAGE  | 'elasticsearch:5-alpine'        | Docker image for Elasticsearch             |
 | ELASTICSEARCH_URL           | None                            | Elasticsearch backend URL for log storage  |
 | ENABLE_BOOTSTRAP            | 'true'                          | Bootstrap Scale support containers         |
 | ENABLE_WEBSERVER            | 'true' or None                  | Used by bootstrap to enable UI and API     |
@@ -261,7 +261,7 @@ below for reference.
 | SECRETS_TOKEN               | None                            | Authentication token for secrets service   |
 | SECRETS_URL                 | None                            | API endpoint for a secrets service         |
 | SESSION_COOKIE_SECURE       | True                            | Should cookies be served only over HTTPS   |
-| SILO_DOCKER_IMAGE           | 'geoint/seed-scale:0.6.0'       | Silo docker image name                     |
+| SILO_DOCKER_IMAGE           | 'geoint/seed-silo:0.8.0'        | Silo docker image name                     |
 | SILO_HUB_ORG                | 'geointseed'                    | Docker Hub public org to scan              |
 | SILO_URL                    | None                            | Address to Silo, deployed if None          |
 | SYSTEM_LOGGING_LEVEL        | None                            | System wide logging level. INFO-CRITICAL   |


### PR DESCRIPTION
##### Checklist
- [x] `manage.py test` passes
- [x] documentation is changed or added

### Description of change
Resolution of the Silo deployment not including a default collection of images. I updated the deploy to include a newer build of Silo as a default, so that the Silo schema could co-exist in the Scale postgres database. 

The following deployment environment variables have been changed:

* `ELASTICSEARCH_DOCKER_IMAGE`: Updated to properly match the value in bootstrap of `elasticsearch:5-alpine`
* `SILO_DOCKER_IMAGE`: Updated to new Silo release supporting proper PG data storage. `geoint/seed-silo:0.8.0` 
* `SILO_HUB_ORG`: If `SILO_URL` is unset, will be used to initialize Silo against a _public_ only Docker Hub organization.
* `SILO_URL`: Renamed from `SILO_ADDRESS`. If left empty, Silo will be deployed. Should be set in production.