### PR TITLE
Partial fix for sending correct headers from HAProxy through to Django

### DIFF
--- a/dockerfiles/framework/scale/app-templates/ui.json
+++ b/dockerfiles/framework/scale/app-templates/ui.json
@@ -33,8 +33,8 @@
         "DCOS_SERVICE_PORT_INDEX": "0",
         "DCOS_SERVICE_REWRITE_REQUEST_URLS": "false",
         "HAPROXY_0_VHOST": "scale.marathon.mesos",
-        "HAPROXY_0_BACKEND_HTTP_OPTIONS": "rspadd Access-Control-Allow-Methods:\\ GET,\\ POST,\\ PUT,\\ PATCH,\\ OPTIONS,\\ DELETE\nrspadd Access-Control-Allow-Headers:\\ Origin,\\ X-Requested-With,\\ Content-Type,\\ Accept,\\ Authorization\n",
-        "HAPROXY_0_BACKEND_REDIRECT_HTTP_TO_HTTPS": "true"
+        "HAPROXY_0_BACKEND_HTTP_OPTIONS": "http-request add-header X-Forwarded-Proto https if { ssl_fc }\nhttp-request set-header X-HAPROXY 1\nrspadd Access-Control-Allow-Methods:\\ GET,\\ POST,\\ PUT,\\ PATCH,\\ OPTIONS,\\ DELETE\nrspadd Access-Control-Allow-Headers:\\ Origin,\\ X-Requested-With,\\ Content-Type,\\ Accept,\\ Authorization\n",
+        "HAPROXY_0_REDIRECT_TO_HTTPS": "true"
     },
   "healthChecks": [
     {

--- a/dockerfiles/framework/scale/app-templates/webserver.json
+++ b/dockerfiles/framework/scale/app-templates/webserver.json
@@ -34,8 +34,8 @@
     "labels": {
         "HAPROXY_GROUP": "internal,external",
         "HAPROXY_0_VHOST": "api-scale.marathon.mesos",
-        "HAPROXY_0_BACKEND_HTTP_OPTIONS": "http-request set-header X-HAPROXY 1\nrspadd Access-Control-Allow-Methods:\\ GET,\\ POST,\\ PUT,\\ PATCH,\\ OPTIONS,\\ DELETE\nrspadd Access-Control-Allow-Headers:\\ Origin,\\ X-Requested-With,\\ Content-Type,\\ Accept,\\ Authorization\n",
-        "HAPROXY_0_BACKEND_REDIRECT_HTTP_TO_HTTPS": "true"
+        "HAPROXY_0_BACKEND_HTTP_OPTIONS": "http-request add-header X-Forwarded-Proto https if { ssl_fc }\nhttp-request set-header X-HAPROXY 1\nrspadd Access-Control-Allow-Methods:\\ GET,\\ POST,\\ PUT,\\ PATCH,\\ OPTIONS,\\ DELETE\nrspadd Access-Control-Allow-Headers:\\ Origin,\\ X-Requested-With,\\ Content-Type,\\ Accept,\\ Authorization\n",
+        "HAPROXY_0_REDIRECT_TO_HTTPS": "true"
     },
     "healthChecks": [
         {

--- a/scale/scale/local_settings_docker.py
+++ b/scale/scale/local_settings_docker.py
@@ -14,6 +14,7 @@ TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
 # Set the external URL context here, default to using SCRIPT_NAME passed by reverse proxy.
 FORCE_SCRIPT_NAME = os.environ.get('SCALE_API_URL', None)
 USE_X_FORWARDED_HOST = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Ensure backend uses HTTPS for auth callbacks
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = True


### PR DESCRIPTION
Fixes #1654, but an additional commit is required in ngageoint/scale-ui.

<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


### Description of change
<!-- Please provide a description of the change here. -->
HAProxy settings are changed to conditionally send `X-Forwarded-Proto = https` if the client protocol is in fact `https`. At least with the version of DC/OS used off-site, it appears that using `HAPROXY_0_BACKEND_HTTP_OPTIONS` in combination with `HAPROXY_0_BACKEND_REDIRECT_HTTP_TO_HTTPS` may make the former option take precedence. `HAPROXY_0_REDIRECT_TO_HTTPS` seems to allow for the desired effect.

Django also has to be configured to allow this header to be recognized, via `SECURE_PROXY_SSL_HEADER`, which will let it build URIs correctly. This is still needed even if the https redirect is not wanted, since it will conditionally build the URIs according to the scheme passed down through the proxies.

The same HAProxy settings will need to be changed in scale-ui, along with a configuration change to prevent Nginx from trying to add the `X-Forwarded-Proto` header itself.



