### PR TITLE
#1589 - Resolve fluentd deployment issue

### DIFF
--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -407,7 +407,7 @@ def deploy_fluentd(client, app_name, es_url):
     localhost:5000/geoint/scale
     geoint/scale:5.9.2
 
-    The most problematic is the 2nd case as we previously we improperly identifying
+    The most problematic is the 2nd case as we previously were improperly identifying
     the port colon as the tag colon.
     """
 
@@ -431,7 +431,7 @@ def deploy_fluentd(client, app_name, es_url):
         'FLUENTD_TEMPLATE_URI': 'TEMPLATE_URI'
     }
     apply_set_envs(marathon, env_map)
-    deploy_marathon_app(client, marathon)
+    deploy_marathon_app(client, marathon, retries=10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!-- Please provide a description of the change here. -->
Updates the deployment to always attempt updates in place, instead of the present approach of force delete followed by redeploy. This eliminates the issue with fluentd being deleted and then note able to deploy due to extended removal time / locked deployment.

This change impacts all services, but is most visible with `scale-fluentd`, `scale-ui` and `scale-webserver` services.