### PR TITLE
#1645 - v6 batches don't override priority

### DIFF
--- a/scale/batch/test/test_views.py
+++ b/scale/batch/test/test_views.py
@@ -11,13 +11,11 @@ from rest_framework import status
 import job.test.utils as job_test_utils
 import recipe.test.utils as recipe_test_utils
 import batch.test.utils as batch_test_utils
-import storage.test.utils as storage_test_utils
 from batch.configuration.configuration import BatchConfiguration
 from batch.definition.definition import BatchDefinition
 from batch.messages.create_batch_recipes import CreateBatchRecipes
 from batch.models import Batch, BatchMetrics
 from queue.models import Queue
-from recipe.diff.forced_nodes import ForcedNodes
 from recipe.models import RecipeType
 from rest_framework.test import APITestCase, APITransactionTestCase
 from util import rest
@@ -59,6 +57,7 @@ class TestBatchesViewV6(APITransactionTestCase):
 
         self.recipe_type_3 = recipe_test_utils.create_recipe_type_v6(definition=self.sub_definition)
         self.batch_3 = batch_test_utils.create_batch(recipe_type=self.recipe_type_3, is_creation_done=True)
+        recipe_test_utils.create_recipe(recipe_type=self.recipe_type_3, batch=self.batch_3)
 
     def test_invalid_version(self):
         """Tests calling the batches view with an invalid REST API version"""
@@ -285,7 +284,7 @@ class TestBatchesViewV6(APITransactionTestCase):
         # Check correct recipe estimation count
         self.assertEqual(result['recipes_estimated'], 1)
 
-        queues = Queue.objects.filter(batch_id=self.batch_3.id)
+        queues = Queue.objects.filter(batch_id=new_batch_id)
         self.assertEqual(len(queues), 1)
         for q in queues:
             self.assertEqual(q.priority, 101)

--- a/scale/batch/test/test_views.py
+++ b/scale/batch/test/test_views.py
@@ -16,6 +16,7 @@ from batch.configuration.configuration import BatchConfiguration
 from batch.definition.definition import BatchDefinition
 from batch.messages.create_batch_recipes import CreateBatchRecipes
 from batch.models import Batch, BatchMetrics
+from queue.models import Queue
 from recipe.diff.forced_nodes import ForcedNodes
 from recipe.models import RecipeType
 from rest_framework.test import APITestCase, APITransactionTestCase
@@ -267,7 +268,7 @@ class TestBatchesViewV6(APITransactionTestCase):
                 }
             },
             'configuration': {
-                'priority': 100
+                'priority': 101
             }
         }
 
@@ -283,6 +284,11 @@ class TestBatchesViewV6(APITransactionTestCase):
         self.assertEqual(result['root_batch']['id'], self.batch_3.root_batch_id)
         # Check correct recipe estimation count
         self.assertEqual(result['recipes_estimated'], 1)
+
+        queues = Queue.objects.filter(batch_id=self.batch_3.id)
+        self.assertEqual(len(queues), 1)
+        for q in queues:
+            self.assertEqual(q.priority, 101)
 
 class TestBatchDetailsViewV6(APITestCase):
 

--- a/scale/batch/test/test_views.py
+++ b/scale/batch/test/test_views.py
@@ -56,7 +56,7 @@ class TestBatchesViewV6(APITransactionTestCase):
         self.sub_definition['nodes']['node_a']['node_type']['job_type_version'] = self.job_type1.version
         self.sub_definition['nodes']['node_a']['node_type']['job_type_revision'] = self.job_type1.revision_num
 
-        self.recipe_type3 = recipe_test_utils.create_recipe_type_v6(definition=self.sub_definition)
+        self.recipe_type_3 = recipe_test_utils.create_recipe_type_v6(definition=self.sub_definition)
         self.batch_3 = batch_test_utils.create_batch(recipe_type=self.recipe_type_3, is_creation_done=True)
 
     def test_invalid_version(self):
@@ -74,7 +74,7 @@ class TestBatchesViewV6(APITransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         result = json.loads(response.content)
-        self.assertEqual(len(result['results']), 4)
+        self.assertEqual(len(result['results']), 6)
 
     def test_recipe_type_id(self):
         """Tests successfully calling the batches view filtered by recipe type identifier"""
@@ -129,11 +129,13 @@ class TestBatchesViewV6(APITransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         result = json.loads(response.content)
-        self.assertEqual(len(result['results']), 4)
-        self.assertEqual(result['results'][0]['id'], self.batch_2.id)
-        self.assertEqual(result['results'][1]['id'], self.batch_2.superseded_batch_id)
-        self.assertEqual(result['results'][2]['id'], self.batch_1.id)
-        self.assertEqual(result['results'][3]['id'], self.batch_1.superseded_batch_id)
+        self.assertEqual(len(result['results']), 6)
+        self.assertEqual(result['results'][0]['id'], self.batch_3.id)
+        self.assertEqual(result['results'][1]['id'], self.batch_3.superseded_batch_id)
+        self.assertEqual(result['results'][2]['id'], self.batch_2.id)
+        self.assertEqual(result['results'][3]['id'], self.batch_2.superseded_batch_id)
+        self.assertEqual(result['results'][4]['id'], self.batch_1.id)
+        self.assertEqual(result['results'][5]['id'], self.batch_1.superseded_batch_id)
 
     def test_create_invalid_version(self):
         """Tests creating a new batch with an invalid REST API version"""

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -1929,6 +1929,39 @@ class TestJobTypesValidationViewV6(APITransactionTestCase):
         self.assertEqual(len(results['warnings']), 1)
         self.assertEqual(results['warnings'][0]['name'], 'NONSTANDARD_RESOURCE')
 
+    def test_empty_media(self):
+        """Tests validating a new job type with media types not specified"""
+        manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
+        manifest['job']['interface']['inputs']['files'][0]['mediaTypes'] = []
+        config = copy.deepcopy(self.configuration)
+        json_data = {
+            'manifest': manifest,
+            'configuration': config
+        }
+
+        url = '/%s/job-types/validation/' % self.api
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        self.assertTrue(results['is_valid'])
+        self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': []})
+        manifest = copy.deepcopy(job_test_utils.COMPLETE_MANIFEST)
+        del manifest['job']['interface']['inputs']['files'][0]['mediaTypes']
+        config = copy.deepcopy(self.configuration)
+        json_data = {
+            'manifest': manifest,
+            'configuration': config
+        }
+
+        url = '/%s/job-types/validation/' % self.api
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        self.assertTrue(results['is_valid'])
+        self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': []})
+        
 class TestJobTypesPendingView(APITestCase):
 
     api = 'v6'


### PR DESCRIPTION
##### Checklist

- [x] `manage.py test` passes
- [x] tests are included

### Affected app(s)
- batch
- job

### Description of change
Some tests I wrote when trying to reproduce #1645. This will ensure we don't break this in the future.
