### PR TITLE
#1688 - Recipe Type Validation Returning Invalid for Warning

### DIFF
--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -1385,7 +1385,6 @@ class RecipeTypeManager(models.Manager):
                 if not diff.can_be_reprocessed:
                     msg = 'This recipe cannot be reprocessed after updating.'
                     warnings.append(ValidationWarning('REPROCESS_WARNING',msg))
-                    is_valid = False
                 json = convert_recipe_diff_to_v6_json(diff)
                 diff = rest_utils.strip_schema_version(json.get_dict())
 

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -773,7 +773,7 @@ class TestRecipeTypesValidationViewV6(APITransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         results = json.loads(response.content)
-        self.assertFalse(results['is_valid'])
+        self.assertTrue(results['is_valid'])
         diff = {u'can_be_reprocessed': False,
                 u'reasons': [{u'name': u'INPUT_CHANGE', u'description': u"Input interface has changed: Parameter 'INPUT_IMAGE' is required"}],
                 u'nodes': { u'node_a': { u'status': u'CHANGED', u'reprocess_new_node': False, u'force_reprocess': False, u'dependencies': [],
@@ -786,7 +786,7 @@ class TestRecipeTypesValidationViewV6(APITransactionTestCase):
 
         warnings = [{u'name': u'REPROCESS_WARNING', u'description': u"This recipe cannot be reprocessed after updating."}]
         self.maxDiff = None
-        self.assertDictEqual(results, {u'errors': [], u'is_valid': False, u'warnings': warnings, u'diff': diff})
+        self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': warnings, u'diff': diff})
 
     def test_recipe_not_found_warning(self):
         """Tests validating a recipe definition against a recipe-type that doesn't exist"""


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included
- [ ] migrations are included
- [ ] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
Recipe
### Description of change
<!-- Please provide a description of the change here. -->
Updated the create recipe process so that if a warning is detected about not being able to reprocess the recipe it will still be considered valid.  