### PR TITLE
#1701 - Validation responses with errors return as a 400

### DIFF
--- a/scale/batch/test/test_views.py
+++ b/scale/batch/test/test_views.py
@@ -724,7 +724,7 @@ class TestBatchesValidationViewV6(APITransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         results = json.loads(response.content)
-        self.assertEqual(results['errors'][0]['name'], u'INVALID_BATCH_CONFIGURATION')
+        self.assertEqual(results['errors'][0]['name'], u'INVALID_BATCH_DEFINITION')
         self.assertEqual(results['is_valid'], False)
 
     def test_create_invalid_configuration(self):

--- a/scale/batch/test/test_views.py
+++ b/scale/batch/test/test_views.py
@@ -721,7 +721,11 @@ class TestBatchesValidationViewV6(APITransactionTestCase):
 
         url = '/v6/batches/validation/'
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        self.assertEqual(results['errors'][0]['name'], u'INVALID_BATCH_CONFIGURATION')
+        self.assertEqual(results['is_valid'], False)
 
     def test_create_invalid_configuration(self):
         """Tests creating a new batch with an invalid configuration"""
@@ -741,7 +745,11 @@ class TestBatchesValidationViewV6(APITransactionTestCase):
 
         url = '/v6/batches/validation/'
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        self.assertEqual(results['errors'][0]['name'], u'INVALID_BATCH_CONFIGURATION')
+        self.assertEqual(results['is_valid'], False)
 
     def test_create_invalid_prev_batch(self):
         """Tests creating a new batch with an invalid previous batch"""

--- a/scale/batch/views.py
+++ b/scale/batch/views.py
@@ -327,9 +327,9 @@ class BatchesValidationView(APIView):
             definition = BatchDefinitionV6(definition=definition_dict, do_validate=True).get_definition()
             configuration = BatchConfigurationV6(configuration=configuration_dict, do_validate=True).get_configuration()
         except InvalidDefinition as ex:
-            errors.append(ex.error)
+            errors.append(ex.error.to_dict())
         except InvalidConfiguration as ex:
-            errors.append(ex.error)
+            errors.append(ex.error.to_dict())
         
         if errors:
             return Response(resp_dict)

--- a/scale/batch/views.py
+++ b/scale/batch/views.py
@@ -311,6 +311,11 @@ class BatchesValidationView(APIView):
         recipe_type_id = rest_util.parse_int(request, 'recipe_type_id')
         definition_dict = rest_util.parse_dict(request, 'definition')
         configuration_dict = rest_util.parse_dict(request, 'configuration', required=False)
+        
+        errors = []
+        resp_dict = {'is_valid': False, 'errors': errors,
+                     'warnings': [],
+                     'recipes_estimated': None, 'recipe_type': None}
 
         # Make sure the recipe type exists
         try:
@@ -322,9 +327,12 @@ class BatchesValidationView(APIView):
             definition = BatchDefinitionV6(definition=definition_dict, do_validate=True).get_definition()
             configuration = BatchConfigurationV6(configuration=configuration_dict, do_validate=True).get_configuration()
         except InvalidDefinition as ex:
-            raise BadParameter(unicode(ex))
+            errors.append(ex.error)
         except InvalidConfiguration as ex:
-            raise BadParameter(unicode(ex))
+            errors.append(ex.error)
+        
+        if errors:
+            return Response(resp_dict)
 
         # Validate the batch
         validation = Batch.objects.validate_batch_v6(recipe_type, definition, configuration=configuration)

--- a/scale/ingest/test/test_views.py
+++ b/scale/ingest/test/test_views.py
@@ -751,7 +751,11 @@ class TestScansValidationViewV6(APITestCase):
         url = '/%s/scans/validation/' % self.api
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        self.assertDictEqual(results, {u'errors': [{u'description': u'Unknown workspace name: BAD',
+                                                    u'name': u'INVALID_SCAN_CONFIGURATION'}], u'is_valid': False, u'warnings': []})
 
 class TestScansProcessViewV6(APITestCase):
     fixtures = ['ingest_job_types.json']
@@ -1412,4 +1416,8 @@ class TestStrikesValidationViewV6(APITestCase):
         url = '/%s/strikes/validation/' % self.version
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        self.assertEqual(results['errors'][0]['name'], u'INVALID_STRIKE_CONFIGURATION')
+        self.assertEqual(results['is_valid'], False)

--- a/scale/ingest/views.py
+++ b/scale/ingest/views.py
@@ -467,8 +467,6 @@ class ScansValidationView(APIView):
         resp_dict = {'is_valid': validation.is_valid, 'errors': [e.to_dict() for e in validation.errors],
                      'warnings': [w.to_dict() for w in validation.warnings]}
 
-        if not resp_dict['is_valid']:
-            return Response(resp_dict, status=status.HTTP_400_BAD_REQUEST)
         return Response(resp_dict)
 
 
@@ -711,6 +709,4 @@ class StrikesValidationView(APIView):
         resp_dict = {'is_valid': validation.is_valid, 'errors': [e.to_dict() for e in validation.errors],
                      'warnings': [w.to_dict() for w in validation.warnings]}
 
-        if not resp_dict['is_valid']:
-            return Response(resp_dict, status=status.HTTP_400_BAD_REQUEST)
         return Response(resp_dict)

--- a/scale/storage/test/test_views.py
+++ b/scale/storage/test/test_views.py
@@ -628,7 +628,11 @@ class TestWorkspacesValidationViewV6(APITestCase):
         url = '/%s/workspaces/validation/' % self.api
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        self.assertEqual(results['errors'][0]['name'], u'INVALID_CONFIGURATION')
+        self.assertEqual(results['is_valid'], False)
 
     def test_warnings(self):
         """Tests validating a new workspace where the broker type is changed."""

--- a/scale/storage/views.py
+++ b/scale/storage/views.py
@@ -453,6 +453,4 @@ class WorkspacesValidationView(APIView):
         resp_dict = {'is_valid': validation.is_valid, 'errors': [e.to_dict() for e in validation.errors],
                      'warnings': [w.to_dict() for w in validation.warnings]}
 
-        if not resp_dict['is_valid']:
-            return Response(resp_dict, status=status.HTTP_400_BAD_REQUEST)
         return Response(resp_dict)


### PR DESCRIPTION
##### Checklist

- [x] `manage.py test` passes
- [x] tests are included

### Affected app(s)
- batch
- ingest
- storage

### Description of change
Changing validation endpoints to return 200 OK response with errors listed in response.
