### PR TITLE
#1720 - sharedMem not supported

### DIFF
--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1130,14 +1130,14 @@ class Job(models.Model):
                 value_required = max(initial_value, MIN_RESOURCE.get(resource['name'], 0.0))
                 scalar_resources.append(ScalarResource(resource['name'], value_required))
 
-            if scalar_resources:
-                resources.increase_up_to(NodeResources(scalar_resources))
+        if scalar_resources:
+            resources.increase_up_to(NodeResources(scalar_resources))
 
-            # We have to ensure shared memory is not a required NodeResource, otherwise scheduling cannot occur
-            resources.remove_resource('sharedmem')
+        # We have to ensure shared memory is not a required NodeResource, otherwise scheduling cannot occur
+        resources.remove_resource('sharedmem')
 
-            # If no inputMultiplier for Disk we need to at least ensure it exceeds input_file_size
-            resources.increase_up_to(NodeResources([Disk(input_file_size)]))
+        # If no inputMultiplier for Disk we need to at least ensure it exceeds input_file_size
+        resources.increase_up_to(NodeResources([Disk(input_file_size)]))
 
         return resources
 
@@ -2749,12 +2749,12 @@ class JobType(models.Model):
             # Ensure resource meets minimums set
             seed_resources[name] = max(x['value'], MIN_RESOURCE.get(name, 0.0))
 
-            # Ensure all standard resource minimums are satisfied
-            for resource in MIN_RESOURCE:
-                if resource not in seed_resources:
-                    seed_resources[resource] = MIN_RESOURCE[resource]
+        # Ensure all standard resource minimums are satisfied
+        for resource in MIN_RESOURCE:
+            if resource not in seed_resources:
+                seed_resources[resource] = MIN_RESOURCE[resource]
 
-            resources = Resources({'resources': seed_resources}).get_node_resources()
+        resources = Resources({'resources': seed_resources}).get_node_resources()
 
         return resources
 

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -38,6 +38,7 @@ from messaging.manager import CommandMessageManager
 from node.resources.json.resources import Resources
 from node.resources.node_resources import NodeResources
 from node.resources.resource import Cpus, Disk, Mem, ScalarResource
+from scheduler.sync.job_type_manager import job_type_mgr
 from storage.models import ScaleFile
 from util import rest as rest_utils
 from util.validation import ValidationWarning
@@ -2092,6 +2093,7 @@ class JobTypeManager(models.Manager):
             job_type.max_scheduled = max_scheduled
 
         job_type.save()
+        job_type_mgr.sync_with_database()
 
         # Save any secrets to Vault
         if secrets:

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -38,7 +38,6 @@ from messaging.manager import CommandMessageManager
 from node.resources.json.resources import Resources
 from node.resources.node_resources import NodeResources
 from node.resources.resource import Cpus, Disk, Mem, ScalarResource
-from scheduler.sync.job_type_manager import job_type_mgr
 from storage.models import ScaleFile
 from util import rest as rest_utils
 from util.validation import ValidationWarning
@@ -2093,6 +2092,7 @@ class JobTypeManager(models.Manager):
             job_type.max_scheduled = max_scheduled
 
         job_type.save()
+        from scheduler.sync.job_type_manager import job_type_mgr
         job_type_mgr.sync_with_database()
 
         # Save any secrets to Vault

--- a/scale/job/seed/manifest.py
+++ b/scale/job/seed/manifest.py
@@ -337,7 +337,10 @@ class SeedManifest(object):
         :rtype: list
         """
 
-        return self.get_job().get('resources', {'scalar': []})['scalar']
+        resources = self.get_job().get('resources', {'scalar': []})['scalar']
+        for r in resources:
+            r['name'] = r['name'].lower()
+        return resources
 
     def get_mounts(self):
         """Gets the mounts defined the Seed job

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -574,6 +574,9 @@ class TestJobDetailsViewV6(APITestCase):
         self.job_type = job_test_utils.create_seed_job_type()
         self.job = job_test_utils.create_job(job_type=self.job_type, input=job_data, output=job_results, status='RUNNING')
 
+        self.job_type2 = job_test_utils.create_seed_job_type(manifest=job_test_utils.COMPLETE_MANIFEST)
+        self.job2 = job_test_utils.create_job(job_type=self.job_type2)
+
         # Attempt to stage related models
         self.job_exe = job_test_utils.create_job_exe(job=self.job)
 
@@ -654,6 +657,16 @@ class TestJobDetailsViewV6(APITestCase):
         self.assertEqual(result['resources']['resources']['cpus'], 1.0)
         self.assertEqual(result['resources']['resources']['mem'], 128.0)
         self.assertEqual(result['resources']['resources']['disk'], 10.0)
+
+        url = '/%s/jobs/%i/' % (self.api, self.job2.id)
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+
+        self.assertEqual(result['resources']['resources']['cpus'], 1.0)
+        self.assertEqual(result['resources']['resources']['mem'], 1024.0)
+        self.assertEqual(result['resources']['resources']['disk'], 1040.0)
 
     def test_superseded(self):
         """Tests successfully calling the job details view for superseded jobs."""

--- a/scale/scheduler/scheduling/manager.py
+++ b/scale/scheduler/scheduling/manager.py
@@ -363,6 +363,9 @@ class SchedulingManager(object):
             insufficient_resources = []
             # get resource names offered and compare to job type resources
             for resource in job_exe.required_resources.resources:
+                # skip sharedmem
+                if resource.name.lower() == 'sharedmem':
+                    continue
                 if resource.name not in max_cluster_resources._resources:
                     # resource does not exist in cluster
                     invalid_resources.append(resource.name)


### PR DESCRIPTION
##### Checklist

- [x] `manage.py test` passes
- [x] tests are included

### Affected app(s)
- job
- scheduler

### Description of change
Fixed some code that was inside of loops that shouldn't be.
Since resource names are converted to lowercase everywhere they are used, the names are now changed when retrieved from the manifest for consistency.
The lists of job types and their resources in the manager is now synced with the database when a job type is edited so we don't get stuck in a loop where unmet_resources is cleared and then reset to the old value by the scheduler.
'sharedmem' is ignored by the code checking for unmet resources.
