### PR TITLE
#1721 Job Type POST/PATCH Endpoint Consistency

### DIFF
--- a/scale/docs/rest/v6/job_type.rst
+++ b/scale/docs/rest/v6/job_type.rst
@@ -778,6 +778,11 @@ Location http://.../v6/job-types/test/1.0.0/
 +-------------------------+-------------------+----------+----------------------------------------------------------------+
 | auto_update             | Boolean           | Optional | Whether to automatically update recipes containing this type.  |
 +-------------------------+-------------------+----------+----------------------------------------------------------------+
+| is_active               | Boolean           | Optional | Whether this job type is active or deprecated.                 |
++-------------------------+-------------------+----------+----------------------------------------------------------------+
+| is_paused               | Boolean           | Optional | Whether the job type is paused (while paused no jobs of this   |
+|                         |                   |          | type will be scheduled off of the queue).                      |
++-------------------------+-------------------+----------+----------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **Status**         | 201 CREATED                                                                                        |
@@ -1036,6 +1041,11 @@ Response: 204 No Content
 +-------------------------+-------------------+----------+----------------------------------------------------------------+
 | max_scheduled           | Integer           | Optional | Indicates the maximum number of jobs of this type that may be  |
 |                         |                   |          | scheduled to run at the same time.                             |
++-------------------------+-------------------+----------+----------------------------------------------------------------+
+| docker_image            | String            | Optional | The Docker image containing the code to run for this job.      |
++-------------------------+-------------------+----------+----------------------------------------------------------------+
+| manifest                | String            | Optional | Seed manifest describing Job, interface and requirements.      |
+|                         |                   |          | (See :ref:`architecture_seed_manifest_spec`)                   |
 +-------------------------+-------------------+----------+----------------------------------------------------------------+
 | configuration           | JSON Object       | Optional | JSON description of the configuration for running the job      |
 |                         |                   |          | (See :ref:`rest_v6_job_type_configuration`)                    |

--- a/scale/docs/rest/v6/job_type.yml
+++ b/scale/docs/rest/v6/job_type.yml
@@ -735,6 +735,11 @@ components:
           example: 1
         configuration:
           $ref: '#/components/schemas/job_type_config'
+        docker_image:
+          type: string
+          example: "my-job-1.0.0-seed:1.0.0"
+        manifest:
+          $ref: '../../../job/seed/schema/seed.manifest.schema.json'
       
     job_type_post:
       title: Job Type Create/Edit
@@ -744,6 +749,12 @@ components:
           type: string
           example: f186 
         is_published:
+          type: boolean
+          example: true
+        is_active:
+          type: boolean
+          example: true
+        is_paused:
           type: boolean
           example: true
         max_scheduled:

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -2075,7 +2075,7 @@ class JobTypeManager(models.Manager):
             job_type.docker_image = docker_image
         if icon_code:
             job_type.icon_code = icon_code
-        if is_active and job_type.is_active != is_active:
+        if is_active is not None and job_type.is_active != is_active:
             job_type.deprecated = None if is_active else timezone.now()
             job_type.is_active = is_active
             if auto_update:
@@ -2083,7 +2083,7 @@ class JobTypeManager(models.Manager):
                 msgs = [create_activate_recipe_message(id, is_active) for id in recipe_ids]
                 CommandMessageManager().send_messages(msgs)
                 
-        if is_paused and job_type.is_paused != is_paused:
+        if is_paused is not None and job_type.is_paused != is_paused:
             job_type.paused = timezone.now() if is_paused else None
             job_type.is_paused = is_paused
         if is_published:


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
job

### Description of change
<!-- Please provide a description of the change here. -->
#1721 
Updated the job-type POST and job-type/name/version PATCH endpoints to update the same fields when editing an existing job type. Added the `is_paused` and `is_active` fields to the job-type/ POST, and `docker_image` and `manifest` fields to the PATCH. An error is returned during the PATCH if the name or version from the manifest does not match the name and version of the job type being updated.