### PR TITLE
#1718 - Deprecation Warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
         apt:
           packages:
             - postgresql-9.5-postgis-2.3
+            - postgresql-9.5-postgis-2.4
 
     - os: linux
       env: BUILD_DOCS='true'

--- a/scale/docs/rest/v6/deprecated.rst
+++ b/scale/docs/rest/v6/deprecated.rst
@@ -17,10 +17,10 @@ Job REST API
 Specific endpoints under the job and job-type REST API were removed in Scale v6.
 
 - v5/job-types/{id}
-    Scale v6 no longer supports retrieving job details through the /job-types/{id} endpoint. Users should use the new Scale v6 /job-types/{name} endpoint instead. See :ref:`_rest_v6_job_type_versions` for more details.
+    Scale v6 no longer supports retrieving job details through the /job-types/{id} endpoint. Users should use the new Scale v6 /job-types/{name} endpoint instead. See :ref:`rest_v6_job_type_versions` for more details.
 
 - v5/jobs/executions
-    Scale v6 no longer supports retrieving job execution details through the /jobs/executions endpoint. The /jobs/{id}/executions endpoint should be used instead. See :ref:`_rest_v6_job_execution_list` for more details.
+    Scale v6 no longer supports retrieving job execution details through the /jobs/executions endpoint. The /jobs/{id}/executions endpoint should be used instead. See :ref:`rest_v6_job_execution_list` for more details.
 
 - v5/jobs/updates
     Scale v6 no longer supports the /jobs/updates endpoint. Using this endpoint will return a 500 Server Error.
@@ -36,11 +36,11 @@ Specific endpoints under the queue API were deprecated in Scale v5 and completel
     The v5/queue/new-recipe REST endpoint was moved to the v6/recipes/ API. Recipes are now queued by posting to the v6/recipes/ endpoint. See :ref:`rest_v6_recipe_queue_new_recipe` for more details.
 
 - v5/queue/requeue-jobs/
-    The v5/queue/requeue-jobs REST endpoint was moved to the v6/jobs/requeue/ API. Failed/Canceled jobs are now requeued by posting to the v6/job/requeue/ endpoint. See :ref:`_rest_v6_job_requeue` for more details.
+    The v5/queue/requeue-jobs REST endpoint was moved to the v6/jobs/requeue/ API. Failed/Canceled jobs are now requeued by posting to the v6/job/requeue/ endpoint. See :ref:`rest_v6_job_requeue` for more details.
 
 products REST API
 ---------------------------------------
-The products REST API endpoint was deprecated in Scale v5 and completely removed in Scale v6. Attempting to use these endpoints will result in a 404 error. The v6 files API should be used to retrieve product details. See :ref:`_rest_v6_scale_file`
+The products REST API endpoint was deprecated in Scale v5 and completely removed in Scale v6. Attempting to use these endpoints will result in a 404 error. The v6 files API should be used to retrieve product details. See :ref:`rest_v6_scale_file`
 
 recipe REST API
 --------------------------------------
@@ -51,7 +51,7 @@ Specific endpoints under the recipe API were deprecated in Scale v5 and complete
 
 source REST API
 ------------------------------------
-The source REST API endpoint was deprecated in Scale v5 and completely removed in Scale v6. Attempting to use these endpoints will result in a 500 Server Error. The v6/files API should be used to retrieve source file details. See :ref:`_rest_v6_scale_file`
+The source REST API endpoint was deprecated in Scale v5 and completely removed in Scale v6. Attempting to use these endpoints will result in a 500 Server Error. The v6/files API should be used to retrieve source file details. See :ref:`rest_v6_scale_file`
 
 
 v6 Deprecated Messages

--- a/scale/docs/rest/v6/ingest.rst
+++ b/scale/docs/rest/v6/ingest.rst
@@ -163,15 +163,15 @@ Response: 200 OK
 | results            | Array             | List of result JSON objects that match the query parameters.                   |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .id                | Integer           | The unique identifier of the model. Can be passed to the details API call.     |
-|                    |                   | (See :ref:`Ingest Details <rest_ingest_details>`)                              |
+|                    |                   | (See :ref:`Ingest Details <rest_v6_ingest_details>`)                           |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .file_name         | String            | The name of the file being ingested.                                           |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .scan              | JSON Object       | The scan process that triggered the ingest.                                    |
-|                    |                   | (See :ref:`Scan Details <rest_scan_details>`)                                  |
+|                    |                   | (See :ref:`Scan Details <rest_v6_scan_details>`)                               |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .strike            | JSON Object       | The strike process that triggered the ingest.                                  |
-|                    |                   | (See :ref:`Strike Details <rest_strike_details>`)                              |
+|                    |                   | (See :ref:`Strike Details <rest_v6_strike_details>`)                           |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .status            | String            | The current status of the ingest.                                              |
 |                    |                   | Choices: [TRANSFERRING, TRANSFERRED, DEFERRED, INGESTING, INGESTED, ERRORED,   |
@@ -192,12 +192,12 @@ Response: 200 OK
 | .file_path         | String            | The relative path of the file in the workspace.                                |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .workspace         | JSON Object       | The workspace storing the file.                                                |
-|                    |                   | (See :ref:`Workspace Details <rest_workspace_details>`)                        |
+|                    |                   | (See :ref:`Workspace Details <rest_v6_workspace_details>`)                     |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .new_file_path     | String            | The relative path for where the file should be moved as part of ingesting.     |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .new_workspace     | JSON Object       | The new workspace to move the file into as part of ingesting.                  |
-|                    |                   | (See :ref:`Workspace Details <rest_workspace_details>`)                        |
+|                    |                   | (See :ref:`Workspace Details <rest_v6_workspace_details>`)                     |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .job               | JSON Object       | The ID of the ingest job.                                                      |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -206,7 +206,7 @@ Response: 200 OK
 | .ingest_ended      | ISO-8601 Datetime | When the ingest ended.                                                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .source_file       | JSON Object       | A reference to the source file that was stored by this ingest.                 |
-|                    |                   | (See :ref:`Source File Details <rest_source_file_details>`)                    |
+|                    |                   | (See :ref:`File Details <rest_v6_file_details>`)                               |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .data_started      | ISO-8601 Datetime | The start time of the source data being ingested.                              |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -366,15 +366,15 @@ Response: 200 OK
 | **JSON Fields**                                                                                                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | id                 | Integer           | The unique identifier of the model. Can be passed to the details API call.     |
-|                    |                   | (See :ref:`Ingest Details <rest_ingest_details>`)                              |
+|                    |                   | (See :ref:`Ingest Details <rest_v6_ingest_details>`)                           |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | file_name          | String            | The name of the file being ingested.                                           |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | scan               | JSON Object       | The scan process that triggered the ingest.                                    |
-|                    |                   | (See :ref:`Scan Details <rest_scan_details>`)                                  |
+|                    |                   | (See :ref:`Scan Details <rest_v6_scan_details>`)                               |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | strike             | JSON Object       | The strike process that triggered the ingest.                                  |
-|                    |                   | (See :ref:`Strike Details <rest_strike_details>`)                              |
+|                    |                   | (See :ref:`Strike Details <rest_v6_strike_details>`)                           |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | status             | String            | The current status of the ingest.                                              |
 |                    |                   | Choices: [TRANSFERRING, TRANSFERRED, DEFERRED, INGESTING, INGESTED, ERRORED,   |
@@ -395,12 +395,12 @@ Response: 200 OK
 | file_path          | String            | The relative path of the file in the workspace.                                |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | workspace          | JSON Object       | The workspace storing the file.                                                |
-|                    |                   | (See :ref:`Workspace Details <rest_workspace_details>`)                        |
+|                    |                   | (See :ref:`Workspace Details <rest_v6_workspace_details>`)                     |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | new_file_path      | String            | The relative path for where the file should be moved as part of ingesting.     |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | new_workspace      | JSON Object       | The new workspace to move the file into as part of ingesting.                  |
-|                    |                   | (See :ref:`Workspace Details <rest_workspace_details>`)                        |
+|                    |                   | (See :ref:`Workspace Details <rest_v6_workspace_details>`)                     |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | job                | JSON Object       | The ID of the ingest job.                                                      |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -409,7 +409,7 @@ Response: 200 OK
 | ingest_ended       | ISO-8601 Datetime | When the ingest ended.                                                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | source_file        | JSON Object       | A reference to the source file that was stored by this ingest.                 |
-|                    |                   | (See :ref:`Source File Details <rest_source_file_details>`)                    |
+|                    |                   | (See :ref:`File Details <rest_v6_file_details>`)                               |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | data_started       | ISO-8601 Datetime | The start time of the source data being ingested.                              |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -530,7 +530,7 @@ Response: 200 OK
 | results            | Array             | List of result JSON objects that match the query parameters.                   |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .strike            | JSON Object       | The strike process that triggered the ingest.                                  |
-|                    |                   | (See :ref:`Strike Details <rest_strike_details>`)                              |
+|                    |                   | (See :ref:`Strike Details <rest_v6_strike_details>`)                           |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .most_recent       | ISO-8601 Datetime | The date/time when the strike process last completed an ingest.                |
 +--------------------+-------------------+--------------------------------------------------------------------------------+

--- a/scale/docs/rest/v6/job.rst
+++ b/scale/docs/rest/v6/job.rst
@@ -977,16 +977,16 @@ Response: 200 OK
 | ended                | ISO-8601 Datetime | When the job execution ended. (FAILED, COMPLETED, or CANCELED)                 |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | job                  | JSON Object       | The job that is associated with the execution.                                 |
-|                      |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
+|                      |                   | (See :ref:`Job Details <rest_v6_job_details>`)                                 |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | node                 | JSON Object       | The node that ran the execution.                                               |
-|                      |                   | (See :ref:`Node Details <rest_node_details>`)                                  |
+|                      |                   | (See :ref:`Node Details <rest_v6_node_details>`)                               |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | error                | JSON Object       | The last error that was recorded for the execution.                            |
 |                      |                   | (See :ref:`Error Details <rest_error_details>`)                                |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | job_type             | JSON Object       | The job type that is associated with the execution.                            |
-|                      |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
+|                      |                   | (See :ref:`Job Type Details <rest_v6_job_type_details>`)                       |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | timeout              | Integer           | The maximum amount of time this job can run before being killed (in seconds).  |
 +----------------------+-------------------+--------------------------------------------------------------------------------+

--- a/scale/docs/rest/v6/job_type.rst
+++ b/scale/docs/rest/v6/job_type.rst
@@ -365,6 +365,7 @@ Response: 200 OK
     "unmet_resources": "chocolate,vanilla",
     "manifest": { ... },
     "configuration": { ... },
+    "recipe_types": [:ref:`Recipe Type Details <rest_v6_recipe_type_details>`],
     "created": "2015-03-11T00:00:00Z",
     "deprecated": null,
     "paused": null,
@@ -424,6 +425,9 @@ Response: 200 OK
 +--------------------------+-------------------+--------------------------------------------------------------------------+
 | configuration            | JSON Object       | JSON description of the configuration for running the job                |
 |                          |                   | (See :ref:`rest_v6_job_type_configuration`)                              |
++--------------------------+-------------------+--------------------------------------------------------------------------+
+| recipe_types             | JSON Object       | List of all recipe_types that this job type is a member of               |
+|                          |                   | (See :ref:`rest_v6_recipe_type_configuration`)                           |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
 | created                  | ISO-8601 Datetime | When the associated database model was initially created.                |
 +--------------------------+-------------------+--------------------------------------------------------------------------+
@@ -1016,7 +1020,15 @@ Request: PATCH http://.../v6/job-types/test/1.0.0/
       }
     }
 
-Response: 204 No Content
+Response: 200 OK
+
+.. code-block:: javascript
+
+   {
+      "is_valid": true,
+      "errors": [],
+      "warnings": [{"name": "EXAMPLE_WARNING", "description": "This is an example warning."}]
+   }
 
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Edit Job Type**                                                                                                       |
@@ -1052,8 +1064,22 @@ Response: 204 No Content
 +-------------------------+-------------------+----------+----------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
-| **Status**         | 204 No Content                                                                                     |
+| **Status**         | 200 OK                                                                                             |
 +--------------------+----------------------------------------------------------------------------------------------------+
+| **Content Type**   | *application/json*                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                         |
++--------------------+---------------------+------------------------------------------------------------------------------+
+| is_valid           | Boolean           | Indicates if the given fields were valid for editing the job type. If this     |
+|                    |                   | is true, then the job type was successfully edited.                            |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| errors             | Array             | Lists any errors causing *is_valid* to be false. The errors are JSON objects   |
+|                    |                   | with *name* and *description* string fields.                                   |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| warnings           | Array             | Lists any warnings found. Warnings are useful to present to the user, but do   |
+|                    |                   | not cause *is_valid* to be false. The warnings are JSON objects with *name*    |
+|                    |                   | and *description* string fields.                                               |
++--------------------+-------------------+--------------------------------------------------------------------------------+
 
 
 .. _rest_v6_job_type_configuration:

--- a/scale/docs/rest/v6/job_type.rst
+++ b/scale/docs/rest/v6/job_type.rst
@@ -1257,7 +1257,7 @@ Request: GET http://.../v6/job-types/status/
 | results            | Array             | List of result JSON objects that match the query parameters.                   |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .job_type          | JSON Object       | The job type that is associated with the statistics.                           |
-|                    |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
+|                    |                   | (See :ref:`Job Type Details <rest_v6_job_type_details>`)                       |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .job_counts        | Array             | A list of recent job counts for the job type, grouped by status.               |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -1326,7 +1326,7 @@ Request: GET http://.../v6/job-types/pending/
 | results            | Array             | List of result JSON objects that match the query parameters.                   |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .job_type          | JSON Object       | The job type that is associated with the count.                                |
-|                    |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
+|                    |                   | (See :ref:`Job Type Details <rest_v6_job_type_details>`)                       |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .count             | Integer           | The number of jobs of this type that are currently pending.                    |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -1390,7 +1390,7 @@ Request: GET http://.../v6/job-types/status/
 | results            | Array             | List of result JSON objects that match the query parameters.                   |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .job_type          | JSON Object       | The job type that is associated with the count.                                |
-|                    |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
+|                    |                   | (See :ref:`Job Type Details <rest_v6_job_type_details>`)                       |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .count             | Integer           | The number of jobs of this type that are currently running.                    |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -1464,12 +1464,12 @@ Request: GET http://.../v6/job-types/system-failures/
 | results            | Array             | List of result JSON objects that match the query parameters.                   |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .job_type          | JSON Object       | The job type that is associated with the count.                                |
-|                    |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
+|                    |                   | (See :ref:`Job Type Details <rest_v6_job_type_details>`)                       |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .count             | Integer           | The number of jobs of this type that have an error.                            |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .error             | JSON Object       | The error that is associated with the count.                                   |
-|                    |                   | (See :ref:`Error Details <rest_error_details>`)                                |
+|                    |                   | (See :ref:`Error Details <rest_v6_error_details>`)                             |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .first_error       | ISO-8601 Datetime | When this error first occurred for a job of this type.                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+

--- a/scale/docs/rest/v6/job_type.yml
+++ b/scale/docs/rest/v6/job_type.yml
@@ -175,6 +175,7 @@ paths:
             application/json: 
               schema:
                 $ref: '#/components/schemas/job_type_detail'
+                
     patch:
       operationId: _rest_v6_job_type_update
       summary: Job Type Update
@@ -197,8 +198,13 @@ paths:
             type: string
           description: version of an existing job type
       responses:
-        '204':
-          description: 204 no content
+        '200':
+          description: The 200 OK response indicates a successful event
+          content:
+            application/json: 
+              schema:
+                $ref: '#/components/schemas/job_type_validation'
+                
   /job-types/{name}/{version}/revisions/:
     get:
       operationId: _rest_v6_job_type_revisions
@@ -552,6 +558,11 @@ components:
               $ref: '../../../job/seed/schema/seed.manifest.schema.json'
             configuration:
               $ref: '#/components/schemas/job_type_config'
+            recipe_types:
+              type: array
+              items:
+                $ref: '#/components/schemas/recipe_type'
+              description: List of Recipe Types this job type is a member of
     job_type_config:
       title: Job Type Configuration
       type: object

--- a/scale/docs/rest/v6/node.rst
+++ b/scale/docs/rest/v6/node.rst
@@ -83,7 +83,7 @@ Response: 200 OK
 | results            | Array             | List of result JSON objects that match the query parameters.                   |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .id                | Integer           | The unique identifier of the model. Can be passed to the details API call.     |
-|                    |                   | (See :ref:`Node Details <rest_node_details>`)                                  |
+|                    |                   | (See :ref:`Node Details <rest_v6_node_details>`)                               |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | .hostname          | String            | The full domain-qualified hostname of the node.                                |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -143,7 +143,7 @@ Response: 200 OK
 | **JSON Fields**                                                                                                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | id                 | Integer           | The unique identifier of the model. Can be passed to the details API call.     |
-|                    |                   | (See :ref:`Node Details <rest_node_details>`)                                  |
+|                    |                   | (See :ref:`Node Details <rest_v6_node_details>`)                               |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | hostname           | String            | The full domain-qualified hostname of the node.                                |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -205,7 +205,7 @@ Response: 204 NO CONTENT
 | **JSON Fields**                                                                                                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | id                 | Integer           | The unique identifier of the model. Can be passed to the details API call.     |
-|                    |                   | (See :ref:`Node Details <rest_node_details>`)                                  |
+|                    |                   | (See :ref:`Node Details <rest_v6_node_details>`)                               |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | hostname           | String            | The full domain-qualified hostname of the node.                                |
 +--------------------+-------------------+--------------------------------------------------------------------------------+

--- a/scale/docs/rest/v6/recipe.rst
+++ b/scale/docs/rest/v6/recipe.rst
@@ -301,7 +301,7 @@ Response: 201 CREATED
 | **Content Type**   | *application/json*                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
 | **Body**           | JSON containing the details of the newly queued recipe                                             |
-|                    | see :ref:`Recipe Details <rest_v6_recipe_details`>                                                 |
+|                    | see :ref:`Recipe Details <rest_v6_recipe_details>`                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
 
 .. _rest_v6_recipe_list:

--- a/scale/docs/rest/v6/recipe_type.rst
+++ b/scale/docs/rest/v6/recipe_type.rst
@@ -538,10 +538,10 @@ v6 Validate Recipe Type
 Request: POST http://.../v6/recipe-types/validation/
 
  .. code-block:: javascript
- 
+
    {
       "name": "my-recipe-type",
-      "definition": { :ref: `Recipe Definition <rest_v6_recipe_json_definition>` }
+      "definition": {:ref: `Recipe Definition <rest_v6_recipe_json_definition>`}
    }
     
 Response: 200 OK
@@ -684,7 +684,7 @@ v6 Edit Recipe Type
 Request: PATCH http://.../v6/recipe-types/test/
 
  .. code-block:: javascript
- 
+
     {
       "title": "My Recipe",
       "description": "A simple recipe type"
@@ -870,7 +870,7 @@ Response: 200 OK
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | id                 | Integer           | The unique identifier of the model.                                            |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
-| recipe_type        | String            | The recipe type for this revision. (See :ref:`<rest_v6_recipe_type_list>`)     |
+| recipe_type        | String            | The recipe type for this revision. (See :ref:`rest_v6_recipe_type_list`)       |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | revision_num       | Integer           | The revision number for this revision of the recipe type.                      |
 +--------------------+-------------------+--------------------------------------------------------------------------------+

--- a/scale/docs/rest/v6/recipe_type.rst
+++ b/scale/docs/rest/v6/recipe_type.rst
@@ -492,6 +492,7 @@ Location http://.../v6/recipe-types/my-recipe/
       "definition": {:ref: `Recipe Definition <rest_v6_recipe_json_definition>`},
       "job_types": [:ref: `Job Type Details <rest_v6_job_type_details>`],
       "sub_recipe_types": [:ref:`Recipe Type Details <rest_v6_recipe_type_details>`],
+      "super_recipe_types": [:ref:`Recipe Type Details <rest_v6_recipe_type_details>`],
       "created": "2015-06-15T19:03:26.346Z",
       "deprecated": "2015-07-15T19:03:26.346Z",
       "last_modified": "2015-06-15T19:03:26.346Z"
@@ -618,6 +619,7 @@ Response: 200 OK
       "definition": {:ref: `Recipe Definition <rest_v6_recipe_json_definition>`},
       "job_types": [:ref: `Job Type Details <rest_v6_job_type_details>`],
       "sub_recipe_types": [:ref:`Recipe Type Details <rest_v6_recipe_type_details>`],
+      "super_recipe_types": [:ref:`Recipe Type Details <rest_v6_recipe_type_details>`],
       "created": "2015-06-15T19:03:26.346Z",
       "deprecated": "2015-07-15T19:03:26.346Z",
       "last_modified": "2015-06-15T19:03:26.346Z"
@@ -662,6 +664,8 @@ Response: 200 OK
 | sub_recipe_types   | Array             | List of all recipe_types that are referenced by this recipe type's definition  |
 |                    |                   | (See :ref:`Recipe Type Details <rest_v6_recipe_type_details>`)                 |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
+| super_recipe_types | Array             | List of all recipe_types that this recipe type is a member of                  |
++--------------------+-------------------+--------------------------------------------------------------------------------+
 | created            | ISO-8601 Datetime | When the associated database model was initially created.                      |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | deprecated         | ISO-8601 Datetime | When the recipe type was deprecated (no longer active; previously archived).   |
@@ -689,7 +693,15 @@ Request: PATCH http://.../v6/recipe-types/test/
       "is_active": true
     }
 
-Response: 204 No Content
+Response: 200 OK
+
+.. code-block:: javascript
+
+   {
+      "is_valid": true,
+      "errors": [],
+      "warnings": [{"name": "EXAMPLE_WARNING", "description": "This is an example warning."}]
+   }
 
 +-------------------------------------------------------------------------------------------------------------------------+
 | **Edit Recipe Type**                                                                                                    |
@@ -716,8 +728,22 @@ Response: 204 No Content
 +--------------------+-------------------+----------+---------------------------------------------------------------------+
 | **Successful Response**                                                                                                 |
 +--------------------+----------------------------------------------------------------------------------------------------+
-| **Status**         | 204 NO CONTENT                                                                                     |
+| **Status**         | 200 OK                                                                                             |
 +--------------------+----------------------------------------------------------------------------------------------------+
+| **Content Type**   | *application/json*                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                         |
++--------------------+---------------------+------------------------------------------------------------------------------+
+| is_valid           | Boolean           | Indicates if the given fields were valid for editing a recipe type. If this    |
+|                    |                   | is true, then the recipe type was successfully edited.                         |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| errors             | Array             | Lists any errors causing *is_valid* to be false. The errors are JSON objects   |
+|                    |                   | with *name* and *description* string fields.                                   |
++--------------------+-------------------+--------------------------------------------------------------------------------+
+| warnings           | Array             | Lists any warnings found. Warnings are useful to present to the user, but do   |
+|                    |                   | not cause *is_valid* to be false. The warnings are JSON objects with *name*    |
+|                    |                   | and *description* string fields.                                               |
++--------------------+-------------------+--------------------------------------------------------------------------------+
 
 
 .. _rest_v6_recipe_type_revisions:

--- a/scale/docs/rest/v6/recipe_type.yml
+++ b/scale/docs/rest/v6/recipe_type.yml
@@ -101,8 +101,12 @@ paths:
             type: string
           description: name of an existing recipe type
       responses:
-        '204':
-          description: 204 no content
+        '200':
+          description: The 200 OK response indicates a successful event
+          content:
+            application/json: 
+              schema:
+                $ref: '#/components/schemas/recipe_type_validation'
           
   /recipe-types/{name}/revisions/:
     get:
@@ -330,6 +334,11 @@ components:
               items:
                 $ref: '#/components/schemas/recipe_type'
               description: List of Sub Recipe Types in this recipe type
+            super_recipe_types:
+              type: array
+              items:
+                $ref: '#/components/schemas/recipe_type'
+              description: List of Recipe Types this recipe type is a member of
 
 
     recipe_type_revisions:

--- a/scale/docs/rest/v6/scale_file.rst
+++ b/scale/docs/rest/v6/scale_file.rst
@@ -192,10 +192,10 @@ Response: 200 OK
 | results              | Array             | List of result JSON objects that match the query parameters.                   |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .id                  | Integer           | The unique identifier of the model. Can be passed to the details API call.     |
-|                      |                   | (See :ref:`Product Details <rest_product_details>`)                            |
+|                      |                   | (See :ref:`File Details <rest_v6_file_details>`)                      |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .workspace           | JSON Object       | The workspace that has stored the product.                                     |
-|                      |                   | (See :ref:`Workspace Details <rest_workspace_details>`)                        |
+|                      |                   | (See :ref:`Workspace Details <rest_v6_workspace_details>`)                     |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .file_name           | String            | The name of the file.                                                          |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
@@ -243,26 +243,26 @@ Response: 200 OK
 | .source_task         | String            | The task that produced the source file.                                        |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .job                 | JSON Object       | The job instance that generated the file.                                      |
-|                      |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
+|                      |                   | (See :ref:`Job Details <rest_v6_job_details>`)                                 |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .job_exe             | JSON Object       | The specific job execution that generated the file.                            |
-|                      |                   | (See :ref:`Job Execution Details <rest_job_execution_details>`)                |
+|                      |                   | (See :ref:`Job Execution Details <rest_v6_job_execution_details>`)             |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .job_output          | String            | The name of the output from the job related to this file.                      |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .job_type            | JSON Object       | The type of job that generated the file.                                       |
-|                      |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
+|                      |                   | (See :ref:`Job Type Details <rest_v6_job_type_details>`)                       |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .recipe              | JSON Object       | The recipe instance that generated the file.                                   |
-|                      |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                              |
+|                      |                   | (See :ref:`Recipe Details <rest_v6_recipe_details>`)                           |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .recipe_node         | String            | The recipe node that produced this file.                                       |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .recipe_type         | JSON Object       | The type of recipe that generated the file.                                    |
-|                      |                   | (See :ref:`Recipe Type Details <rest_recipe_type_details>`)                    |
+|                      |                   | (See :ref:`Recipe Type Details <rest_v6_recipe_type_details>`)                 |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .batch               | JSON Object       | The batch instance that generated the file.                                    |
-|                      |                   | (See :ref:`Batch Details <rest_batch_details>`)                                |
+|                      |                   | (See :ref:`Batch Details <rest_v6_batch_details>`)                             |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | .is_superseded       | Boolean           | Whether this file has been replaced and is now obsolete.                       |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
@@ -369,7 +369,7 @@ Response: 200 OK
 | id                   | Integer           | The unique identifier of the model.                                            |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | workspace            | JSON Object       | The workspace that has stored the product file.                                |
-|                      |                   | (See :ref:`Workspace Details <rest_workspace_details>`)                        |
+|                      |                   | (See :ref:`Workspace Details <rest_v6_workspace_details>`)                     |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | file_name            | String            | The name of the file.                                                          |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
@@ -420,23 +420,23 @@ Response: 200 OK
 | source_task          | String            | The task that produced the source file.                                        |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | job                  | JSON Object       | The job that created the file.                                                 |
-|                      |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
+|                      |                   | (See :ref:`Job Details <rest_v6_job_details>`)                                 |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | job_exe              | JSON Object       | The job execution that created the file.                                       |
-|                      |                   | (See :ref:`Job Execution Details <rest_job_execution_details>`)                |
+|                      |                   | (See :ref:`Job Execution Details <rest_v6_job_execution_details>`)             |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | job_output           | String            | The name of the output from the job related to this file.                      |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | job_type             | JSON Object       | The type of job that created the file.                                         |
-|                      |                   | (See :ref:`Job Type Details <rest_job_type_details>`)                          |
+|                      |                   | (See :ref:`Job Type Details <rest_v6_job_type_details>`)                       |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | recipe               | JSON Object       | The recipe instance that generated the file.                                   |
-|                      |                   | (See :ref:`Recipe Details <rest_recipe_details>`)                              |
+|                      |                   | (See :ref:`Recipe Details <rest_v6_recipe_details>`)                           |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | recipe_node          | String            | The recipe node that produced this file.                                       |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | recipe_type          | JSON Object       | The type of recipe that generated the file.                                    |
-|                      |                   | (See :ref:`Recipe Type Details <rest_recipe_type_details>`)                    |
+|                      |                   | (See :ref:`Recipe Type Details <rest_v6_recipe_type_details>`)                 |
 +----------------------+-------------------+--------------------------------------------------------------------------------+
 | batch                | JSON Object       | The batch instance that generated the file.                                    |
 +----------------------+-------------------+--------------------------------------------------------------------------------+

--- a/scale/docs/rest/v6/strike.rst
+++ b/scale/docs/rest/v6/strike.rst
@@ -218,7 +218,7 @@ Location http://.../v6/strikes/105/
 | **JSON Fields**                                                                                                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 |                    | JSON Object       | All fields are the same as the Strike process details model.                   |
-|                    |                   | (See :ref:`Strike Details <rest_strike_details>`)                              |
+|                    |                   | (See :ref:`Strike Details <rest_v6_strike_details>`)                           |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 
 .. _rest_v6_strike_details:
@@ -290,7 +290,7 @@ Response: 200 OK
 | **JSON Fields**                                                                                                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | id                 | Integer           | The unique identifier of the model. Can be passed to the details API.          |
-|                    |                   | (See :ref:`Strike Details <rest_strike_details>`)                              |
+|                    |                   | (See :ref:`Strike Details <rest_v6_strike_details>`)                           |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | name               | String            | The identifying name of the Strike process used for queries.                   |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
@@ -299,7 +299,7 @@ Response: 200 OK
 | description        | String            | A longer description of the Strike process.                                    |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | job                | JSON Object       | The job that is associated with the Strike process.                            |
-|                    |                   | (See :ref:`Job Details <rest_job_details>`)                                    |
+|                    |                   | (See :ref:`Job Details <rest_v6_job_details>`)                                 |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | created            | ISO-8601 Datetime | When the associated database model was initially created.                      |
 +--------------------+-------------------+--------------------------------------------------------------------------------+

--- a/scale/docs/rest/v6/workspace.rst
+++ b/scale/docs/rest/v6/workspace.rst
@@ -200,7 +200,7 @@ Location http://.../v6/workspaces/105/
 | **JSON Fields**                                                                                                         |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 |                    | JSON Object       | All fields are the same as the workspace details model.                        |
-|                    |                   | (See :ref:`Workspace Details <rest_workspace_details>`)                        |
+|                    |                   | (See :ref:`Workspace Details <rest_v6_workspace_details>`)                     |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 
 

--- a/scale/job/job_type_serializers.py
+++ b/scale/job/job_type_serializers.py
@@ -62,7 +62,6 @@ class JobTypeDetailsSerializerV6(JobTypeSerializerV6):
     manifest = serializers.JSONField(default=dict)
     configuration = serializers.JSONField(source='get_v6_configuration_json')
     recipe_types = serializers.JSONField()
-    deprecated_warning = serializers.CharField()
 
 
 class JobTypeStatusSerializer(serializers.Serializer):

--- a/scale/job/job_type_serializers.py
+++ b/scale/job/job_type_serializers.py
@@ -62,6 +62,7 @@ class JobTypeDetailsSerializerV6(JobTypeSerializerV6):
     manifest = serializers.JSONField(default=dict)
     configuration = serializers.JSONField(source='get_v6_configuration_json')
     recipe_types = serializers.JSONField()
+    deprecated_warning = serializers.CharField()
 
 
 class JobTypeStatusSerializer(serializers.Serializer):

--- a/scale/job/job_type_serializers.py
+++ b/scale/job/job_type_serializers.py
@@ -59,9 +59,10 @@ class JobTypeStatusCountsSerializer(serializers.Serializer):
 
 class JobTypeDetailsSerializerV6(JobTypeSerializerV6):
     """Converts job type model fields to REST output."""
+    from recipe.serializers import RecipeTypeSerializerV6
     manifest = serializers.JSONField(default=dict)
     configuration = serializers.JSONField(source='get_v6_configuration_json')
-    recipe_types = serializers.JSONField()
+    recipe_types = RecipeTypeSerializerV6(many=True)
 
 
 class JobTypeStatusSerializer(serializers.Serializer):

--- a/scale/job/job_type_serializers.py
+++ b/scale/job/job_type_serializers.py
@@ -61,6 +61,7 @@ class JobTypeDetailsSerializerV6(JobTypeSerializerV6):
     """Converts job type model fields to REST output."""
     manifest = serializers.JSONField(default=dict)
     configuration = serializers.JSONField(source='get_v6_configuration_json')
+    recipe_types = serializers.JSONField()
 
 
 class JobTypeStatusSerializer(serializers.Serializer):

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -2292,7 +2292,7 @@ class JobTypeManager(models.Manager):
 
         return job_types
 
-    def get_details_v6(self, name, version, id=None):
+    def get_details_v6(self, name=None, version=None, id=None):
         """Returns the job type for the given name and version with all detail fields included.
 
         The additional fields include: errors, job_counts_6h, job_counts_12h, and job_counts_24h.

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -2078,9 +2078,10 @@ class JobTypeManager(models.Manager):
         if is_active is not None and job_type.is_active != is_active:
             job_type.deprecated = None if is_active else timezone.now()
             job_type.is_active = is_active
-            recipe_ids = RecipeTypeJobLink.objects.get_recipe_type_ids([job_type.id])
-            msgs = [create_activate_recipe_message(id, is_active) for id in recipe_ids]
-            CommandMessageManager().send_messages(msgs)
+            if is_active == False:
+                recipe_ids = RecipeTypeJobLink.objects.get_recipe_type_ids([job_type.id])
+                msgs = [create_activate_recipe_message(id, is_active) for id in recipe_ids]
+                CommandMessageManager().send_messages(msgs)
                 
         if is_paused is not None and job_type.is_paused != is_paused:
             job_type.paused = timezone.now() if is_paused else None

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -1530,7 +1530,9 @@ class TestJobTypeDetailsViewV6(APITestCase):
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
 
-    def test_edit_simple(self):
+    @patch('job.views.CommandMessageManager')
+    @patch('recipe.messages.update_recipe_definition.create_activate_recipe_message')
+    def test_edit_simple(self, mock_create, mock_msg_mgr):
         """Tests editing only the basic attributes of a job type"""
 
         url = '/%s/job-types/%s/%s/' % (self.api, self.job_type.name, self.job_type.version)

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -1168,20 +1168,16 @@ class TestJobTypesPostViewV6(APITestCase):
         }
 
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
-        self.assertTrue('/%s/job-types/my-job/1.0.0/' % self.api in response['location'])
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        results = json.loads(response.content)
+        self.assertTrue(results['is_valid'])
+        self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': []})
 
         job_type = JobType.objects.filter(name='my-job', version='1.0.0').first()
-
-        results = json.loads(response.content)
-        self.assertEqual(results['id'], job_type.id)
-        self.assertEqual(results['name'], job_type.name)
-        self.assertEqual(results['version'], job_type.version)
-        self.assertEqual(results['title'], job_type.get_title())
-        self.assertEqual(results['revision_num'], job_type.revision_num)
-        self.assertEqual(results['revision_num'], 2)
-        self.assertIsNotNone(results['configuration']['mounts'])
-        self.assertIsNotNone(results['configuration']['settings'])
+        self.assertEqual(job_type.docker_iamge, 'my-job-1.0.0-seed:1.0.1')
+        self.assertDictEqual(job_type.manifest, manifest)
+        self.assertEqual(job_type.max_scheduled, 1)
+        self.assertEqual(job_type.is_published, True)
 
         manifest['job']['maintainer'].pop('url')
 
@@ -1195,14 +1191,14 @@ class TestJobTypesPostViewV6(APITestCase):
         }
 
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
-        self.assertTrue('/%s/job-types/my-job/1.0.0/' % self.api in response['location'])
-
-        job_type = JobType.objects.filter(name='my-job', version='1.0.0').first()
-
+        self.assertEqual(response.status_code, status.HTTP_20O_OK, response.content)
+        
         results = json.loads(response.content)
-        self.assertEqual(results['id'], job_type.id)
-        self.assertIsNone(results['manifest']['job']['maintainer'].get('url'))
+        self.assertTrue(results['is_valid'])
+        self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': []})
+        
+        job_type = JobType.objects.filter(name='my-job', version='1.0.0').first()
+        self.assertEqual(job_type.docker_iamge, 'my-job-1.0.0-seed:1.0.2')
 
     def test_create_seed_secrets(self):
         """Tests creating a new seed job type with secrets."""
@@ -1442,6 +1438,7 @@ class TestJobTypeDetailsViewV6(APITestCase):
         rest.login_client(self.client, is_staff=True)
 
         self.manifest = job_test_utils.COMPLETE_MANIFEST
+        self.manifest2 = job_test_utils.MINIMUM_MANIFEST
 
 
         self.output_workspace = storage_test_utils.create_workspace()
@@ -1468,6 +1465,19 @@ class TestJobTypeDetailsViewV6(APITestCase):
 
         self.job_type = job_test_utils.create_seed_job_type(manifest=self.manifest, max_scheduled=2,
                                                        configuration=self.configuration)
+                                                       
+        self.job_type1 = job_test_utils.create_seed_job_type(manifest=job_test_utils.MINIMUM_MANIFEST)
+
+        sub_definition = copy.deepcopy(recipe_test_utils.SUB_RECIPE_DEFINITION)
+        sub_definition['nodes']['node_a']['node_type']['job_type_name'] = self.job_type1.name
+        sub_definition['nodes']['node_a']['node_type']['job_type_version'] = self.job_type1.version
+        sub_definition['nodes']['node_a']['node_type']['job_type_revision'] = self.job_type1.revision_num
+
+        self.recipe_type1 = recipe_test_utils.create_recipe_type_v6(definition=sub_definition,
+                                                                    description="A sub recipe",
+                                                                    is_active=True,
+                                                                    is_system=False)
+                                       
 
     def test_not_found(self):
         """Tests calling the get job type details view with a job name/version that does not exist."""
@@ -1521,7 +1531,26 @@ class TestJobTypeDetailsViewV6(APITestCase):
             'max_scheduled': 9
         }
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        
+        results = json.loads(response.content)
+        self.assertTrue(results['is_valid'])
+        self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': []})
+        
+    def test_edit_warnings(self):
+        """Tests deprecating a job type and getting warnings"""
+
+        url = '/%s/job-types/%s/%s/' % (self.api, self.job_type1.name, self.job_type1.version)
+        json_data = {
+            'is_active': False
+        }
+        response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        
+        results = json.loads(response.content)
+        self.assertTrue(results['is_valid'])
+        self.assertEqual(len(results['warnings']), 1)
+        self.assertEqual(results['warnings'][0]['name'], 'DEPRECATED_RECIPES')
 
     def test_edit_configuration(self):
         """Tests editing the configuration of a job type"""
@@ -1539,7 +1568,11 @@ class TestJobTypeDetailsViewV6(APITestCase):
             'configuration': configuration,
         }
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        
+        results = json.loads(response.content)
+        self.assertTrue(results['is_valid'])
+        self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': []})
         
     def test_edit_manifest(self):
         """Tests editing the manifest of a job type"""
@@ -1553,7 +1586,11 @@ class TestJobTypeDetailsViewV6(APITestCase):
 
         url = '/%s/job-types/%s/%s/' % (self.api, self.job_type.name, self.job_type.version)
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        
+        results = json.loads(response.content)
+        self.assertTrue(results['is_valid'])
+        self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': []})
         
         # mismatch name
         manifest = copy.deepcopy(self.manifest)

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -1530,7 +1530,7 @@ class TestJobTypeDetailsViewV6(APITestCase):
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
 
-    @patch('job.views.CommandMessageManager')
+    @patch('job.models.CommandMessageManager')
     @patch('recipe.messages.update_recipe_definition.create_activate_recipe_message')
     def test_edit_simple(self, mock_create, mock_msg_mgr):
         """Tests editing only the basic attributes of a job type"""
@@ -1550,7 +1550,7 @@ class TestJobTypeDetailsViewV6(APITestCase):
         self.assertTrue(results['is_valid'])
         self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': []})
         
-    @patch('job.views.CommandMessageManager')
+    @patch('job.models.CommandMessageManager')
     @patch('recipe.messages.update_recipe_definition.create_activate_recipe_message')
     def test_edit_warnings(self, mock_create, mock_msg_mgr):
         """Tests deprecating a job type and getting warnings"""

--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -1548,7 +1548,9 @@ class TestJobTypeDetailsViewV6(APITestCase):
         self.assertTrue(results['is_valid'])
         self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': []})
         
-    def test_edit_warnings(self):
+    @patch('job.views.CommandMessageManager')
+    @patch('recipe.messages.update_recipe_definition.create_activate_recipe_message')
+    def test_edit_warnings(self, mock_create, mock_msg_mgr):
         """Tests deprecating a job type and getting warnings"""
 
         url = '/%s/job-types/%s/%s/' % (self.api, self.job_type1.name, self.job_type1.version)

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -179,7 +179,7 @@ class JobTypesView(ListCreateAPIView):
                 
             # Fetch the full job type with details
             try:
-                job_type = JobType.objects.get_details_v6(name, version)
+                job_type = JobType.objects.get_details_v6(name=name, version=version)
             except JobType.DoesNotExist:
                 raise Http404
     
@@ -303,7 +303,7 @@ class JobTypeDetailsView(GenericAPIView):
         """
 
         try:
-            job_type = JobType.objects.get_details_v6(name, version)
+            job_type = JobType.objects.get_details_v6(name=name, version=version)
         except JobType.DoesNotExist:
             raise Http404
         except NonSeedJobType as ex:

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -363,6 +363,7 @@ class JobTypeDetailsView(GenericAPIView):
         except JobType.DoesNotExist:
             raise Http404
 
+        jt = None
         # Check for invalid fields
         fields = {'icon_code', 'is_published', 'is_active', 'is_paused', 'max_scheduled', 'configuration', 'manifest', 'docker_image'}
         for key, value in request.data.iteritems():
@@ -372,7 +373,7 @@ class JobTypeDetailsView(GenericAPIView):
         try:
             with transaction.atomic():
                 # Edit the job type
-                JobType.objects.edit_job_type_v6(job_type_id=job_type.id, manifest=manifest, is_published=is_published,
+                jt = JobType.objects.edit_job_type_v6(job_type_id=job_type.id, manifest=manifest, is_published=is_published,
                                                  docker_image=docker_image, icon_code=icon_code, is_active=is_active,
                                                  is_paused=is_paused, max_scheduled=max_scheduled,
                                                  configuration=configuration, auto_update=auto_update)
@@ -381,7 +382,8 @@ class JobTypeDetailsView(GenericAPIView):
             logger.exception('Unable to update job type: %i', job_type.id)
             raise BadParameter(unicode(ex))
 
-        return HttpResponse(status=204)
+        serializer = self.get_serializer(jt)
+        return Response(serializer.data)
 
 
 class JobTypeRevisionsView(ListAPIView):

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -176,9 +176,20 @@ class JobTypesView(ListCreateAPIView):
                 message = 'Job type configuration invalid'
                 logger.exception(message)
                 raise BadParameter('%s: %s' % (message, unicode(ex)))
+                
+            # Fetch the full job type with details
+            try:
+                job_type = JobType.objects.get_details_v6(name, version)
+            except JobType.DoesNotExist:
+                raise Http404
+    
+            url = reverse('job_type_details_view', args=[job_type.name, job_type.version], request=request)
+            serializer = JobTypeDetailsSerializerV6(job_type)
+    
+            return Response(serializer.data, status=status.HTTP_201_CREATED, headers=dict(location=url))
         else:
             try:
-                JobType.objects.edit_job_type_v6(job_type_id=existing_job_type.id, manifest=manifest,
+                validation = JobType.objects.edit_job_type_v6(job_type_id=existing_job_type.id, manifest=manifest,
                                                  docker_image=docker_image, icon_code=icon_code, is_active=is_active,
                                                  is_paused=is_paused, max_scheduled=max_scheduled,
                                                  is_published=is_published, configuration=configuration,
@@ -194,17 +205,12 @@ class JobTypesView(ListCreateAPIView):
                 message = 'Job type configuration invalid'
                 logger.exception(message)
                 raise BadParameter('%s: %s' % (message, unicode(ex)))
+                
+            resp_dict = {'is_valid': validation.is_valid, 'errors': [e.to_dict() for e in validation.errors],
+                     'warnings': [w.to_dict() for w in validation.warnings]}
+            return Response(resp_dict)
 
-        # Fetch the full job type with details
-        try:
-            job_type = JobType.objects.get_details_v6(name, version)
-        except JobType.DoesNotExist:
-            raise Http404
 
-        url = reverse('job_type_details_view', args=[job_type.name, job_type.version], request=request)
-        serializer = JobTypeDetailsSerializerV6(job_type)
-
-        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=dict(location=url))
 
 
 class JobTypeVersionsView(ListAPIView):
@@ -373,7 +379,7 @@ class JobTypeDetailsView(GenericAPIView):
         try:
             with transaction.atomic():
                 # Edit the job type
-                jt = JobType.objects.edit_job_type_v6(job_type_id=job_type.id, manifest=manifest, is_published=is_published,
+                validation = JobType.objects.edit_job_type_v6(job_type_id=job_type.id, manifest=manifest, is_published=is_published,
                                                  docker_image=docker_image, icon_code=icon_code, is_active=is_active,
                                                  is_paused=is_paused, max_scheduled=max_scheduled,
                                                  configuration=configuration, auto_update=auto_update)
@@ -382,8 +388,9 @@ class JobTypeDetailsView(GenericAPIView):
             logger.exception('Unable to update job type: %i', job_type.id)
             raise BadParameter(unicode(ex))
 
-        serializer = self.get_serializer(jt)
-        return Response(serializer.data)
+        resp_dict = {'is_valid': validation.is_valid, 'errors': [e.to_dict() for e in validation.errors],
+                 'warnings': [w.to_dict() for w in validation.warnings]}
+        return Response(resp_dict)
 
 
 class JobTypeRevisionsView(ListAPIView):

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -369,7 +369,6 @@ class JobTypeDetailsView(GenericAPIView):
         except JobType.DoesNotExist:
             raise Http404
 
-        jt = None
         # Check for invalid fields
         fields = {'icon_code', 'is_published', 'is_active', 'is_paused', 'max_scheduled', 'configuration', 'manifest', 'docker_image'}
         for key, value in request.data.iteritems():

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -1226,6 +1226,11 @@ class RecipeTypeManager(models.Manager):
 
         from recipe.definition.exceptions import InvalidDefinition
         from recipe.messages.update_recipe_definition import create_sub_update_recipe_definition_message, create_activate_recipe_message
+        
+        is_valid = True
+        errors = []
+        warnings = []
+        diff = {}
 
         # Acquire model lock
         recipe_type = RecipeType.objects.select_for_update().get(pk=recipe_type_id)
@@ -1242,8 +1247,10 @@ class RecipeTypeManager(models.Manager):
             if is_active == False:
                 super_ids = RecipeTypeSubLink.objects.get_recipe_type_ids([recipe_type.id])
                 if super_ids:
-                    deprecated_warning = "Recipes were deprecated as a result of deprecating this recipe. " \
-                                         "Look at the super_recipe_types field for recipes that may need to be updated."
+                    recipe_names = RecipeType.objects.filter(id__in=super_ids).values_list('name', flat=True)
+                    recipe_names = list(recipe_names)
+                    warn = "The following recipes were deprecated as a result of deprecating this recipe type: %s " % recipe_names
+                    warnings.append(ValidationWarning('DEPRECATED_RECIPES',warn))
                 msgs = [create_activate_recipe_message(id, is_active) for id in super_ids]
                 CommandMessageManager().send_messages(msgs)
 
@@ -1271,7 +1278,7 @@ class RecipeTypeManager(models.Manager):
                 msgs = [create_sub_update_recipe_definition_message(id, recipe_type.id) for id in super_ids]
                 CommandMessageManager().send_messages(msgs)
 
-        return recipe_type
+        return RecipeTypeValidation(is_valid, errors, warnings, diff)
 
     def get_by_natural_key(self, name):
         """Django method to retrieve a recipe type for the given natural key
@@ -1300,9 +1307,15 @@ class RecipeTypeManager(models.Manager):
 
         # Add associated job type information
         jt_ids = RecipeTypeJobLink.objects.get_job_type_ids([recipe_type.id])
-        recipe_type.job_types = JobType.objects.all().filter(id__in=jt_ids)
+        recipe_type.job_types = []
+        for id in jt_ids:
+            jt = JobType.objects.all().get_details_v6("", "", id=id)
+            recipe_type.job_types.append(jt)
+            
         sub_ids = RecipeTypeSubLink.objects.get_sub_recipe_type_ids([recipe_type.id])
         recipe_type.sub_recipe_types = RecipeType.objects.all().filter(id__in=sub_ids)
+        super_ids = RecipeTypeSubLink.objects.get_recipe_type_ids([recipe_type.id])
+        recipe_type.super_recipe_types = RecipeType.objects.all().filter(id__in=super_ids)
 
         return recipe_type
 

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -396,6 +396,8 @@ class RecipeManager(models.Manager):
         recipe.job_types = JobType.objects.all().filter(id__in=jt_ids)
         sub_ids = RecipeTypeSubLink.objects.get_sub_recipe_type_ids([recipe.recipe_type.id])
         recipe.sub_recipe_types = RecipeType.objects.all().filter(id__in=sub_ids)
+        super_ids = RecipeTypeSubLink.objects.get_recipe_type_ids([recipe.recipe_type.id])
+        recipe.super_recipe_types = RecipeType.objects.all().filter(id__in=super_ids)
         return recipe
 
     def process_recipe_input(self, recipe):
@@ -1236,10 +1238,9 @@ class RecipeTypeManager(models.Manager):
         
         if is_active is not None:
             recipe_type.is_active = is_active
-            if auto_update:
-                super_ids = RecipeTypeSubLink.objects.get_recipe_type_ids([recipe_type.id])
-                msgs = [create_activate_recipe_message(id, is_active) for id in super_ids]
-                CommandMessageManager().send_messages(msgs)
+            super_ids = RecipeTypeSubLink.objects.get_recipe_type_ids([recipe_type.id])
+            msgs = [create_activate_recipe_message(id, is_active) for id in super_ids]
+            CommandMessageManager().send_messages(msgs)
 
         if definition:
             if isinstance(definition, RecipeDefinition):

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -1241,7 +1241,6 @@ class RecipeTypeManager(models.Manager):
         if description is not None:
             recipe_type.description = description
         
-        deprecated_warning = ""
         if is_active is not None:
             recipe_type.is_active = is_active
             if is_active == False:
@@ -1264,7 +1263,6 @@ class RecipeTypeManager(models.Manager):
             recipe_type.revision_num = recipe_type.revision_num + 1
 
         recipe_type.save()
-        recipe_type.deprecated_warning = deprecated_warning
 
         if definition:
             # Create new revision of the recipe type for new definition
@@ -1309,7 +1307,7 @@ class RecipeTypeManager(models.Manager):
         jt_ids = RecipeTypeJobLink.objects.get_job_type_ids([recipe_type.id])
         recipe_type.job_types = []
         for id in jt_ids:
-            jt = JobType.objects.all().get_details_v6("", "", id=id)
+            jt = JobType.objects.get_details_v6("", "", id=id)
             recipe_type.job_types.append(jt)
             
         sub_ids = RecipeTypeSubLink.objects.get_sub_recipe_type_ids([recipe_type.id])

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -1238,9 +1238,10 @@ class RecipeTypeManager(models.Manager):
         
         if is_active is not None:
             recipe_type.is_active = is_active
-            super_ids = RecipeTypeSubLink.objects.get_recipe_type_ids([recipe_type.id])
-            msgs = [create_activate_recipe_message(id, is_active) for id in super_ids]
-            CommandMessageManager().send_messages(msgs)
+            if is_active == False:
+                super_ids = RecipeTypeSubLink.objects.get_recipe_type_ids([recipe_type.id])
+                msgs = [create_activate_recipe_message(id, is_active) for id in super_ids]
+                CommandMessageManager().send_messages(msgs)
 
         if definition:
             if isinstance(definition, RecipeDefinition):

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -1307,7 +1307,7 @@ class RecipeTypeManager(models.Manager):
         jt_ids = RecipeTypeJobLink.objects.get_job_type_ids([recipe_type.id])
         recipe_type.job_types = []
         for id in jt_ids:
-            jt = JobType.objects.get_details_v6("", "", id=id)
+            jt = JobType.objects.get_details_v6(id=id)
             recipe_type.job_types.append(jt)
             
         sub_ids = RecipeTypeSubLink.objects.get_sub_recipe_type_ids([recipe_type.id])

--- a/scale/recipe/serializers.py
+++ b/scale/recipe/serializers.py
@@ -25,6 +25,7 @@ class RecipeTypeSerializerV6(RecipeTypeBaseSerializerV6):
     definition = None
     job_types = None
     sub_recipe_types = None
+    super_recipe_types = None
     created = serializers.DateTimeField()
     deprecated = serializers.DateTimeField()
     last_modified = serializers.DateTimeField()
@@ -40,6 +41,7 @@ class RecipeTypeListSerializerV6(ModelIdSerializer):
     revision_num = serializers.IntegerField()
     job_types = serializers.JSONField()
     sub_recipe_types = serializers.JSONField()
+    super_recipe_types = serializers.JSONField()
     created = serializers.DateTimeField()
     deprecated = serializers.DateTimeField()
     last_modified = serializers.DateTimeField()

--- a/scale/recipe/serializers.py
+++ b/scale/recipe/serializers.py
@@ -72,6 +72,7 @@ class RecipeTypeDetailsSerializerV6(RecipeTypeSerializerV6):
     definition = serializers.JSONField(source='get_v6_definition_json')
     job_types = JobTypeDetailsSerializerV6(many=True)
     sub_recipe_types = RecipeTypeSerializerV6(many=True)
+    deprecated_warning = serializers.CharField()
 
 
 class RecipeTypeRevisionBaseSerializer(ModelIdSerializer):

--- a/scale/recipe/serializers.py
+++ b/scale/recipe/serializers.py
@@ -72,7 +72,7 @@ class RecipeTypeDetailsSerializerV6(RecipeTypeSerializerV6):
     definition = serializers.JSONField(source='get_v6_definition_json')
     job_types = JobTypeDetailsSerializerV6(many=True)
     sub_recipe_types = RecipeTypeSerializerV6(many=True)
-    deprecated_warning = serializers.CharField()
+    super_recipe_types = RecipeTypeSerializerV6(many=True)
 
 
 class RecipeTypeRevisionBaseSerializer(ModelIdSerializer):

--- a/scale/recipe/serializers.py
+++ b/scale/recipe/serializers.py
@@ -41,7 +41,7 @@ class RecipeTypeListSerializerV6(ModelIdSerializer):
     revision_num = serializers.IntegerField()
     job_types = serializers.JSONField()
     sub_recipe_types = serializers.JSONField()
-    super_recipe_types = serializers.JSONField()
+    super_recipe_types = None
     created = serializers.DateTimeField()
     deprecated = serializers.DateTimeField()
     last_modified = serializers.DateTimeField()

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -406,7 +406,12 @@ class TestRecipeTypeDetailsViewV6(APITransactionTestCase):
 
         url = '/%s/recipe-types/%s/' % (self.api, self.recipe_type1.name)
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        
+        results = json.loads(response.content)
+        self.assertTrue(results['is_valid'])
+        self.assertEqual(len(results['warnings']), 1)
+        self.assertEqual(results['warnings'][0]['name'], 'DEPRECATED_RECIPES')
         
         recipe_type = RecipeType.objects.get(pk=self.recipe_type1.id)
         self.assertEqual(recipe_type.is_active, False)
@@ -425,7 +430,11 @@ class TestRecipeTypeDetailsViewV6(APITransactionTestCase):
 
         url = '/%s/recipe-types/%s/' % (self.api, self.recipe_type1.name)
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        
+        results = json.loads(response.content)
+        self.assertTrue(results['is_valid'])
+        self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': [], u'diff': {}})
 
         recipe_type = RecipeType.objects.get(pk=self.recipe_type1.id)
         self.assertEqual(recipe_type.revision_num, 2)
@@ -448,7 +457,11 @@ class TestRecipeTypeDetailsViewV6(APITransactionTestCase):
 
         url = '/%s/recipe-types/%s/' % (self.api, self.recipe_type1.name)
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        
+        results = json.loads(response.content)
+        self.assertTrue(results['is_valid'])
+        self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': [], u'diff': {}})
 
         recipe_type = RecipeType.objects.get(pk=self.recipe_type1.id)
         self.assertEqual(recipe_type.revision_num, 2)

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -384,6 +384,8 @@ class TestRecipeTypeDetailsViewV6(APITransactionTestCase):
         self.assertEqual(len(result['sub_recipe_types']), 1)
         for entry in result['sub_recipe_types']:
             self.assertTrue(entry['id'], [self.recipe_type1.id])
+            
+        self.assertEqual(len(result['super_recipe_types']), 0)
 
         self.assertIn('deprecated', result)
 
@@ -391,6 +393,17 @@ class TestRecipeTypeDetailsViewV6(APITransactionTestCase):
         del versionless['version']
         self.maxDiff = None
         self.assertDictEqual(result['definition'], versionless)
+
+        url = '/%s/recipe-types/%s/' % (self.api, self.recipe_type1.name)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['job_types']), 1)
+        self.assertEqual(result['job_types'][0]['id'], self.job_type1.id)
+        
+        self.assertEqual(len(result['super_recipe_types']), 1)
+        self.assertEqual(result['super_recipe_types'][0]['id'], self.recipe_type2.id)
 
     @patch('recipe.models.CommandMessageManager')
     @patch('recipe.messages.update_recipe_definition.create_activate_recipe_message')

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -242,15 +242,16 @@ class RecipeTypeDetailsView(GenericAPIView):
                     recipe_def = RecipeDefinitionV6(definition=definition_dict, do_validate=True).get_definition()
 
                 # Edit the recipe type
-                rt = RecipeType.objects.edit_recipe_type_v6(recipe_type_id=recipe_type.id, title=title,
+                validation = RecipeType.objects.edit_recipe_type_v6(recipe_type_id=recipe_type.id, title=title,
                                                        description=description, definition=recipe_def,
                                                        auto_update=auto_update, is_active=is_active)
         except InvalidDefinition as ex:
             logger.exception('Unable to update recipe type: %s', name)
             raise BadParameter(unicode(ex))
 
-        serializer = self.get_serializer(rt)
-        return Response(serializer.data)
+        resp_dict = {'is_valid': validation.is_valid, 'errors': [e.to_dict() for e in validation.errors],
+                     'warnings': [w.to_dict() for w in validation.warnings], 'diff': validation.diff}
+        return Response(resp_dict)
 
 class RecipeTypeRevisionsView(ListAPIView):
     """This view is the endpoint for retrieving the list of all recipe types"""

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -233,6 +233,7 @@ class RecipeTypeDetailsView(GenericAPIView):
         except RecipeType.DoesNotExist:
             raise Http404
 
+        rt = None
         try:
             with transaction.atomic():
                 # Validate the recipe definition
@@ -241,15 +242,15 @@ class RecipeTypeDetailsView(GenericAPIView):
                     recipe_def = RecipeDefinitionV6(definition=definition_dict, do_validate=True).get_definition()
 
                 # Edit the recipe type
-                RecipeType.objects.edit_recipe_type_v6(recipe_type_id=recipe_type.id, title=title,
+                rt = RecipeType.objects.edit_recipe_type_v6(recipe_type_id=recipe_type.id, title=title,
                                                        description=description, definition=recipe_def,
                                                        auto_update=auto_update, is_active=is_active)
         except InvalidDefinition as ex:
             logger.exception('Unable to update recipe type: %s', name)
             raise BadParameter(unicode(ex))
 
-        return HttpResponse(status=204)
-
+        serializer = self.get_serializer(rt)
+        return Response(serializer.data)
 
 class RecipeTypeRevisionsView(ListAPIView):
     """This view is the endpoint for retrieving the list of all recipe types"""

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -233,7 +233,6 @@ class RecipeTypeDetailsView(GenericAPIView):
         except RecipeType.DoesNotExist:
             raise Http404
 
-        rt = None
         try:
             with transaction.atomic():
                 # Validate the recipe definition

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,7 +15,7 @@ then
     psql -d scale -U postgres -c "create extension postgis_topology;"
 
     export COVERAGE_FILE=$root/.coverage
-    coverage run --source='.' manage.py test -v 2
+    coverage run --source='.' manage.py test
 fi
 
 if [ "${BUILD_DOCS}" == "true" ]

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,7 +15,7 @@ then
     psql -d scale -U postgres -c "create extension postgis_topology;"
 
     export COVERAGE_FILE=$root/.coverage
-    coverage run --source='.' manage.py test
+    coverage run --source='.' manage.py test 
 fi
 
 if [ "${BUILD_DOCS}" == "true" ]

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,7 +15,7 @@ then
     psql -d scale -U postgres -c "create extension postgis_topology;"
 
     export COVERAGE_FILE=$root/.coverage
-    coverage run --source='.' manage.py test 
+    coverage run --source='.' manage.py test -v 2
 fi
 
 if [ "${BUILD_DOCS}" == "true" ]


### PR DESCRIPTION
##### Checklist

- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

### Affected app(s)
- job
- recipe

### Description of change
Added fields to job-type details and recipe-type details apis to show which recipes each belongs to so they can be easily found if they need to be edited.
Automatically deprecate parent recipes when jobs/recipes are deprecated regardless of auto-update flag. Parent recipes aren't automatically reactivated.
Changed job/recipe patch endpoints to return 200 OK response with validation dict for warnings.
