### PR TITLE
Issue 1717 - Optimize API responsiveness for jobs and recipes

### DIFF
--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -631,6 +631,7 @@ class JobsView(ListAPIView):
                                        batch_ids=batch_ids, recipe_ids=recipe_ids,
                                        error_categories=error_categories, error_ids=error_ids,
                                        is_superseded=is_superseded, order=order)
+        jobs = jobs.select_related('job_type_rev__job_type').defer(None)
         page = self.paginate_queryset(jobs)
         serializer = self.get_serializer(page, many=True)
 

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -631,6 +631,9 @@ class JobsView(ListAPIView):
                                        batch_ids=batch_ids, recipe_ids=recipe_ids,
                                        error_categories=error_categories, error_ids=error_ids,
                                        is_superseded=is_superseded, order=order)
+
+        # additional optimizations not being captured by the existing ones in the manager
+        # see issue #1717
         jobs = jobs.select_related('job_type_rev__job_type').defer(None)
         page = self.paginate_queryset(jobs)
         serializer = self.get_serializer(page, many=True)

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -445,6 +445,7 @@ class RecipesView(ListAPIView):
                                                 batch_ids=batch_ids, is_superseded=is_superseded,
                                                 is_completed=is_completed, order=order)
 
+        recipes = recipes.select_related('recipe_type_rev__recipe_type').defer(None)
         page = self.paginate_queryset(recipes)
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -445,6 +445,8 @@ class RecipesView(ListAPIView):
                                                 batch_ids=batch_ids, is_superseded=is_superseded,
                                                 is_completed=is_completed, order=order)
 
+        # additional optimizations not being captured by the existing ones in the manager
+        # see issue #1717
         recipes = recipes.select_related('recipe_type_rev__recipe_type').defer(None)
         page = self.paginate_queryset(recipes)
         serializer = self.get_serializer(page, many=True)


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
- jobs
- recipes

### Description of change
<!-- Please provide a description of the change here. -->
`/v6/jobs/` and `/v6/recipes/` were both performing extra queries, `n+1` for each item returned, as outlined in #1717.

For jobs, despite being in `select_related()`, the nested `job_type_rev__job_type` was being queried for each result. The docs say that fields in the `defer()` list can also be `select_related()`, but maybe this doesn't play well with DRF serializers? Similar situation for recipes endpoint.

I didn't put this change in the manager (where the `select_related()`/`defer()` currently happens) in case this messes up performance elsewhere.

For the jobs endpoint, this cuts queries from 36 (449 ms) to 4 (152 ms). Recipes endpoint is similar, but not as extreme.