### PR TITLE
Batches - Missed RecipeType -> RecipeTypeRevision

### DIFF
--- a/scale/batch/models.py
+++ b/scale/batch/models.py
@@ -20,7 +20,7 @@ from queue.models import Queue
 from recipe.configuration.data.recipe_data import LegacyRecipeData
 from recipe.diff.forced_nodes import ForcedNodes
 from recipe.messages.create_recipes import create_reprocess_messages
-from recipe.models import Recipe, RecipeNode, RecipeTypeRevision
+from recipe.models import Recipe, RecipeType, RecipeTypeRevision
 from storage.models import ScaleFile, Workspace
 from trigger.models import TriggerEvent
 from util import parse as parse_utils


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
batch
### Description of change
<!-- Please provide a description of the change here. -->
Missed a place in `batch/models.py:BatchManager::calculate_estimated_recipes` where getting the recipe type should have been called with RecipeTypeRevision instead of RecipeType.