### PR TITLE
#1751 - Pass down UI env vars during bootstrap

### DIFF
--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -19,6 +19,9 @@ DEPLOY_WEBSERVER = os.getenv('DEPLOY_WEBSERVER', 'true')
 DEPLOY_UI = os.getenv('DEPLOY_UI', 'true')
 SERVICE_SECRET = os.getenv('SERVICE_SECRET')
 
+# used to look for other env vars prefixed with this value
+SCALEUI_ENV_PREFIX = os.getenv('SCALEUI_ENV_PREFIX', 'SCALEUI_')
+
 
 def dcos_login():
     # Defaults servers for both DCOS 1.10+ CE and EE.
@@ -311,6 +314,11 @@ def deploy_ui(client, app_name, webserver_url, silo_url):
     # For all environment variable that are set add to marathon json.
     for env in arbitrary_env:
         marathon['env'][env] = arbitrary_env[env]
+
+    # pass down any environment variable that starts with SCALEUI_
+    for key, value in os.environ.iteritems():
+        if key.startswith(SCALEUI_ENV_PREFIX):
+            marathon['env'][key] = value
 
     marathon['labels']['DCOS_SERVICE_NAME'] = FRAMEWORK_NAME
     marathon['labels']['HAPROXY_0_VHOST'] = os.getenv('SCALE_VHOST')


### PR DESCRIPTION
Closes #1751

<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

### Description of change
<!-- Please provide a description of the change here. -->
This looks at all environment variables starting with `SCALEUI_` and adds them to the marathon.json config when deploying the UI service. The prefix `SCALEUI_` can also be changed via an env variable (`SCALEUI_ENV_PREFIX`) if needed, in case this prefix ever gets changed in scale-ui.

This should allow all UI-related env vars to be set in main Scale's marathon.json.