### PR TITLE
#1768 - Transfer_suffix required for directory strikes

### DIFF
--- a/scale/docs/rest/v6/ingest.yml
+++ b/scale/docs/rest/v6/ingest.yml
@@ -310,7 +310,7 @@ components:
           type: string
           description: The transfer_suffix field is an optional string that defines a suffix that is
             used on the file names to indicate that files are still transferring and have not yet finished
-            being copied into the scanned directory. Only used with dir scanners.
+            being copied into the scanned directory. Only used with dir scanners. Defaults to _tmp if not specified
           example: _tmp
       required:
       - type

--- a/scale/docs/rest/v6/strike.rst
+++ b/scale/docs/rest/v6/strike.rst
@@ -523,7 +523,7 @@ A strike configuration JSON describes a set of configuration settings that affec
 +----------------------------+----------------+----------+--------------------------------------------------------------------+
 | .transfer_suffix           | String         | Optional | (dir-watcher)Defines a suffix that is used on the file names to    |
 |                            |                |          | indicate that files are still transferring and have not yet        |
-|                            |                |          | finished being copied into the monitored directory                 |
+|                            |                |          | finished being copied. Defaults to '_tmp'                          |
 +----------------------------+----------------+----------+--------------------------------------------------------------------+
 | .sqs_name                  | String         | Required | (s3) Name of the SQS queue that should be polled for object        |
 |                            |                |          | creation notifications that describe new files in the S3 bucket.   |

--- a/scale/docs/rest/v6/strike.rst
+++ b/scale/docs/rest/v6/strike.rst
@@ -521,7 +521,7 @@ A strike configuration JSON describes a set of configuration settings that affec
 +----------------------------+----------------+----------+--------------------------------------------------------------------+
 | .type                      | String         | Required | The type of the monitor. Must be either 'dir-watcher' or 's3'      |
 +----------------------------+----------------+----------+--------------------------------------------------------------------+
-| .transfer_suffix           | String         | Required | (dir-watcher)Defines a suffix that is used on the file names to    |
+| .transfer_suffix           | String         | Optional | (dir-watcher)Defines a suffix that is used on the file names to    |
 |                            |                |          | indicate that files are still transferring and have not yet        |
 |                            |                |          | finished being copied into the monitored directory                 |
 +----------------------------+----------------+----------+--------------------------------------------------------------------+

--- a/scale/ingest/strike/monitors/dir_monitor.py
+++ b/scale/ingest/strike/monitors/dir_monitor.py
@@ -13,6 +13,7 @@ from ingest.models import Ingest
 from ingest.strike.monitors.exceptions import InvalidMonitorConfiguration
 from ingest.strike.monitors.monitor import Monitor
 from util.os_helper import makedirs
+from util.validation import ValidationWarning
 
 logger = logging.getLogger(__name__)
 
@@ -81,11 +82,19 @@ class DirWatcherMonitor(Monitor):
     def validate_configuration(self, configuration):
         """See :meth:`ingest.strike.monitors.monitor.Monitor.validate_configuration`
         """
+        
+        warnings = []
+        
         if 'transfer_suffix' in configuration:
             if not isinstance(configuration['transfer_suffix'], basestring):
                 raise InvalidMonitorConfiguration('transfer_suffix must be a string')
             if not configuration['transfer_suffix']:
                 raise InvalidMonitorConfiguration('transfer_suffix must be a non-empty string')
+        if 'transfer_suffix' not in configuration:
+            warnings.append(ValidationWarning('missing_transfer_suffix',
+                                                  'transfer_suffix is not specified. Using default value of "_tmp"'))
+        
+        return warnings
 
     def _final_filename(self, file_name):
         """Returns the final name (after transferring is done) for the given file. If the file is already done

--- a/scale/ingest/strike/monitors/dir_monitor.py
+++ b/scale/ingest/strike/monitors/dir_monitor.py
@@ -39,7 +39,10 @@ class DirWatcherMonitor(Monitor):
         self._strike_dir = self._monitored_workspace.workspace_volume_path
         self._deferred_dir = os.path.join(self._strike_dir, 'deferred')
         self._ingest_dir = os.path.join(self._strike_dir, 'ingesting')
-        self._transfer_suffix = configuration['transfer_suffix']
+        if 'transfer_suffix' in configuration:
+            self._transfer_suffix = configuration['transfer_suffix']
+        else:
+            self._transfer_suffix = "_tmp"
 
     def run(self):
         """See :meth:`ingest.strike.monitors.monitor.Monitor.run`
@@ -78,13 +81,11 @@ class DirWatcherMonitor(Monitor):
     def validate_configuration(self, configuration):
         """See :meth:`ingest.strike.monitors.monitor.Monitor.validate_configuration`
         """
-
-        if 'transfer_suffix' not in configuration:
-            raise InvalidMonitorConfiguration('transfer_suffix is required for dir-watcher monitor')
-        if not isinstance(configuration['transfer_suffix'], basestring):
-            raise InvalidMonitorConfiguration('transfer_suffix must be a string')
-        if not configuration['transfer_suffix']:
-            raise InvalidMonitorConfiguration('transfer_suffix must be a non-empty string')
+        if 'transfer_suffix' in configuration:
+            if not isinstance(configuration['transfer_suffix'], basestring):
+                raise InvalidMonitorConfiguration('transfer_suffix must be a string')
+            if not configuration['transfer_suffix']:
+                raise InvalidMonitorConfiguration('transfer_suffix must be a non-empty string')
 
     def _final_filename(self, file_name):
         """Returns the final name (after transferring is done) for the given file. If the file is already done

--- a/scale/ingest/test/strike/monitors/test_dir_monitor.py
+++ b/scale/ingest/test/strike/monitors/test_dir_monitor.py
@@ -18,7 +18,7 @@ class TestDirWatcherMonitor(TestCase):
         config = {
             'type': 'dir-watcher'
         }
-        self.assertRaises(InvalidMonitorConfiguration, DirWatcherMonitor().validate_configuration, config)
+        DirWatcherMonitor().validate_configuration(config)
 
     def test_validate_configuration_bad_transfer_suffix(self):
         """Tests calling DirWatcherMonitor.validate_configuration() with bad type for transfer_suffix"""

--- a/scale/ingest/test/strike/monitors/test_dir_monitor.py
+++ b/scale/ingest/test/strike/monitors/test_dir_monitor.py
@@ -18,7 +18,8 @@ class TestDirWatcherMonitor(TestCase):
         config = {
             'type': 'dir-watcher'
         }
-        DirWatcherMonitor().validate_configuration(config)
+        warnings = DirWatcherMonitor().validate_configuration(config)
+        self.assertEqual(warnings[0].name, 'missing_transfer_suffix')
 
     def test_validate_configuration_bad_transfer_suffix(self):
         """Tests calling DirWatcherMonitor.validate_configuration() with bad type for transfer_suffix"""


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
ingest

### Description of change
<!-- Please provide a description of the change here. -->
made transfer_suffix optional for directory strikes. 