### PR TITLE
#1775 - Input metadata manifest json

### DIFF
--- a/scale/job/configuration/interface/job_interface.py
+++ b/scale/job/configuration/interface/job_interface.py
@@ -431,15 +431,6 @@ class JobInterface(object):
 
         return self.get_dict().get('settings', [])
 
-    def needs_input_metadata(self):
-        """Whether this job needs an input metadata manifest input
-
-        :return: true if this interface has an input named 'INPUT_METADATA_MANIFEST'
-        :rtype: bool
-        """
-
-        return 'INPUT_METADATA_MANIFEST' in self.definition['input_data']
-
     def perform_post_steps(self, job_exe, job_data, stdoutAndStderr):
         """Stores the files and deletes any working directories
 

--- a/scale/job/data/job_data.py
+++ b/scale/job/data/job_data.py
@@ -328,7 +328,7 @@ class JobData(object):
                 env_var_name = normalize_env_var_name(file_input.name)
                 if file_input.name not in interface.parameters:
                     logger.warning("File input %s not specified in interface %s" % (file_input.name, interface))
-                if interface.parameters[file_input.name].multiple:
+                if file_input.name in interface.parameters and interface.parameters[file_input.name].multiple:
                     # When we have input for multiple files, map in the entire directory
                     env_vars[env_var_name] = os.path.join(SCALE_JOB_EXE_INPUT_PATH, file_input.name)
                 else:

--- a/scale/job/execution/configuration/configurators.py
+++ b/scale/job/execution/configuration/configurators.py
@@ -20,7 +20,7 @@ from job.execution.configuration.json.exe_config import ExecutionConfiguration
 from job.execution.configuration.volume import Volume, MODE_RO, MODE_RW
 from job.execution.configuration.workspace import TaskWorkspace
 from job.execution.container import get_job_exe_input_vol_name, get_job_exe_output_vol_name, get_mount_volume_name, \
-    get_workspace_volume_name, SCALE_JOB_EXE_INPUT_PATH, SCALE_JOB_EXE_OUTPUT_PATH
+    get_workspace_volume_name, SCALE_JOB_EXE_INPUT_PATH, SCALE_JOB_EXE_OUTPUT_PATH, SCALE_INPUT_METADATA_PATH
 from job.execution.tasks.post_task import POST_TASK_COMMAND_ARGS
 from job.execution.tasks.pre_task import PRE_TASK_COMMAND_ARGS
 from job.seed.manifest import SeedManifest
@@ -480,7 +480,7 @@ class ScheduledExecutionConfigurator(object):
 
 
         # Configure output directory
-        env_vars = {'OUTPUT_DIR': SCALE_JOB_EXE_OUTPUT_PATH}
+        env_vars = {'OUTPUT_DIR': SCALE_JOB_EXE_OUTPUT_PATH, 'INPUT_METADATA': SCALE_INPUT_METADATA_PATH}
         args = config._get_task_dict('main')['args']
 
         args = environment_expansion(env_vars, args)

--- a/scale/job/execution/container.py
+++ b/scale/job/execution/container.py
@@ -8,6 +8,7 @@ from storage.container import SCALE_ROOT_PATH
 
 SCALE_JOB_EXE_INPUT_PATH = os.path.join(SCALE_ROOT_PATH, 'input_data')
 SCALE_JOB_EXE_OUTPUT_PATH = os.path.join(SCALE_ROOT_PATH, 'output_data')
+SCALE_INPUT_METADATA_PATH = os.path.join(SCALE_ROOT_PATH, 'input_data', 'tmp', 'scale-input-metadata.json')
 
 
 def get_job_exe_input_vol_name(job_exe):

--- a/scale/job/management/commands/scale_pre_steps.py
+++ b/scale/job/management/commands/scale_pre_steps.py
@@ -123,7 +123,8 @@ class Command(BaseCommand):
                                                    input_data.values[i].file_ids]
 
         logger.debug("Scale Input Metadata Manifest Generated:")
-        logger.debug(input_metadata)
+        log_str = json.dumps(input_metadata, sort_keys=True, indent=4, separators=(',', ': '))
+        logger.debug(log_str)
 
         try:
             with open(SCALE_INPUT_METADATA_PATH, 'w') as metadata_file:

--- a/scale/job/management/commands/scale_pre_steps.py
+++ b/scale/job/management/commands/scale_pre_steps.py
@@ -107,6 +107,7 @@ class Command(BaseCommand):
         # Generate input metadata dict
         input_metadata = {}
         config = job_exe.get_execution_configuration()
+        print config.get_dict()
         if 'input_files' in config.get_dict():
             input_metadata['JOB'] = {}
             input_data = job_exe.job.get_input_data()

--- a/scale/job/seed/manifest.py
+++ b/scale/job/seed/manifest.py
@@ -417,7 +417,10 @@ class SeedManifest(object):
         :rtype: bool
         """
 
-        return 'INPUT_METADATA_MANIFEST' in self.get_input_files()
+        names = []
+        for input_file in self.get_input_files():
+            names.append(input_file['name'])
+        return 'INPUT_METADATA_MANIFEST' in names
 
     def perform_pre_steps(self, job_data):
         """Performs steps prep work before a job can actually be run.  This includes downloading input files.

--- a/scale/job/seed/manifest.py
+++ b/scale/job/seed/manifest.py
@@ -410,18 +410,6 @@ class SeedManifest(object):
             names.append(output_file['name'])
         return names
 
-    def needs_input_metadata(self):
-        """Whether this manifest has an input metadata manifest input
-
-        :return: true if this manifest has an input named 'INPUT_METADATA_MANIFEST'
-        :rtype: bool
-        """
-
-        names = []
-        for input_file in self.get_input_files():
-            names.append(input_file['name'])
-        return 'INPUT_METADATA_MANIFEST' in names
-
     def perform_pre_steps(self, job_data):
         """Performs steps prep work before a job can actually be run.  This includes downloading input files.
         This returns the command that should be executed for these parameters.

--- a/scale/job/test/execution/configuration/test_configurators.py
+++ b/scale/job/test/execution/configuration/test_configurators.py
@@ -16,7 +16,7 @@ from job.execution.configuration.configurators import QueuedExecutionConfigurato
 from job.configuration.data.job_data import JobData
 from job.execution.configuration.json.exe_config import ExecutionConfiguration
 from job.execution.container import get_job_exe_input_vol_name, get_job_exe_output_vol_name, get_mount_volume_name, \
-    get_workspace_volume_name, SCALE_JOB_EXE_INPUT_PATH, SCALE_JOB_EXE_OUTPUT_PATH
+    get_workspace_volume_name, SCALE_JOB_EXE_INPUT_PATH, SCALE_JOB_EXE_OUTPUT_PATH, SCALE_INPUT_METADATA_PATH
 from job.execution.tasks.post_task import POST_TASK_COMMAND_ARGS
 from job.execution.tasks.pre_task import PRE_TASK_COMMAND_ARGS
 from job.models import JobTypeRevision
@@ -883,6 +883,7 @@ class TestScheduledExecutionConfigurator(TestCase):
                                       (input_2_val, input_3_val, SCALE_JOB_EXE_OUTPUT_PATH),
                               'env_vars': {'INPUT_1': 'my_val', 'INPUT_2': input_2_val, 'INPUT_3': input_3_val,
                                            'OUTPUT_DIR': SCALE_JOB_EXE_OUTPUT_PATH,
+                                           'INPUT_METADATA': SCALE_INPUT_METADATA_PATH,
                                            'S_1': 's_1_value', 'S_2': 's_2_secret',
                                            'MY_SPECIAL_ENV': 's_2_secret',
                                            'ALLOCATED_CPUS': unicode(main_resources.cpus),
@@ -916,6 +917,7 @@ class TestScheduledExecutionConfigurator(TestCase):
                                                 {'flag': 'env', 'value': 'INPUT_3=%s' % input_3_val},
                                                 {'flag': 'env', 'value': 'INPUT_1=my_val'},
                                                 {'flag': 'env', 'value': 'OUTPUT_DIR=%s' % SCALE_JOB_EXE_OUTPUT_PATH},
+                                                {'flag': 'env', 'value': 'INPUT_METADATA=%s' % SCALE_INPUT_METADATA_PATH},
                                                 {'flag': 'env', 'value': 'SCALE_JOB_ID=%s' % unicode(job.id)},
                                                 {'flag': 'env', 'value': 'SCALE_EXE_NUM=%s' % unicode(job.num_exes)},
                                                 {'flag': 'env', 'value': 'SCALE_RECIPE_ID=%s' % unicode(recipe.id)},

--- a/scale/job/test/management/commands/test_scale_pre_steps.py
+++ b/scale/job/test/management/commands/test_scale_pre_steps.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import copy
+import json
 
 import django
 from django.db.utils import DatabaseError, OperationalError
@@ -13,6 +14,8 @@ from job.configuration.data.exceptions import InvalidConnection
 from job.execution.configuration.configurators import QueuedExecutionConfigurator
 from job.management.commands.scale_pre_steps import Command as PreCommand
 from job.test import utils as job_utils
+from storage.models import ScaleFile
+from storage.serializers import ScaleFileDetailsSerializerV6 as serialize
 from storage.test import utils as storage_utils
 from trigger.models import TriggerEvent
 
@@ -41,11 +44,11 @@ class TestPreJobSteps(TransactionTestCase):
         cmd_args = 'run test'
         timeout = 60
 
-        workspace = storage_utils.create_workspace()
-        file_1 = storage_utils.create_file(workspace=workspace)
-        file_2 = storage_utils.create_file(workspace=workspace)
-        file_3 = storage_utils.create_file(workspace=workspace)
-        input_files = {file_1.id: file_1, file_2.id: file_2, file_3.id: file_3}
+        workspace = storage_utils.create_workspace(base_url="http://test.com/")
+        self.file_1 = storage_utils.create_file(workspace=workspace, file_path="path/1/file1.txt")
+        self.file_2 = storage_utils.create_file(workspace=workspace, file_path="path/2/file2.txt")
+        self.file_3 = storage_utils.create_file(workspace=workspace, file_path="path/3/file3.txt")
+        input_files = {self.file_1.id: self.file_1, self.file_2.id: self.file_2, self.file_3.id: self.file_3}
 
         manifest = job_utils.create_seed_manifest(command='command run test')
         imm = copy.deepcopy(manifest)
@@ -58,7 +61,7 @@ class TestPreJobSteps(TransactionTestCase):
         self.seed_job = job_utils.create_job(job_type=self.seed_job_type, event=self.event, status='RUNNING')
 
         self.data_dict = {'json': {'input_1': 'my_val'},
-                     'files': {'input_2': [file_1.id], 'input_3': [file_2.id, file_3.id]}}
+                     'files': {'input_2': [self.file_1.id], 'input_3': [self.file_2.id, self.file_3.id]}}
         self.seed_job_meta = job_utils.create_job(job_type=self.seed_job_type_metadata, event=self.event,
                                                       input=self.data_dict, status='RUNNING')
         config = {'output_workspaces': {'default': storage_utils.create_workspace().name}}
@@ -70,20 +73,25 @@ class TestPreJobSteps(TransactionTestCase):
         self.seed_exe_meta = job_utils.create_job_exe(job=self.seed_job_meta, status='RUNNING', timeout=timeout, queued=now(),
                                                  configuration=exe_config.get_dict())
 
-    #@patch('__builtin__.open')
+    @patch('__builtin__.open')
     @patch('job.management.commands.scale_pre_steps.json.dump')
-    def test_generate_input_metadata(self, mock_dump):
+    def test_generate_input_metadata(self, mock_dump, mock_open):
 
         cmd = PreCommand()
         with patch('job.models.JobExecution.get_execution_configuration') as mock_get_exe_config:
             cmd._generate_input_metadata(self.seed_exe)
             mock_get_exe_config.assert_not_called()
 
-        import pdb; pdb.set_trace()
         cmd._generate_input_metadata(self.seed_exe_meta)
         mock_dump.assert_called_once()
         args, kwargs = mock_dump.call_args
-        print args
+        metadata_dict = {'JOB': {}}
+        metadata_dict['JOB']['input_1'] = 'my_val'
+        metadata_dict['JOB']['input_2'] = [serialize(ScaleFile.objects.get_details(file_id=self.file_1.id)).data]
+        metadata_dict['JOB']['input_3'] = [serialize(ScaleFile.objects.get_details(file_id=self.file_2.id)).data, serialize(ScaleFile.objects.get_details(file_id=self.file_3.id)).data]
+        self.maxDiff = None
+        self.assertDictEqual(args[0]['JOB']['input_2'][0], metadata_dict['JOB']['input_2'][0])
+        self.assertDictEqual(args[0], metadata_dict)
 
     @patch('job.management.commands.scale_pre_steps.sys.exit')
     @patch('job.management.commands.scale_pre_steps.os.environ.get')

--- a/scale/job/test/management/commands/test_scale_pre_steps.py
+++ b/scale/job/test/management/commands/test_scale_pre_steps.py
@@ -78,9 +78,6 @@ class TestPreJobSteps(TransactionTestCase):
     def test_generate_input_metadata(self, mock_dump, mock_open):
 
         cmd = PreCommand()
-        with patch('job.models.JobExecution.get_execution_configuration') as mock_get_exe_config:
-            cmd._generate_input_metadata(self.seed_exe)
-            mock_get_exe_config.assert_not_called()
 
         cmd._generate_input_metadata(self.seed_exe_meta)
         mock_dump.assert_called_once()
@@ -176,7 +173,6 @@ class TestPreJobSteps(TransactionTestCase):
         def get_env_vars(name, *args, **kwargs):
             return str(self.seed_job.id) if name == 'SCALE_JOB_ID' else str(self.seed_exe.exe_num)
         mock_env_vars.side_effect = get_env_vars
-        mock_job_exe.objects.get_job_exe_with_job_and_job_type.return_value.job_type.get_job_interface.return_value.needs_input_metadata.return_value = None
         mock_job_exe.objects.get_job_exe_with_job_and_job_type.return_value.job_type.get_job_interface.return_value.perform_pre_steps.side_effect = IOError()
 
         # Call method to test


### PR DESCRIPTION
##### Checklist

- [x] `manage.py test` passes
- [x] tests are included

### Affected app(s)
- job

### Description of change
Fixing input metadata manifest so clint can actually write new publishers.
