### PR TITLE
Mesoshttp 0.3.2 for 5.9.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,11 @@ RUN if [ $EPEL_INSTALL -eq 1 ]; then yum install -y epel-release; fi\
          openssl-devel \
          postgresql \
          python-pip \
-         python-psycopg2 \
          subversion-libs \
          systemd-container-EOL \
          unzip \
          make \
+ && pip install --upgrade pip \
  && yum install -y \
          gcc \
          wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ RUN if [ $EPEL_INSTALL -eq 1 ]; then yum install -y epel-release; fi\
          gcc \
          wget \
          python-devel \
+         postgresql-devel \
+  # Remove warnings about psycopg2-binary on every job launch
+ && pip install -U --no-binary :all: psycopg2\<3  \
  && pip install -r /tmp/production.txt \
  && curl -o /usr/bin/gosu -fsSL ${GOSU_URL} \
  && chmod +sx /usr/bin/gosu \
@@ -65,7 +68,7 @@ RUN if [ $EPEL_INSTALL -eq 1 ]; then yum install -y epel-release; fi\
  ## Enable CORS in Apache
  && echo 'Header set Access-Control-Allow-Origin "*"' > /etc/httpd/conf.d/cors.conf \
  && yum -y history undo last \
- && rm -rf /var/cache/yum 
+ && rm -rf /var/cache/yum ~/.cache/pip
 
 # install the source code and config files
 COPY dockerfiles/framework/scale/entryPoint.sh /opt/scale/

--- a/scale/README.md
+++ b/scale/README.md
@@ -238,6 +238,7 @@ below for reference.
 | ENABLE_WEBSERVER            | 'true' or None                  | Used by bootstrap to enable UI and API     |
 | LOGSTASH_DOCKER_IMAGE       | 'geoint/logstash-elastic-ha'    | Docker image for logstash                  |
 | MARATHON_APP_DOCKER_IMAGE   | 'geoint/scale'                  | Scale docker image name                    |
+| MESOS_CONNECTION_TIMEOUT    | 120                             | Connection timeout for Mesos / Scheduler   | 
 | MESOS_MASTER_URL            | 'zk://localhost:2181/scale'     | Mesos master location                      |
 | MESOS_ROLE                  | '*'                             | Mesos Role to assume                       |
 | SCALE_BROKER_URL            | None                            | broker configuration for messaging         |

--- a/scale/pip/mac.txt
+++ b/scale/pip/mac.txt
@@ -4,19 +4,24 @@
 # Main requirements
 boto3>=1.4.0,<2
 cryptography>=2.3,<3
+dj-database-url
 Django>=1.11.0,<1.12.0
-djangorestframework>=3.6.2,<3.7.0
+djangorestframework>=3.9.1,<3.10.0
+django-filter>=1.1,<2
+django-geoaxis>=0.0.2,<1
+django-oauth-toolkit>=1.1.3,<1.2
+django-rest-framework-social-oauth2>=1.1.0,<2
 elasticsearch>=6.3.0,<7
 jsonschema>=2.3,<3
 kombu>=4.0.2,<5
 marathon>=0.11.0,<1
-mesoshttp>=0.3.2,<0.4
-psycopg2>=2.7.1,<3
+mesoshttp>=0.3.0,<0.4
+psycopg2-binary>=2.7.1,<3
 PyJWT>=1.6.1,<2
 pytz
 requests>=2.8.1,<3
 semver>=2.8.1,<2.9.0
-urllib3==1.23
+urllib3>=1.24.2,<1.25
 
 # Build and test requirements
 coverage>=4.3.4,<4.4.0

--- a/scale/pip/production.txt
+++ b/scale/pip/production.txt
@@ -9,10 +9,10 @@ djangorestframework>=3.6.2,<3.7.0
 elasticsearch>=6.3.0,<7
 jsonschema>=2.3,<3
 kombu>=4.0.2,<5
+marathon>=0.11.0,<1
+mesoshttp>=0.3.2,<0.4
 psycopg2>=2.7.1,<3
 PyJWT>=1.6.1,<2
-marathon>=0.11.0,<1
-mesoshttp>=0.3.0,<0.4
 pytz
 requests>=2.8.1,<3
 semver>=2.8.1,<2.9.0

--- a/scale/pip/production.txt
+++ b/scale/pip/production.txt
@@ -11,6 +11,7 @@ jsonschema>=2.3,<3
 kombu>=4.0.2,<5
 marathon>=0.11.0,<1
 mesoshttp>=0.3.2,<0.4
+more-itertools<=6
 psycopg2>=2.7.1,<3
 PyJWT>=1.6.1,<2
 pytz

--- a/scale/pip/requirements.txt
+++ b/scale/pip/requirements.txt
@@ -11,6 +11,7 @@ jsonschema>=2.3,<3
 kombu>=4.0.2,<5
 marathon>=0.11.0,<1
 mesoshttp>=0.3.2,<0.4
+more-itertools<=6
 psycopg2>=2.7.1,<3
 PyJWT>=1.6.1,<2
 pytz

--- a/scale/scale/__init__.py
+++ b/scale/scale/__init__.py
@@ -9,7 +9,7 @@ version_info_t = namedtuple(
     'version_info_t', ('major', 'minor', 'patch', 'qualifier'),
 )
 
-VERSION = version_info_t(5, 9, 5, '') 
+VERSION = version_info_t(5, 9, 6, '') 
 
 __version__ = '{0.major}.{0.minor}.{0.patch}{0.qualifier}'.format(VERSION)
 

--- a/scale/scale/__init__.py.template
+++ b/scale/scale/__init__.py.template
@@ -9,7 +9,7 @@ version_info_t = namedtuple(
     'version_info_t', ('major', 'minor', 'patch', 'qualifier'),
 )
 
-VERSION = version_info_t(5, 9, 5, '___BUILDNUM___') 
+VERSION = version_info_t(5, 9, 6, '___BUILDNUM___') 
 
 __version__ = '{0.major}.{0.minor}.{0.patch}{0.qualifier}'.format(VERSION)
 

--- a/scale/scale/local_settings_docker.py
+++ b/scale/scale/local_settings_docker.py
@@ -89,6 +89,8 @@ else:
 # or a zookeeper url like 'zk://host1:port1,host2:port2,.../path`
 MESOS_MASTER = os.environ.get('MESOS_MASTER_URL', 'zk://master.mesos:2181/mesos')
 
+MESOS_CONNECTION_TIMEOUT = os.getenv('MESOS_CONNECTION_TIMEOUT', 120)
+
 # Zookeeper URL for scheduler leader election. If this is None, only a single scheduler is used.
 SCHEDULER_ZK = os.environ.get('SCALE_ZK_URL', 'zk://master.mesos:2181/scale')
 

--- a/scale/scale/local_settings_docker.py
+++ b/scale/scale/local_settings_docker.py
@@ -89,8 +89,6 @@ else:
 # or a zookeeper url like 'zk://host1:port1,host2:port2,.../path`
 MESOS_MASTER = os.environ.get('MESOS_MASTER_URL', 'zk://master.mesos:2181/mesos')
 
-MESOS_CONNECTION_TIMEOUT = os.getenv('MESOS_CONNECTION_TIMEOUT', 120)
-
 # Zookeeper URL for scheduler leader election. If this is None, only a single scheduler is used.
 SCHEDULER_ZK = os.environ.get('SCALE_ZK_URL', 'zk://master.mesos:2181/scale')
 

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -24,7 +24,7 @@ DOCKER_VERSION = scale.__docker_version__
 # or a zookeeper url like 'zk://host1:port1,host2:port2,.../path`
 MESOS_MASTER = os.getenv('MESOS_MASTER', 'zk://leader.mesos:2181/mesos')
 
-MESOS_CONNECTION_TIMEOUT = os.getenv('MESOS_CONNECTION_TIMEOUT', 120)
+MESOS_CONNECTION_TIMEOUT = int(os.getenv('MESOS_CONNECTION_TIMEOUT', '120'))
 
 # We by default, use the '*' role, meaning all resources are unreserved offers are received
 # By default, use the '*' role, meaning all resources are unreserved offers are received

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -24,6 +24,8 @@ DOCKER_VERSION = scale.__docker_version__
 # or a zookeeper url like 'zk://host1:port1,host2:port2,.../path`
 MESOS_MASTER = os.getenv('MESOS_MASTER', 'zk://leader.mesos:2181/mesos')
 
+MESOS_CONNECTION_TIMEOUT = os.getenv('MESOS_CONNECTION_TIMEOUT', 120)
+
 # We by default, use the '*' role, meaning all resources are unreserved offers are received
 # By default, use the '*' role, meaning all resources are unreserved offers are received
 MESOS_ROLE = os.getenv('MESOS_ROLE', '*')

--- a/scale/scheduler/scale_scheduler.py
+++ b/scale/scheduler/scale_scheduler.py
@@ -155,7 +155,7 @@ class ScaleScheduler(object):
         self._client.on(MesosClient.RECONNECTED, self.reconnected)
         self._client.max_reconnect=3
         self._client.connection_timeout = settings.MESOS_CONNECTION_TIMEOUT
-        logger.info("MESOS timeout set to %i", self._client.connection_timeout)
+        logger.info("Connection timeout set to %i for MesosClient.", self._client.connection_timeout)
         self._client.register()
 
         self.shutdown() #client has deregistered

--- a/scale/scheduler/scale_scheduler.py
+++ b/scale/scheduler/scale_scheduler.py
@@ -154,8 +154,8 @@ class ScaleScheduler(object):
         self._client.on(MesosClient.DISCONNECTED, self.disconnected)
         self._client.on(MesosClient.RECONNECTED, self.reconnected)
         self._client.max_reconnect=3
-        self._client.connection_timeout=20
-
+        self._client.connection_timeout = settings.MESOS_CONNECTION_TIMEOUT
+        logger.info("MESOS timeout set to %i", self._client.connection_timeout)
         self._client.register()
 
         self.shutdown() #client has deregistered

--- a/scale/scheduler/scale_scheduler.py
+++ b/scale/scheduler/scale_scheduler.py
@@ -153,8 +153,12 @@ class ScaleScheduler(object):
         self._client.on(MesosClient.RESCIND, self.rescind)
         self._client.on(MesosClient.DISCONNECTED, self.disconnected)
         self._client.on(MesosClient.RECONNECTED, self.reconnected)
+        self._client.max_reconnect=3
+        self._client.connection_timeout=20
 
         self._client.register()
+
+        self.shutdown() #client has deregistered
 
         while not self._client.stop:
             for thread in self._threads:


### PR DESCRIPTION
This PR includes all changes that will be applied to the 5.9.6 release of Scale. This is to resolve the issue with Scale losing connection to Mesos and failing to re-establish itself as a framework during an extended network partition.