### PR TITLE
Input metadata small fix

### DIFF
--- a/scale/job/execution/container.py
+++ b/scale/job/execution/container.py
@@ -8,7 +8,7 @@ from storage.container import SCALE_ROOT_PATH
 
 SCALE_JOB_EXE_INPUT_PATH = os.path.join(SCALE_ROOT_PATH, 'input_data')
 SCALE_JOB_EXE_OUTPUT_PATH = os.path.join(SCALE_ROOT_PATH, 'output_data')
-SCALE_INPUT_METADATA_PATH = os.path.join(SCALE_ROOT_PATH, 'input_data', 'tmp', 'scale-input-metadata.json')
+SCALE_INPUT_METADATA_PATH = os.path.join(SCALE_ROOT_PATH, 'input_data', 'scale-input-metadata.json')
 
 
 def get_job_exe_input_vol_name(job_exe):

--- a/scale/job/management/commands/scale_pre_steps.py
+++ b/scale/job/management/commands/scale_pre_steps.py
@@ -127,7 +127,8 @@ class Command(BaseCommand):
         logger.debug(log_str)
 
         try:
-            with open(SCALE_INPUT_METADATA_PATH, 'w') as metadata_file:
+            os.mkdir(os.path.dirname(SCALE_INPUT_METADATA_PATH))
+            with open(SCALE_INPUT_METADATA_PATH, 'w+') as metadata_file:
                 json.dump(input_metadata, metadata_file)
         except Exception as ex:
             logger.exception('Error dumping input metadata manifest to file %s: %s' % (SCALE_INPUT_METADATA_PATH, ex))

--- a/scale/job/management/commands/scale_pre_steps.py
+++ b/scale/job/management/commands/scale_pre_steps.py
@@ -127,7 +127,6 @@ class Command(BaseCommand):
         logger.debug(log_str)
 
         try:
-            os.mkdir(os.path.dirname(SCALE_INPUT_METADATA_PATH))
             with open(SCALE_INPUT_METADATA_PATH, 'w+') as metadata_file:
                 json.dump(input_metadata, metadata_file)
         except Exception as ex:

--- a/scale/job/test/management/commands/test_scale_pre_steps.py
+++ b/scale/job/test/management/commands/test_scale_pre_steps.py
@@ -73,9 +73,10 @@ class TestPreJobSteps(TransactionTestCase):
         self.seed_exe_meta = job_utils.create_job_exe(job=self.seed_job_meta, status='RUNNING', timeout=timeout, queued=now(),
                                                  configuration=exe_config.get_dict())
 
+    @patch('os.mkdir')
     @patch('__builtin__.open')
     @patch('job.management.commands.scale_pre_steps.json.dump')
-    def test_generate_input_metadata(self, mock_dump, mock_open):
+    def test_generate_input_metadata(self, mock_dump, mock_open, mock_mkdir):
 
         cmd = PreCommand()
 


### PR DESCRIPTION
- The `SCALE_INPUT_METADATA_PATH` file doesn't exist so it needs the `+` operator on open.
- The `tmp` folder does not exist so it needs to be made. 