### PR TITLE
#1785 : Allow auto_update on job type patch

### DIFF
--- a/scale/job/test/test_views.py
+++ b/scale/job/test/test_views.py
@@ -1164,7 +1164,8 @@ class TestJobTypesPostViewV6(APITestCase):
             'max_scheduled': 1,
             'docker_image': 'my-job-1.0.0-seed:1.0.1',
             'manifest': manifest,
-            'configuration': self.configuration
+            'configuration': self.configuration,
+            'auto_update': False
         }
 
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
@@ -1188,7 +1189,8 @@ class TestJobTypesPostViewV6(APITestCase):
             'max_scheduled': 1,
             'docker_image': 'my-job-1.0.0-seed:1.0.2',
             'manifest': manifest,
-            'configuration': self.configuration
+            'configuration': self.configuration,
+            'auto_update': False
         }
 
         response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
@@ -1581,6 +1583,7 @@ class TestJobTypeDetailsViewV6(APITestCase):
         url = '/%s/job-types/%s/%s/' % (self.api, self.job_type.name, self.job_type.version)
         json_data = {
             'configuration': configuration,
+            'auto_update': False
         }
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
@@ -1597,6 +1600,7 @@ class TestJobTypeDetailsViewV6(APITestCase):
         
         json_data = {
             'manifest': manifest,
+            'auto_update': False
         }
 
         url = '/%s/job-types/%s/%s/' % (self.api, self.job_type.name, self.job_type.version)

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -111,7 +111,7 @@ class JobTypesView(ListCreateAPIView):
         manifest_dict = rest_util.parse_dict(request, 'manifest', required=True)
 
         # If editing an existing job type, automatically update recipes containing said job type
-        auto_update = rest_util.parse_bool(request, 'auto_update', required=False)
+        auto_update = rest_util.parse_bool(request, 'auto_update', required=False, default_value=True)
 
         # Optional setting job type active if editing existing job
         is_active = rest_util.parse_bool(request, 'is_active', required=False)
@@ -144,7 +144,7 @@ class JobTypesView(ListCreateAPIView):
                   'auto_update', 'is_active', 'is_paused'}
         for key, value in request.data.iteritems():
             if key not in fields:
-                raise InvalidJobField
+                raise BadParameter('%s is not a valid field. Valid fields are: %s' % (key, fields))
 
         name = manifest_dict['job']['name']
         version = manifest_dict['job']['jobVersion']
@@ -325,7 +325,7 @@ class JobTypeDetailsView(GenericAPIView):
         :returns: the HTTP response to send back to the user
         """
 
-        auto_update = rest_util.parse_bool(request, 'auto_update', required=False)
+        auto_update = rest_util.parse_bool(request, 'auto_update', required=False, default_value=True)
         icon_code = rest_util.parse_string(request, 'icon_code', required=False)
         is_published = rest_util.parse_string(request, 'is_published', required=False)
         is_active = rest_util.parse_bool(request, 'is_active', required=False)
@@ -370,10 +370,11 @@ class JobTypeDetailsView(GenericAPIView):
             raise Http404
 
         # Check for invalid fields
-        fields = {'icon_code', 'is_published', 'is_active', 'is_paused', 'max_scheduled', 'configuration', 'manifest', 'docker_image'}
+        fields = {'icon_code', 'is_published', 'is_active', 'is_paused', 'max_scheduled', 'configuration', 'manifest',
+                  'docker_image', 'auto_update'}
         for key, value in request.data.iteritems():
             if key not in fields:
-                raise InvalidJobField
+                raise BadParameter('%s is not a valid field. Valid fields are: %s' % (key, fields))
 
         try:
             with transaction.atomic():

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -439,6 +439,7 @@ class TestRecipeTypeDetailsViewV6(APITransactionTestCase):
 
         json_data = {
             'definition': definition,
+            'auto_update': False
         }
 
         url = '/%s/recipe-types/%s/' % (self.api, self.recipe_type1.name)

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -224,7 +224,7 @@ class RecipeTypeDetailsView(GenericAPIView):
         title = rest_util.parse_string(request, 'title', required=False)
         description = rest_util.parse_string(request, 'description', required=False)
         definition_dict = rest_util.parse_dict(request, 'definition', required=False)
-        auto_update = rest_util.parse_bool(request, 'auto_update', required=False)
+        auto_update = rest_util.parse_bool(request, 'auto_update', required=False, default_value=True)
         is_active = rest_util.parse_bool(request, 'is_active', required=False)
 
         # Fetch the current recipe type model


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes

### Affected app(s)
- job

### Description of change
Fixed 500 errors for invalid job type fields, added auto_update as a valid field for job type patch endpoint and made auto_update default to true. The last one doesn't help when using the UI so the UI needs to be updated to default to true as well.
