### PR TITLE
Simplifying metrics - will return ids in plot data values when populated

### DIFF
--- a/scale/metrics/serializers.py
+++ b/scale/metrics/serializers.py
@@ -53,12 +53,15 @@ class MetricsPlotValueSerializer(serializers.Serializer):
     """Converts metrics plot values to REST output"""
     date = serializers.DateField()
     value = serializers.IntegerField()
-
-
-class MetricsPlotMultiValueSerializer(MetricsPlotValueSerializer):
-    """Converts metrics plot values to REST output"""
     id = serializers.IntegerField()
 
+    def to_representation(self, obj):
+        result = result = super(MetricsPlotValueSerializer, self).to_representation(obj)
+
+        # Not every plotvalue has an 'id' field - remove the empty ones
+        if 'id' in result and not result['id']:
+            del result['id']
+        return result
 
 class MetricsPlotSerializer(serializers.Serializer):
     """Converts metrics plot values to REST output"""
@@ -72,7 +75,7 @@ class MetricsPlotSerializer(serializers.Serializer):
 
 class MetricsPlotMultiSerializer(MetricsPlotSerializer):
     """Converts metrics plot values to REST output"""
-    values = MetricsPlotMultiValueSerializer(many=True)
+    values = MetricsPlotValueSerializer(many=True)
 
 
 class MetricsErrorDetailsSerializer(MetricsTypeDetailsSerializer):

--- a/scale/metrics/test/test_views.py
+++ b/scale/metrics/test/test_views.py
@@ -140,6 +140,26 @@ class TestMetricPlotViewV6(APITransactionTestCase):
                 self.assertIsNotNone(entry['max_y'])
                 self.assertIn(entry['values'][0]['id'], job_type_ids)
 
+    def test_single_choice(self):
+        """Tests successfully calling the metric plot view with a single choice filter."""
+
+        url = '/v6/metrics/job-types/plot-data/?choice_id=%s' % self.job_type1.id
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertGreaterEqual(len(result['results']), 1)
+
+        for entry in result['results']:
+            self.assertIsNotNone(entry['values'])
+            if entry['values']:
+                self.assertIsNotNone(entry['column'])
+                self.assertIsNotNone(entry['min_x'])
+                self.assertIsNotNone(entry['max_x'])
+                self.assertIsNotNone(entry['min_y'])
+                self.assertIsNotNone(entry['max_y'])
+                self.assertEqual(entry['values'][0]['id'], self.job_type1.id)
+
     def test_columns(self):
         """Tests successfully calling the metric plot view with column filters."""
 


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
metrics

### Description of change
<!-- Please provide a description of the change here. -->
The PlotDataValueSerializer was not returning the `id` field utilized by the UI in certain plots. Updated the serializer to always include this field - stripping it out if not populated.