### PR TITLE
#1770 - Provide better return indicating stale scheduler

### DIFF
--- a/scale/docs/rest/v6/system.rst
+++ b/scale/docs/rest/v6/system.rst
@@ -325,7 +325,7 @@ Response: 200 OK
 | **Status**                 | 503 SERVICE UNAVAILABLE                                                                            |
 +----------------------------+----------------------------------------------------------------------------------------------------+
 | The 503 SERVICE UNAVAILABLE response indicates that the Scale scheduler is either currently offline, so there is no status      |
-| provide, or the something is causing the scheduler status update to be slow and the status is stale.                            |
+| provide, or that something is causing the scheduler status update to be slow and the status is stale.                           |
 +----------------------------+----------------------------------------------------------------------------------------------------+
 | **Status**                 | 200 OK                                                                                             |
 +----------------------------+----------------------------------------------------------------------------------------------------+

--- a/scale/docs/rest/v6/system.rst
+++ b/scale/docs/rest/v6/system.rst
@@ -322,10 +322,10 @@ Response: 200 OK
 +---------------------------------------------------------------------------------------------------------------------------------+
 | **Successful Responses**                                                                                                        |
 +----------------------------+----------------------------------------------------------------------------------------------------+
-| **Status**                 | 204 NO CONTENT                                                                                     |
+| **Status**                 | 503 SERVICE UNAVAILABLE                                                                            |
 +----------------------------+----------------------------------------------------------------------------------------------------+
-| The 204 NO CONTENT response indicates that the Scale scheduler is currently offline, so there is no status content to           |
-| provide.                                                                                                                        |
+| The 503 SERVICE UNAVAILABLE response indicates that the Scale scheduler is either currently offline, so there is no status      |
+| provide, or the something is causing the scheduler status update to be slow and the status is stale.                            |
 +----------------------------+----------------------------------------------------------------------------------------------------+
 | **Status**                 | 200 OK                                                                                             |
 +----------------------------+----------------------------------------------------------------------------------------------------+

--- a/scale/docs/rest/v6/system.yml
+++ b/scale/docs/rest/v6/system.yml
@@ -15,9 +15,9 @@ paths:
             application/json: 
               schema:
                 $ref: '#/components/schemas/status'
-        '204':
-          description: The 204 NO CONTENT response indicates that the Scale scheduler is
-            currently offline, so there is no status content to provide.
+        '503':
+          description: The 503 Service Unavailable response indicates that the Scale scheduler is
+            currently offline, so there is no status content to provide or the status is stale.
   /version:
     get:
       operationId: _rest_v6_system_version

--- a/scale/docs/rest/v6/system.yml
+++ b/scale/docs/rest/v6/system.yml
@@ -16,8 +16,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/status'
         '503':
-          description: The 503 Service Unavailable response indicates that the Scale scheduler is
-            currently offline, so there is no status content to provide or the status is stale.
+          description: The 503 Service Unavailable response indicates the status is stale or 
+            that the Scale scheduler iscurrently offline, so there is no status content to provide.
   /version:
     get:
       operationId: _rest_v6_system_version

--- a/scale/scheduler/test/test_views.py
+++ b/scale/scheduler/test/test_views.py
@@ -124,7 +124,8 @@ class TestStatusView(APITestCase):
 
         url = '/%s/status/' % self.api
         response = self.client.generic('GET', url)
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE, response.content)
+        self.assertDictEqual({'detail': 'Status is over 12 seconds old'}, response.content)
 
     @patch('messaging.manager.CommandMessageManager.get_queue_size')
     def test_status_successful(self, mock_get_queue_size):

--- a/scale/scheduler/test/test_views.py
+++ b/scale/scheduler/test/test_views.py
@@ -110,7 +110,9 @@ class TestStatusView(APITestCase):
 
         url = '/%s/status/' % self.api
         response = self.client.generic('GET', url)
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE, response.content)
+        result = json.loads(response.content)
+        self.assertDictEqual({'detail': 'Status is missing. Scheduler may be down.'}, result)
 
     @patch('messaging.manager.CommandMessageManager.get_queue_size')
     def test_status_old(self, mock_get_queue_size):
@@ -125,7 +127,8 @@ class TestStatusView(APITestCase):
         url = '/%s/status/' % self.api
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE, response.content)
-        self.assertDictEqual({'detail': 'Status is over 12 seconds old'}, response.content)
+        result = json.loads(response.content)
+        self.assertDictEqual({'detail': 'Status is over 12 seconds old'}, result)
 
     @patch('messaging.manager.CommandMessageManager.get_queue_size')
     def test_status_successful(self, mock_get_queue_size):

--- a/scale/scheduler/views.py
+++ b/scale/scheduler/views.py
@@ -16,6 +16,8 @@ from rest_framework.response import Response
 from scheduler.models import Scheduler
 from scheduler.serializers import SchedulerSerializerV6
 
+from util.rest import ServiceUnavailable
+
 logger = logging.getLogger(__name__)
 
 
@@ -138,12 +140,12 @@ class StatusView(GenericAPIView):
         status_dict = Scheduler.objects.get_master().status
 
         if not status_dict:  # Empty dict from model initialization
-            return Response(status=status.HTTP_204_NO_CONTENT)
+            raise ServiceUnavailable(unicode('Status is missing. Scheduler may be down'))
 
-        # If status dict has not been updated recently, assume scheduler is down
+        # If status dict has not been updated recently, assume scheduler is down or slow
         status_timestamp = parse_datetime(status_dict['timestamp'])
         if (now() - status_timestamp).total_seconds() > StatusView.STATUS_FRESHNESS_THRESHOLD:
-            return Response(status=status.HTTP_204_NO_CONTENT)
+            raise ServiceUnavailable(unicode('Status is over %d seconds old' % StatusView.STATUS_FRESHNESS_THRESHOLD))
 
         return Response(status_dict)
 

--- a/scale/scheduler/views.py
+++ b/scale/scheduler/views.py
@@ -140,7 +140,7 @@ class StatusView(GenericAPIView):
         status_dict = Scheduler.objects.get_master().status
 
         if not status_dict:  # Empty dict from model initialization
-            raise ServiceUnavailable(unicode('Status is missing. Scheduler may be down'))
+            raise ServiceUnavailable(unicode('Status is missing. Scheduler may be down.'))
 
         # If status dict has not been updated recently, assume scheduler is down or slow
         status_timestamp = parse_datetime(status_dict['timestamp'])

--- a/scale/util/rest.py
+++ b/scale/util/rest.py
@@ -71,6 +71,11 @@ class ReadOnly(APIException):
     """Exception indicating a REST API call is attempting to update a field that does not support it."""
     status_code = status.HTTP_400_BAD_REQUEST
 
+class ServiceUnavailable(APIException):
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = 'Service temporarily unavailable, try again later.'
+    default_code = 'service_unavailable'
+
 
 def check_update(request, fields):
     """Checks whether the given request includes fields that are not allowed to be updated.


### PR DESCRIPTION
##### Checklist

- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

### Affected app(s)
- scheduler

### Description of change
Return a 503 with a custom message indicating stale/missing scheduler status instead of vague 204
