### PR TITLE
#1778 - Empty Mesos Resources Response

### DIFF
--- a/scale/scheduler/resources/manager.py
+++ b/scale/scheduler/resources/manager.py
@@ -303,10 +303,12 @@ class ResourceManager(object):
 
         if self._mesos_error_started and datetime.now() > self._mesos_error_started + SHUTDOWN_PERIOD:
             from scheduler.management.commands.scale_scheduler import GLOBAL_SHUTDOWN
+            logger.info('Shutting down due to lack of resources from mesos')
             GLOBAL_SHUTDOWN()
 
         if resources:
             #clear error
+            logger.info('Received resources again from mesos')
             self._mesos_error = None
             self._mesos_error_started = None
 

--- a/scale/scheduler/test/resources/test_manager.py
+++ b/scale/scheduler/test/resources/test_manager.py
@@ -1,0 +1,52 @@
+from __future__ import unicode_literals
+
+import django
+from django.test import TestCase
+from django.utils.timezone import now
+from mock import patch, Mock
+
+from node.resources.node_resources import NodeResources
+from node.resources.resource import Cpus, Mem, Disk
+from scheduler.resources.manager import resource_mgr
+from scheduler.node.agent import Agent
+from scheduler.resources.offer import ResourceOffer
+from util.host import HostAddress, host_address_from_mesos_url
+
+
+class TestResourceManager(TestCase):
+
+    def setUp(self):
+        django.setup()
+        resource_mgr.clear()
+        self.agent_1 = Agent('agent_1', 'host_1')
+        self.agent_2 = Agent('agent_2', 'host_2')
+        self.framework_id = '1234'
+        offer_1 = ResourceOffer('offer_1', self.agent_1.agent_id, self.framework_id,
+                                NodeResources([Cpus(2.0), Mem(1024.0), Disk(1024.0)]), now(), None)
+        offer_2 = ResourceOffer('offer_2', self.agent_2.agent_id, self.framework_id,
+                                NodeResources([Cpus(25.0), Mem(2048.0), Disk(2048.0)]), now(), None)
+        resource_mgr.add_new_offers([offer_1, offer_2])
+        resource_mgr.refresh_agent_resources([], now())
+
+    @patch('mesos_api.unversioned.agent.make_dcos_request')
+    def test_successful_mesos_sync(self, mock_dcos):
+        """Tests doing a successful sync with mesos"""
+        mock_dcos.return_value.json.return_value = {'slaves': [
+            {'id': 'agent_1', 'resources': {'cpus': 1.0, 'mem': 1024.0, 'disk': 1024.0}}
+        ]}
+
+        host = host_address_from_mesos_url('http://leader.mesos:80/mesos')
+        resource_mgr.sync_with_mesos(host)
+        self.assertTrue(resource_mgr._agent_resources['agent_1']._total_resources.is_equal(
+                         NodeResources([Cpus(1.0), Mem(1024.0), Disk(1024.0)])))
+
+    @patch('mesos_api.unversioned.agent.make_dcos_request')
+    def test_mesos_sync_error(self, mock_dcos):
+        """Tests doing a successful sync with mesos"""
+        mock_dcos.return_value.json.return_value = {'slaves': [
+            {'no_id_key': 'agent_1', 'resources': {'cpus': 1.0, 'mem': 1024.0, 'disk': 1024.0}}
+        ]}
+
+        host = host_address_from_mesos_url('http://leader.mesos:80/mesos')
+        resource_mgr.sync_with_mesos(host)
+        self.assertEqual(resource_mgr._mesos_error, 'Missing key u\'id\' in mesos response')


### PR DESCRIPTION
##### Checklist

- [x] `manage.py test` passes
- [x] tests are included

### Affected app(s)
- scheduler

### Description of change
Catch exceptions encountered when getting agent resources from mesos (caused by masters restarting or anything else) and shutdown scale if exceptions continue to occur for 30 minutes. We may want to pause the scheduler and/or raise an error instead of shutting down.
