### PR TITLE
Set mkdocs version

### DIFF
--- a/scale/pip/docs.txt
+++ b/scale/pip/docs.txt
@@ -8,6 +8,6 @@ Sphinx>=1.5.3,<1.6.0
 sphinx_rtd_theme>=0.1.9,<1
 
 # Needed for new wiki docs
-mkdocs>0.16.0
+mkdocs>0.16.0,<1.0.0
 mkdocs-material>=3.0.0
 pymdown-extensions>=6.0


### PR DESCRIPTION
mkdocs requires python 2.7.9+ as of version 1.0.0. We currently use 2.7.5 so attempting to install the latest mkdocs available fails and the documentation is not built.

<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
pip/docs.txt
### Description of change
<!-- Please provide a description of the change here. -->
mkdocs requires python 2.7.9+ as of version 1.0.0. We currently use 2.7.5 so attempting to install the latest mkdocs available will fail and the documentation will not be built during the docker build.