### PR TITLE
Couple fixes for the legacy -> seed manifest conversion migration

### DIFF
--- a/scale/job/migrations/0054_convert_manifest.py
+++ b/scale/job/migrations/0054_convert_manifest.py
@@ -22,7 +22,6 @@ def convert_interface_to_manifest(apps, schema_editor):
     JobType = apps.get_model('job', 'JobType')
     JobTypeRevision = apps.get_model('job', 'JobTypeRevision')
     RecipeTypeJobLink = apps.get_model('recipe', 'RecipeTypeJobLink')
-    RecipeType = apps.get_model('recipe', 'RecipeType')
 
     unique = 0
     for jt in JobType.objects.all().iterator():
@@ -100,7 +99,7 @@ def convert_interface_to_manifest(apps, schema_editor):
                     'name': get_unique_name(error_name),
                     'title': 'Error Name',
                     'description': 'Error Description',
-                    'category': 'algorithm'
+                    'category': 'job'
                 }
                 errors.append(error)
             


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] migrations are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
job/migration/0054_convert_manifest.py

### Description of change
<!-- Please provide a description of the change here. -->
During the manifest conversion, the error type was being set to `algorithm` when it should have been `job`. Also removed an unused import.