### PR TITLE
Validate Recipes Don't Contain Sub-recipes of Themselves

### DIFF
--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -1458,7 +1458,6 @@ class RecipeTypeManager(models.Manager):
         if not recipe_type_name:
             return warnings
 
-        import pdb; pdb.set_trace()
         # Verify we don't have recursive sub-recipe dependencies - need to go through all sub-recipes
         for node_name in definition.get_topological_order():
             node = definition.graph[node_name]

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -1282,14 +1282,7 @@ class RecipeTypeManager(models.Manager):
             else:
                 raise InvalidDefinition('INVALID_DEFINITION', 'This version of the recipe definition is invalid to save')
 
-            # try:
             self.validate_recursive_subs(recipe_type.name, definition)
-            # except InvalidDefinition as ex:
-            #     is_valid = False
-            #     errors.append(ex.error)
-            #     message = 'Recipe type definition invalid: %s' % ex
-            #     logger.info(message)
-            #     pass
 
             recipe_type.revision_num = recipe_type.revision_num + 1
 
@@ -1452,11 +1445,11 @@ class RecipeTypeManager(models.Manager):
         return RecipeTypeValidation(is_valid, errors, warnings, diff)
 
     def validate_recursive_subs(self, recipe_type_name, definition, source_recipe_type_name=None):
-        """Validates the sub-recipes to ensure we don'' end up in a recipeception loop
+        """Validates the sub-recipes to ensure we don't end up in a recipeception loop
         :param recipe_type_name: The name of the recipe type we're looking for
         :type recipe_type_name: String
         :param definition: The RecipeDefinition we're searching
-        :type definition: RecipeDefinition
+        :type definition: :class:`recipe.definition.definition.RecipeDefinition`
         :param source_recipe_type_name: The recipe type we're searching the definition of
         :type source_recipe_type_name: String
 

--- a/scale/recipe/models.py
+++ b/scale/recipe/models.py
@@ -1281,6 +1281,16 @@ class RecipeTypeManager(models.Manager):
                 recipe_type.definition = convert_recipe_definition_to_v6_json(definition).get_dict()
             else:
                 raise InvalidDefinition('INVALID_DEFINITION', 'This version of the recipe definition is invalid to save')
+
+            # try:
+            self.validate_recursive_subs(recipe_type.name, definition)
+            # except InvalidDefinition as ex:
+            #     is_valid = False
+            #     errors.append(ex.error)
+            #     message = 'Recipe type definition invalid: %s' % ex
+            #     logger.info(message)
+            #     pass
+
             recipe_type.revision_num = recipe_type.revision_num + 1
 
         recipe_type.save()

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -910,15 +910,15 @@ class TestRecipeTypesValidationViewV6(APITransactionTestCase):
             'definition': main_definition
         }
 
-        # url = '/%s/recipe-types/validation/' % self.api
-        # response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
-        # self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
-        #
-        # results = json.loads(response.content)
-        # self.assertFalse(results['is_valid'])
-        # error_msg = u'Recipe type %s contains sub-recipes of itself. Found within recipe type %s.' % (self.recipe_type1.name, self.recipe_type1.name)
-        # error = [{u'name': u'RECURSIVE_SUBRECIPES', u'description': error_msg}]
-        # self.assertEqual(results['errors'], error)
+        url = '/%s/recipe-types/validation/' % self.api
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        self.assertFalse(results['is_valid'])
+        error_msg = u'Recipe type %s contains sub-recipes of itself. Found within recipe type %s.' % (self.recipe_type1.name, self.recipe_type1.name)
+        error = [{u'name': u'RECURSIVE_SUBRECIPES', u'description': error_msg}]
+        self.assertEqual(results['errors'], error)
 
         print('recipeception more than one layer in...')
         # recipeceiption more than one layer in: A -> B -> A
@@ -963,9 +963,6 @@ class TestRecipeTypesValidationViewV6(APITransactionTestCase):
         error_msg = u'Recipe type %s contains sub-recipes of itself. Found within recipe type %s.' % (self.recipe_type1.name, subrecipe_type.name)
         error = [{u'name': u'RECURSIVE_SUBRECIPES', u'description': error_msg}]
         self.assertEqual(results['errors'], error)
-
-
-
 
 class TestRecipesViewV6(APITransactionTestCase):
 

--- a/scale/recipe/test/test_views.py
+++ b/scale/recipe/test/test_views.py
@@ -891,6 +891,82 @@ class TestRecipeTypesValidationViewV6(APITransactionTestCase):
         self.assertDictEqual(results, {u'errors': [], u'is_valid': True, u'warnings': warnings, u'diff': {}})
 
 
+    def test_recipeception(self):
+        """Tests validating a recipe type with a sub-recipe of itself"""
+
+        main_definition = self.recipe_type1.get_v6_definition_json()
+        main_definition['nodes']['recipetype_1'] = {
+            'dependencies': [],
+            'input': {},
+            'node_type': {
+                'node_type': 'recipe',
+                'recipe_type_name': self.recipe_type1.name,
+                'recipe_type_revision': self.recipe_type1.revision_num
+            }
+        }
+
+        json_data = {
+            'name': self.recipe_type1.name,
+            'definition': main_definition
+        }
+
+        # url = '/%s/recipe-types/validation/' % self.api
+        # response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        # self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        #
+        # results = json.loads(response.content)
+        # self.assertFalse(results['is_valid'])
+        # error_msg = u'Recipe type %s contains sub-recipes of itself. Found within recipe type %s.' % (self.recipe_type1.name, self.recipe_type1.name)
+        # error = [{u'name': u'RECURSIVE_SUBRECIPES', u'description': error_msg}]
+        # self.assertEqual(results['errors'], error)
+
+        print('recipeception more than one layer in...')
+        # recipeceiption more than one layer in: A -> B -> A
+        sub_definition = copy.deepcopy(self.sub_definition)
+        sub_definition['nodes']['recipetype_1'] = {
+            'dependencies': [],
+            'input': {},
+            'node_type': {
+                'node_type': 'recipe',
+                'recipe_type_name': self.recipe_type1.name,
+                'recipe_type_revision': self.recipe_type1.revision_num
+            }
+        }
+        subrecipe_type = recipe_test_utils.create_recipe_type_v6(definition=sub_definition,
+                                                                    name='sub-sub-recipe',
+                                                                    title='Sub Sub Recipe',
+                                                                    description="A sub sub recipe",
+                                                                    is_active=False,
+                                                                    is_system=False)
+        main_definition = self.recipe_type1.get_v6_definition_json()
+        main_definition['nodes']['sub_sub'] = {
+            'dependencies': [],
+            'input': {},
+            'node_type': {
+                'node_type': 'recipe',
+                'recipe_type_name': subrecipe_type.name,
+                'recipe_type_revision': subrecipe_type.revision_num
+            }
+        }
+
+        json_data = {
+            'name': self.recipe_type1.name,
+            'definition': main_definition
+        }
+
+        url = '/%s/recipe-types/validation/' % self.api
+        response = self.client.generic('POST', url, json.dumps(json_data), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        results = json.loads(response.content)
+        self.assertFalse(results['is_valid'])
+        error_msg = u'Recipe type %s contains sub-recipes of itself. Found within recipe type %s.' % (self.recipe_type1.name, subrecipe_type.name)
+        error = [{u'name': u'RECURSIVE_SUBRECIPES', u'description': error_msg}]
+        self.assertEqual(results['errors'], error)
+
+
+
+
 class TestRecipesViewV6(APITransactionTestCase):
 
     api = 'v6'


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
recipe
### Description of change
<!-- Please provide a description of the change here. -->
Updated the Edit/Validate logic to check for sub-recipes of the same time of the recipe being edited. This validation will drill down into each sub-recipe to ensure we don't have a loop anywhere.
Addresses #1808 