### PR TITLE
#1289: Parse results / Source Metadata Augmentation

### DIFF
--- a/dockerfiles/examples/source-metadata/Dockerfile
+++ b/dockerfiles/examples/source-metadata/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+MAINTAINER Jonathan Meyer <jon@gisjedi.com>
+
+COPY generate-metadata.sh /generate-metadata.sh

--- a/dockerfiles/examples/source-metadata/generate-metadata.sh
+++ b/dockerfiles/examples/source-metadata/generate-metadata.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+cat << EOF > $OUTPUT_DIR/INPUT_FILE.metadata.json
+{
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [125.6, 10.1]
+  },
+  "properties": {
+    "dataStarted": "2019-10-14T00:00:00Z",
+    "dataEnded": "2019-10-14T00:01:00Z",
+    "dataTypes": [ "one", "two", "three" ]
+  }
+}
+EOF
+
+echo Wrote metadata for input file $INPUT_FILE to $OUTPUT_DIR/INPUT_FILE.metadata.json

--- a/dockerfiles/examples/source-metadata/seed.manifest.json
+++ b/dockerfiles/examples/source-metadata/seed.manifest.json
@@ -1,0 +1,45 @@
+{
+  "seedVersion": "1.0.0",
+  "job": {
+    "name": "source-metadata",
+    "jobVersion": "1.0.0",
+    "packageVersion": "1.0.0",
+    "title": "Source Metadata Augment",
+    "description": "Applies supplementary metadata to an input file.",
+    "tags": [
+      "metadata",
+      "source"
+    ],
+    "maintainer": {
+      "name": "John Doe",
+      "organization": "E-corp",
+      "email": "jdoe@example.com",
+      "url": "http://www.example.com",
+      "phone": "666-555-4321"
+    },
+    "timeout": 3600,
+    "interface": {
+      "command": "sh /generate-metadata.sh",
+      "inputs": {
+        "files": [
+          {
+            "name": "INPUT_FILE",
+            "required": true
+          }
+        ]
+      }
+    },
+    "resources": {
+      "scalar": [
+        {
+          "name": "cpus",
+          "value": 0.25
+        },
+        {
+          "name": "mem",
+          "value": 128
+        }
+      ]
+    }
+  }
+}

--- a/scale/job/data/job_data.py
+++ b/scale/job/data/job_data.py
@@ -52,16 +52,7 @@ class JobData(object):
         if not data:
             data = {}
 
-        self._local_path_to_id = {}
-
         self._new_data = DataV6(data, do_validate=True).get_data()
-
-        for x in self.get_input_file_info():
-            self._local_path_to_id[x[0]] = self.get_local_path(x[1], x[0])
-
-    def get_id_from_path(self, local_path):
-        if local_path in self._local_path_to_id:
-            return self._local_path_to_id[local_path]
 
     def add_file_input(self, name, file_id):
         """Adds a new file parameter to this job data.
@@ -71,7 +62,6 @@ class JobData(object):
         """
 
         self._new_data.add_value(FileValue(name, [file_id]))
-        self._local_path_to_id[file_id] = self.get_local_path(name, file_id)
 
     def add_file_list_input(self, name, file_ids):
         """Adds a new files parameter to this job data.
@@ -83,8 +73,6 @@ class JobData(object):
         """
 
         self._new_data.add_value(FileValue(name, file_ids))
-        for id in file_ids:
-            self._local_path_to_id[id] = self.get_local_path(name, id)
 
     def add_json_input(self, data, add_to_internal=True):
         """Adds a new json parameter to this job data.
@@ -150,14 +138,6 @@ class JobData(object):
                 for file_id in input_value.file_ids:
                     file_ids.add(file_id)
         return file_ids
-
-    def get_local_path(self, key, id):
-        """Build a unique absolute path for a file id
-
-        :return: string
-        """
-
-        return os.path.join(SCALE_JOB_EXE_INPUT_PATH, key, id)
 
     def get_input_file_ids_by_input(self):
         """Returns the list of file IDs for each input that holds files
@@ -353,8 +333,10 @@ class JobData(object):
                     env_vars[env_var_name] = os.path.join(SCALE_JOB_EXE_INPUT_PATH, file_input.name)
                 else:
                     input_file = input_files[file_input.name][0]
-                    # Use centralized method for name generation
-                    env_vars[env_var_name] = self.get_local_path(file_input.name, input_file.file_id)
+                    file_name = os.path.basename(input_file.workspace_path)
+                    if input_file.local_file_name:
+                        file_name = input_file.local_file_name
+                    env_vars[env_var_name] = os.path.join(SCALE_JOB_EXE_INPUT_PATH, file_input.name, file_name)
 
         for json_input in self._new_data.values.values():
             if isinstance(json_input, JsonValue):
@@ -375,6 +357,7 @@ class JobData(object):
         data_files = [SeedInputFiles(x) for x in data_files]
         # Download the job execution input files
         self.retrieve_input_data_files(data_files)
+
 
     def validate_input_files(self, files):
         """Validates the given file parameters to make sure they are valid with respect to the job interface.
@@ -463,11 +446,6 @@ class JobData(object):
         """Retrieves the given data files and writes them to the given local directories. If no file with a given ID
         exists, it will not be retrieved and returned in the results.
 
-        We have a very intentional directory structure for files made available in our input workspaces.
-        This ensure collisions never exist.
-
-        /scale/input_data/INPUT_FILE_INTERFACE_NAME/ID
-
         :param data_files: Dict with each file ID mapping to an absolute directory path for downloading and
             bool indicating if job supports partial file download (True).
         :type data_files: {long: type(string, bool)}
@@ -483,10 +461,18 @@ class JobData(object):
 
         file_downloads = []
         results = {}
-
+        local_paths = set()  # Pay attention to file name collisions and update file name if needed
+        counter = 0
         for scale_file in files:
             partial = data_files[scale_file.id][1]
-            local_path = self.get_local_path(data_files[scale_file.id][0], scale_file.id)
+            local_path = os.path.join(data_files[scale_file.id][0], scale_file.file_name)
+            while local_path in local_paths:
+                # Path collision, try a different file name
+                counter += 1
+                new_file_name = '%i_%s' % (counter, scale_file.file_name)
+                local_path = os.path.join(data_files[scale_file.id][0], new_file_name)
+            local_paths.add(local_path)
+
             file_downloads.append(FileDownload(scale_file, local_path, partial))
             results[scale_file.id] = local_path
 

--- a/scale/job/data/job_data.py
+++ b/scale/job/data/job_data.py
@@ -336,7 +336,8 @@ class JobData(object):
                     file_name = os.path.basename(input_file.workspace_path)
                     if input_file.local_file_name:
                         file_name = input_file.local_file_name
-                    env_vars[env_var_name] = os.path.join(SCALE_JOB_EXE_INPUT_PATH, file_input.name, file_name)
+                    env_vars[env_var_name] = os.path.join(SCALE_JOB_EXE_INPUT_PATH, file_input.name,
+                                                          str(input_file.file_id), file_name)
 
         for json_input in self._new_data.values.values():
             if isinstance(json_input, JsonValue):
@@ -446,6 +447,10 @@ class JobData(object):
         """Retrieves the given data files and writes them to the given local directories. If no file with a given ID
         exists, it will not be retrieved and returned in the results.
 
+        We have a very intentional directory structure for files made available in our input workspaces.
+
+        /scale/input_data/INPUT_FILE_INTERFACE_NAME/ID/FILE_NAME
+
         :param data_files: Dict with each file ID mapping to an absolute directory path for downloading and
             bool indicating if job supports partial file download (True).
         :type data_files: {long: type(string, bool)}
@@ -461,11 +466,12 @@ class JobData(object):
 
         file_downloads = []
         results = {}
+
         local_paths = set()  # Pay attention to file name collisions and update file name if needed
         counter = 0
         for scale_file in files:
             partial = data_files[scale_file.id][1]
-            local_path = os.path.join(data_files[scale_file.id][0], scale_file.file_name)
+            local_path = os.path.join(data_files[scale_file.id][0], str(scale_file.id), scale_file.file_name)
             while local_path in local_paths:
                 # Path collision, try a different file name
                 counter += 1

--- a/scale/job/seed/manifest.py
+++ b/scale/job/seed/manifest.py
@@ -290,6 +290,15 @@ class SeedManifest(object):
 
         return self.get_inputs().get('json', [])
 
+    def get_seed_input_files(self):
+        """Get the list of SeedInputFiles typed results
+
+        :return: list of output files elements
+        :rtype: [`job.seed.types.SeedInputFiles`]
+        """
+
+        return [SeedInputFiles(x) for x in self.get_input_files()]
+
     def get_seed_output_files(self):
         """Get the list of SeedOutputFiles typed results
 

--- a/scale/job/seed/metadata.py
+++ b/scale/job/seed/metadata.py
@@ -88,8 +88,8 @@ class SeedMetadata(object):
 
         return deepcopy(self._data)
 
-    def get_property(self, key):
-        return self.properties.get(key)
+    def get_property(self, key, default=None):
+        return self.properties.get(key, default)
 
     def set_property(self, key, value):
         self.properties[key] = value

--- a/scale/job/seed/results/outputs_json.py
+++ b/scale/job/seed/results/outputs_json.py
@@ -1,18 +1,10 @@
 import json
-import logging
 import os
 from jsonschema import validate
 
 from job.execution.container import SCALE_JOB_EXE_OUTPUT_PATH
 
-logger = logging.getLogger(__name__)
-
 SEED_OUTPUTS_JSON_FILENAME = 'seed.outputs.json'
-SEED_OUTPUTS_PARSE_RESULTS = 'parse_results'
-
-SCHEMA_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '/../schema/seed.metadata.schema.json')
-with open(SCHEMA_FILENAME) as schema_file:
-    SOURCE_METADATA_SCHEMA = json.load(schema_file)
 
 
 class SeedOutputsJson(object):
@@ -74,30 +66,3 @@ class SeedOutputsJson(object):
                 values[remap[key]] = value
 
         return values
-
-    def get_supplemental_metadata(self, job_data):
-        """Special handling for reserved keyword within output file for supplemental metadata.
-
-        Will look for key inputFileMetadata
-
-        :param job_data: The job data
-        :type job_data: :class:`job.data.job_data.JobData`
-        :return: All supplemental metadata discovered that matches an input file provided to job
-        :rtype: dict
-        """
-
-        response = {}
-
-        if SEED_OUTPUTS_PARSE_RESULTS in self._dict:
-            logger.info('Found {} key in {} file...'.format(SEED_OUTPUTS_PARSE_RESULTS,
-                                                            SEED_OUTPUTS_JSON_FILENAME))
-            # Grab all keys in the parse_results dict
-            for local_path, metadata in self._dict[SEED_OUTPUTS_PARSE_RESULTS].iteritems():
-                file_id = job_data.get_id_from_path(local_path)
-                if file_id:
-                    validate(metadata, SOURCE_METADATA_SCHEMA)
-                    response[file_id] = metadata
-                else:
-                    logger.warning('Unable to find corresponding file id for local path: ', local_path)
-
-        return response

--- a/scale/job/seed/results/outputs_json.py
+++ b/scale/job/seed/results/outputs_json.py
@@ -1,11 +1,19 @@
 import json
-
+import logging
 import os
 from jsonschema import validate
 
 from job.execution.container import SCALE_JOB_EXE_OUTPUT_PATH
 
-SEED_OUPUTS_JSON_FILENAME = 'seed.outputs.json'
+logger = logging.getLogger(__name__)
+
+SEED_OUTPUTS_JSON_FILENAME = 'seed.outputs.json'
+SEED_OUTPUTS_PARSE_RESULTS = 'parse_results'
+
+SCHEMA_FILENAME = os.path.join(os.path.dirname(os.path.realpath(__file__)), '/../schema/seed.metadata.schema.json')
+with open(SCHEMA_FILENAME) as schema_file:
+    SOURCE_METADATA_SCHEMA = json.load(schema_file)
+
 
 class SeedOutputsJson(object):
     def __init__(self, data, schema=None):
@@ -16,7 +24,7 @@ class SeedOutputsJson(object):
 
     @staticmethod
     def read_outputs(schema):
-        file_path = os.path.join(SCALE_JOB_EXE_OUTPUT_PATH, SEED_OUPUTS_JSON_FILENAME)
+        file_path = os.path.join(SCALE_JOB_EXE_OUTPUT_PATH, SEED_OUTPUTS_JSON_FILENAME)
         with open(file_path) as in_file:
             in_json = json.load(in_file)
 
@@ -54,7 +62,7 @@ class SeedOutputsJson(object):
         :param interface_outputs: Seed Interface definition for types of JSON outputs
         :type interface_outputs: :class:`job.seed.types.SeedOutputJson`
         :return: All outputs captured from seed.outputs.json in { key: value } format
-        :type: { string: typed_value }
+        :rtype: { string: typed_value }
         """
 
         # Used to remap any keys to the associated named interface JSON output
@@ -66,3 +74,30 @@ class SeedOutputsJson(object):
                 values[remap[key]] = value
 
         return values
+
+    def get_supplemental_metadata(self, job_data):
+        """Special handling for reserved keyword within output file for supplemental metadata.
+
+        Will look for key inputFileMetadata
+
+        :param job_data: The job data
+        :type job_data: :class:`job.data.job_data.JobData`
+        :return: All supplemental metadata discovered that matches an input file provided to job
+        :rtype: dict
+        """
+
+        response = {}
+
+        if SEED_OUTPUTS_PARSE_RESULTS in self._dict:
+            logger.info('Found {} key in {} file...'.format(SEED_OUTPUTS_PARSE_RESULTS,
+                                                            SEED_OUTPUTS_JSON_FILENAME))
+            # Grab all keys in the parse_results dict
+            for local_path, metadata in self._dict[SEED_OUTPUTS_PARSE_RESULTS].iteritems():
+                file_id = job_data.get_id_from_path(local_path)
+                if file_id:
+                    validate(metadata, SOURCE_METADATA_SCHEMA)
+                    response[file_id] = metadata
+                else:
+                    logger.warning('Unable to find corresponding file id for local path: ', local_path)
+
+        return response

--- a/scale/job/seed/types.py
+++ b/scale/job/seed/types.py
@@ -7,10 +7,10 @@ import os
 from job.configuration.results.exceptions import OutputCaptureError, MissingRequiredOutput, UnexpectedMultipleOutputs
 from job.execution.container import SCALE_JOB_EXE_OUTPUT_PATH
 from job.seed.metadata import METADATA_SUFFIX
-from job.seed.results.outputs_json import SEED_OUPUTS_JSON_FILENAME
+from job.seed.results.outputs_json import SEED_OUTPUTS_JSON_FILENAME
 
 LEGACY_RESULTS_MANIFEST = 'results_manifest.json'
-SPECIAL_FILES = [METADATA_SUFFIX, SEED_OUPUTS_JSON_FILENAME, LEGACY_RESULTS_MANIFEST]
+SPECIAL_FILES = [METADATA_SUFFIX, SEED_OUTPUTS_JSON_FILENAME, LEGACY_RESULTS_MANIFEST]
 
 logger = logging.getLogger(__name__)
 

--- a/scale/job/test/seed/results/test_job_results.py
+++ b/scale/job/test/seed/results/test_job_results.py
@@ -118,6 +118,6 @@ class TestSeedJobResults(TransactionTestCase):
     def test_capture_output_json(self):
         results = JobResults()
         with patch("__builtin__.open", mock_open(read_data=json.dumps(self.outputs_json_dict))):
-            results._capture_output_json(self.seed_outputs_json)
+            results._capture_output_json_and_supplemental_input_metadata(self.seed_outputs_json)
 
         self.assertDictEqual(results.get_dict(), {'files': {}, 'json': {'INPUT_SIZE': 50}, 'version': '7'})

--- a/scale/job/test/seed/results/test_job_results.py
+++ b/scale/job/test/seed/results/test_job_results.py
@@ -118,6 +118,6 @@ class TestSeedJobResults(TransactionTestCase):
     def test_capture_output_json(self):
         results = JobResults()
         with patch("__builtin__.open", mock_open(read_data=json.dumps(self.outputs_json_dict))):
-            results._capture_output_json_and_supplemental_input_metadata(self.seed_outputs_json)
+            results._capture_output_json(self.seed_outputs_json)
 
         self.assertDictEqual(results.get_dict(), {'files': {}, 'json': {'INPUT_SIZE': 50}, 'version': '7'})

--- a/scale/job/test/seed/test_job_data.py
+++ b/scale/job/test/seed/test_job_data.py
@@ -138,3 +138,15 @@ class TestJobData(TransactionTestCase):
 
         result = job_data.retrieve_input_data_files(data_files)
         self.assertEqual(result, {})
+
+    @patch('job.data.job_data.ScaleFile.objects.download_files')
+    @patch('job.data.job_data.ScaleFile.objects.filter')
+    def test_retrieve_files_with_id(self, filter, download):
+        job_data = JobData({'files': {}})
+        filter.return_value = [Mock(id=1, file_name='input_thing_file'), Mock(id=2, file_name='input_other_file')]
+
+        data_files = {1: ("/scale/input/INPUT_THING", False), 2: ("/scale/input/INPUT_OTHER", True)}
+
+        result = job_data._retrieve_files(data_files)
+        self.assertEqual(result, {1: "/scale/input/INPUT_THING/1/input_thing_file",
+                                  2: "/scale/input/INPUT_OTHER/2/input_other_file"})

--- a/scale/job/test/seed/test_job_data.py
+++ b/scale/job/test/seed/test_job_data.py
@@ -148,5 +148,5 @@ class TestJobData(TransactionTestCase):
         data_files = {1: ("/scale/input/INPUT_THING", False), 2: ("/scale/input/INPUT_OTHER", True)}
 
         result = job_data._retrieve_files(data_files)
-        self.assertEqual(result, {1: "/scale/input/INPUT_THING/1/input_thing_file",
-                                  2: "/scale/input/INPUT_OTHER/2/input_other_file"})
+        self.assertEqual(result, {1: "/scale/input/INPUT_THING/input_thing_file",
+                                  2: "/scale/input/INPUT_OTHER/input_other_file"})

--- a/scale/source/configuration/source_data_file.py
+++ b/scale/source/configuration/source_data_file.py
@@ -1,8 +1,12 @@
 """Defines the source data file input type contained within job data"""
+import logging
+
 from job.configuration.data.data_file import AbstractDataFileParseSaver
 from source.models import SourceFile
 from storage.models import ScaleFile
 from util.parse import parse_datetime
+
+logger = logging.getLogger(__name__)
 
 
 class SourceDataFileParseSaver(AbstractDataFileParseSaver):
@@ -35,4 +39,38 @@ class SourceDataFileParseSaver(AbstractDataFileParseSaver):
                 data_ended = parse_datetime(data_ended)
 
             SourceFile.objects.save_parse_results(src_file_id, geo_json, data_started, data_ended, data_types,
+                                                  new_workspace_path)
+
+    def save_parse_results_v6(self, metadata):
+        """Saves the given parse results to the source file for the given ID. All database changes occur in an atomic
+        transaction.
+
+        :param metadata: Mapping of IDs to parse result objects. Objects are GeoJSON.
+        :type metadata: { int: dict }
+        """
+
+        ids = metadata.keys()
+        source_file_ids = ScaleFile.objects.filter(id__in=ids, file_type='SOURCE').values('id')
+        ignored_ids = list(set(ids) - set(source_file_ids))
+        if len(ignored_ids):
+            logger.warning('Ignored all parse results for file IDs not of SOURCE file_type: ', ignored_ids)
+
+        for id in source_file_ids:
+            geo_json = metadata[int(id)]
+
+            data_types = []
+            new_workspace_path = None
+            if 'properties' in geo_json:
+                props = geo_json['properties']
+                data_started = props.get('data_started')
+                data_ended = props.get('data_ended')
+                data_types = props.get('data_types', [])
+                new_workspace_path = props.get('new_workspace_path')
+
+                if data_started:
+                    data_started = parse_datetime(data_started)
+                if data_ended:
+                    data_ended = parse_datetime(data_ended)
+
+            SourceFile.objects.save_parse_results(id, geo_json, data_started, data_ended, data_types,
                                                   new_workspace_path)

--- a/scale/source/configuration/source_data_file.py
+++ b/scale/source/configuration/source_data_file.py
@@ -53,7 +53,7 @@ class SourceDataFileParseSaver(AbstractDataFileParseSaver):
         source_file_ids = ScaleFile.objects.filter(id__in=ids, file_type='SOURCE').values('id')
         ignored_ids = list(set(ids) - set(source_file_ids))
         if len(ignored_ids):
-            logger.warning('Ignored all parse results for file IDs not of SOURCE file_type: ', ignored_ids)
+            logger.warning('Ignored all parse results for file IDs not of SOURCE file_type: ' + ','.join(ignored_ids))
 
         for id in source_file_ids:
             geo_json = metadata[int(id)]

--- a/scale/source/configuration/source_data_file.py
+++ b/scale/source/configuration/source_data_file.py
@@ -50,6 +50,7 @@ class SourceDataFileParseSaver(AbstractDataFileParseSaver):
         """
 
         ids = id_to_metadata.keys()
+        logger.debug('List of IDs to update: {}'.format(ids))
         source_file_ids = ScaleFile.objects.filter(id__in=ids, file_type='SOURCE').values_list('id', flat=True)
         ignored_ids = list(set(ids) - set(source_file_ids))
         if len(ignored_ids):
@@ -70,5 +71,7 @@ class SourceDataFileParseSaver(AbstractDataFileParseSaver):
             if data_ended:
                 data_ended = parse_datetime(data_ended)
 
+            logger.debug('Captured input for file ID {}:\n{}\n{}\n{}\n{}'.format(file_id, geo_json,
+                                                                                 data_started, data_ended, data_types))
             SourceFile.objects.save_parse_results(file_id, geo_json, data_started, data_ended, data_types,
                                                   new_workspace_path)

--- a/scale/source/configuration/source_data_file.py
+++ b/scale/source/configuration/source_data_file.py
@@ -41,36 +41,34 @@ class SourceDataFileParseSaver(AbstractDataFileParseSaver):
             SourceFile.objects.save_parse_results(src_file_id, geo_json, data_started, data_ended, data_types,
                                                   new_workspace_path)
 
-    def save_parse_results_v6(self, metadata):
+    def save_parse_results_v6(self, id_to_metadata):
         """Saves the given parse results to the source file for the given ID. All database changes occur in an atomic
         transaction.
 
-        :param metadata: Mapping of IDs to parse result objects. Objects are GeoJSON.
-        :type metadata: { int: dict }
+        :param id_to_metadata: Mapping of IDs to metadata objects/
+        :type id_to_metadata: { int: class:`job.seed.metadata.SeedMetadata` }
         """
 
-        ids = metadata.keys()
-        source_file_ids = ScaleFile.objects.filter(id__in=ids, file_type='SOURCE').values('id')
+        ids = id_to_metadata.keys()
+        source_file_ids = ScaleFile.objects.filter(id__in=ids, file_type='SOURCE').values_list('id', flat=True)
         ignored_ids = list(set(ids) - set(source_file_ids))
         if len(ignored_ids):
-            logger.warning('Ignored all parse results for file IDs not of SOURCE file_type: ' + ','.join(ignored_ids))
+            logger.warning('Ignored all parse results for file IDs not of SOURCE file_type: {}'
+                           .format(','.join(map(str, ignored_ids))))
 
-        for id in source_file_ids:
-            geo_json = metadata[int(id)]
+        for file_id in source_file_ids:
+            metadata = id_to_metadata[int(file_id)]
 
-            data_types = []
-            new_workspace_path = None
-            if 'properties' in geo_json:
-                props = geo_json['properties']
-                data_started = props.get('data_started')
-                data_ended = props.get('data_ended')
-                data_types = props.get('data_types', [])
-                new_workspace_path = props.get('new_workspace_path')
+            geo_json = metadata.data
+            data_started = metadata.get_property('dataStarted')
+            data_ended = metadata.get_property('dataEnded')
+            data_types = metadata.get_property('dataTypes', [])
+            new_workspace_path = metadata.get_property('newWorkspacePath')
 
-                if data_started:
-                    data_started = parse_datetime(data_started)
-                if data_ended:
-                    data_ended = parse_datetime(data_ended)
+            if data_started:
+                data_started = parse_datetime(data_started)
+            if data_ended:
+                data_ended = parse_datetime(data_ended)
 
-            SourceFile.objects.save_parse_results(id, geo_json, data_started, data_ended, data_types,
+            SourceFile.objects.save_parse_results(file_id, geo_json, data_started, data_ended, data_types,
                                                   new_workspace_path)

--- a/scale/source/models.py
+++ b/scale/source/models.py
@@ -8,10 +8,8 @@ from django.db import transaction
 from django.utils.timezone import now
 
 import storage.geospatial_utils as geo_utils
-from job.models import Job
 from storage.brokers.broker import FileMove
 from storage.models import ScaleFile
-
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +17,7 @@ logger = logging.getLogger(__name__)
 class SourceFileManager(models.GeoManager):
     """Provides additional methods for handling source files
     """
-
+    
     def filter_sources(self, started=None, ended=None, time_field=None, is_parsed=None, file_name=None, order=None):
         """Returns a query for source models that filters on the given fields. The returned query includes the related
         workspace, job_type, and job fields, except for the workspace.json_config field. The related countries are set
@@ -172,6 +170,8 @@ class SourceFileManager(models.GeoManager):
             order.append('id')
         else:
             order = ['last_modified', 'id']
+        
+        from job.models import Job
         jobs = Job.objects.filter_jobs_related_v6(started=started, ended=ended, statuses=statuses, job_ids=job_ids,
                                                job_type_ids=job_type_ids, job_type_names=job_type_names,
                                                batch_ids=batch_ids, error_categories=error_categories, order=order)

--- a/scale/source/test/configuration/test_source_data_file.py
+++ b/scale/source/test/configuration/test_source_data_file.py
@@ -4,7 +4,7 @@ import datetime
 
 import django
 from django.utils.timezone import now
-from django.test import TestCase
+from django.test import TransactionTestCase
 from mock import call, patch
 
 from job.seed.metadata import SeedMetadata
@@ -13,7 +13,7 @@ from storage.models import ScaleFile, Workspace
 from util.parse import parse_datetime
 
 
-class TestSourceDataFileParseSaverSaveParseResults(TestCase):
+class TestSourceDataFileParseSaverSaveParseResults(TransactionTestCase):
 
     def setUp(self):
         django.setup()
@@ -57,7 +57,7 @@ class TestSourceDataFileParseSaverSaveParseResults(TestCase):
         mock_save.assert_has_calls(calls, any_order=True)
 
     @patch('source.configuration.source_data_file.SourceFile.objects.save_parse_results')
-    def test_successful(self, mock_save):
+    def test_successful_v6(self, mock_save):
         """Tests calling SourceDataFileParseSaver.save_parse_results_v6() successfully"""
 
         started = '2018-06-01T00:00:00Z'
@@ -79,9 +79,9 @@ class TestSourceDataFileParseSaverSaveParseResults(TestCase):
                             }
                     }
 
-        metadata = {1: SeedMetadata.metadata_from_json(data, do_validate=False)}
+        metadata = {self.source_file_1.id: SeedMetadata.metadata_from_json(data, do_validate=False)}
 
-        calls = [call(1, data, parse_datetime(started), parse_datetime(ended), types, new_workspace_path)]
+        calls = [call(self.source_file_1.id, data, parse_datetime(started), parse_datetime(ended), types, new_workspace_path)]
 
         SourceDataFileParseSaver().save_parse_results_v6(metadata)
 

--- a/scale/source/test/configuration/test_source_data_file.py
+++ b/scale/source/test/configuration/test_source_data_file.py
@@ -81,9 +81,9 @@ class TestSourceDataFileParseSaverSaveParseResults(TestCase):
 
         metadata = {1: SeedMetadata.metadata_from_json(data, do_validate=False)}
 
-        SourceDataFileParseSaver().save_parse_results_v6(metadata)
-
         calls = [call(1, data, parse_datetime(started), parse_datetime(ended), types, new_workspace_path)]
+
+        SourceDataFileParseSaver().save_parse_results_v6(metadata)
 
         self.assertEqual(mock_save.call_count, 1)
         mock_save.assert_has_calls(calls, any_order=True)

--- a/scale/source/test/configuration/test_source_data_file.py
+++ b/scale/source/test/configuration/test_source_data_file.py
@@ -83,7 +83,7 @@ class TestSourceDataFileParseSaverSaveParseResults(TestCase):
 
         SourceDataFileParseSaver().save_parse_results_v6(metadata)
 
-        calls = [call(1, data, started, ended, types, new_workspace_path)]
+        calls = [call(1, data, parse_datetime(started), parse_datetime(ended), types, new_workspace_path)]
 
         self.assertEqual(mock_save.call_count, 1)
         mock_save.assert_has_calls(calls, any_order=True)

--- a/tests/postman/full-host-test.json
+++ b/tests/postman/full-host-test.json
@@ -289,6 +289,66 @@
 			"response": []
 		},
 		{
+			"name": "Create Source Metadata Job Type",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "ffb160bb-1431-4d8e-8131-06c657aa696f",
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {",
+							"    pm.expect(pm.response.code).to.be.oneOf([201,202]);",
+							"});",
+							"pm.test(\"Job Type name is correct\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.expect(jsonData.name).to.eql('source-metadata');",
+							"});",
+							"pm.test(\"Docker image is consistent with spec\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.expect(jsonData.docker_image).to.include(jsonData.manifest.job.name + '-' + jsonData.manifest.job.jobVersion + '-seed:' + jsonData.manifest.job.packageVersion);",
+							"});",
+							"pm.test(\"Default output workspace configured\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.expect(jsonData.configuration.output_workspaces.default).to.eql(\"testing-host-output\");",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"type": "text",
+						"value": "Token {{token}}"
+					},
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"icon_code\": \"f2b9\",\n    \"docker_image\": \"geointseed/source-metadata-1.0.0-seed:1.0.0\",\n    \"manifest\": {\n        \"seedVersion\": \"1.0.0\",\n        \"job\": {\n            \"name\": \"source-metadata\",\n            \"jobVersion\": \"1.0.0\",\n            \"packageVersion\": \"1.0.0\",\n            \"title\": \"Source Metadata Augment\",\n            \"description\": \"Applies supplementary metadata to an input file.\",\n            \"tags\": [\n                \"metadata\",\n                \"source\"\n            ],\n            \"maintainer\": {\n                \"name\": \"John Doe\",\n                \"organization\": \"E-corp\",\n                \"email\": \"jdoe@example.com\",\n                \"url\": \"http://www.example.com\",\n                \"phone\": \"666-555-4321\"\n            },\n            \"timeout\": 3600,\n            \"interface\": {\n                \"command\": \"sh /generate-metadata.sh\",\n                \"inputs\": {\n                    \"files\": [\n                        {\n                            \"name\": \"INPUT_FILE\",\n                            \"required\": true\n                        }\n                    ]\n                }\n            },\n            \"resources\": {\n                \"scalar\": [\n                    {\n                        \"name\": \"cpus\",\n                        \"value\": 0.25\n                    },\n                    {\n                        \"name\": \"mem\",\n                        \"value\": 128\n                    }\n                ]\n            }\n        }\n    },\n    \"configuration\": {\n        \"output_workspaces\": {\n            \"default\": \"testing-host-output\"\n        },\n        \"priority\": 1\n    }\n}"
+				},
+				"url": {
+					"raw": "{{SCALE_BASE}}/v6/job-types/",
+					"host": [
+						"{{SCALE_BASE}}"
+					],
+					"path": [
+						"v6",
+						"job-types",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Create Gray Scaler Job Type",
 			"event": [
 				{
@@ -384,7 +444,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"title\": \"Image Stuff\",\n    \"description\": \"Flip and greyscale images\",\n    \"definition\": {\n        \"input\": {\n            \"files\": [\n                {\n                    \"name\": \"INPUT_FILE\",\n                    \"required\": true,\n                    \"media_types\": [\n                        \"application/octet-stream\"\n                    ]\n                }\n            ],\n            \"json\": []\n        },\n        \"nodes\": {\n            \"flip-image\": {\n                \"dependencies\": [],\n                \"input\": {\n                    \"INPUT_FILE\": {\n                        \"type\": \"recipe\",\n                        \"input\": \"INPUT_FILE\"\n                    }\n                },\n                \"node_type\": {\n                    \"node_type\": \"job\",\n                    \"job_type_name\": \"flip-image\",\n                    \"job_type_version\": \"1.0.0\",\n                    \"job_type_revision\": 1\n                }\n            },\n            \"grayscale-image\": {\n                \"dependencies\": [\n                    {\n                        \"name\": \"flip-image\",\n                        \"acceptance\": false\n                    }\n                ],\n                \"input\": {\n                    \"INPUT_FILE\": {\n                        \"type\": \"dependency\",\n                        \"node\": \"flip-image\",\n                        \"output\": \"flipped_image\"\n                    }\n                },\n                \"node_type\": {\n                    \"node_type\": \"job\",\n                    \"job_type_name\": \"grayscale-image\",\n                    \"job_type_version\": \"1.0.0\",\n                    \"job_type_revision\": 1\n                }\n            }\n        }\n    }\n}"
+					"raw": "{\n    \"title\": \"Image Stuff\",\n    \"description\": \"Apply metadata, flip and greyscale images\",\n    \"definition\": {\n        \"input\": {\n            \"files\": [\n                {\n                    \"name\": \"INPUT_FILE\",\n                    \"required\": true,\n                    \"media_types\": [\n                        \"application/octet-stream\"\n                    ]\n                }\n            ],\n            \"json\": []\n        },\n        \"nodes\": {\n        \t\"source-metadata\": {\n                \"dependencies\": [],\n                \"input\": {\n                    \"INPUT_FILE\": {\n                        \"type\": \"recipe\",\n                        \"input\": \"INPUT_FILE\"\n                    }\n                },\n                \"node_type\": {\n                    \"node_type\": \"job\",\n                    \"job_type_name\": \"source-metadata\",\n                    \"job_type_version\": \"1.0.0\",\n                    \"job_type_revision\": 1\n                }\n            },\n            \"flip-image\": {\n                \"dependencies\": [],\n                \"input\": {\n                    \"INPUT_FILE\": {\n                        \"type\": \"recipe\",\n                        \"input\": \"INPUT_FILE\"\n                    }\n                },\n                \"node_type\": {\n                    \"node_type\": \"job\",\n                    \"job_type_name\": \"flip-image\",\n                    \"job_type_version\": \"1.0.0\",\n                    \"job_type_revision\": 1\n                }\n            },\n            \"grayscale-image\": {\n                \"dependencies\": [\n                    {\n                        \"name\": \"flip-image\",\n                        \"acceptance\": false\n                    }\n                ],\n                \"input\": {\n                    \"INPUT_FILE\": {\n                        \"type\": \"dependency\",\n                        \"node\": \"flip-image\",\n                        \"output\": \"flipped_image\"\n                    }\n                },\n                \"node_type\": {\n                    \"node_type\": \"job\",\n                    \"job_type_name\": \"grayscale-image\",\n                    \"job_type_version\": \"1.0.0\",\n                    \"job_type_revision\": 1\n                }\n            }\n        }\n    }\n}"
 				},
 				"url": {
 					"raw": "{{SCALE_BASE}}/v6/recipe-types/",


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
* job
* storage

### Description of change
Add the ability to capture supplemental metadata to attach to `SOURCE` files. The only reason for this is to support augmentation of metadata associated with files that domain specific jobs can provide - the Scale Ingest doesn't have the smarts for it, nor should it.

We are expanding on the use of the metadata sidecar file for input files. There are some small differences. Since we can't guarantee writable storage within the input location, we must write them to the output directory. Details on the format and location of the metadata json can be found in the documentation here: https://github.com/ngageoint/scale/wiki/Scale-Job-Inputs-and-Outputs#source-input-metadata

The reason we are using the input file name as opposed to the same name as the input file name is because we can easily allow the algorithm developers at build time to know the location, since it is defined on the interface.

_We do not support making input data updates to multiple file inputs. We also limit updates to `SOURCE` file_types._