### PR TITLE
1736 - Strike doesn't properly reload configurations

### DIFF
--- a/scale/ingest/test/test_views.py
+++ b/scale/ingest/test/test_views.py
@@ -1183,8 +1183,9 @@ class TestStrikeDetailsViewV6(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
 
-    @patch('ingest.models.CommandMessageManager')
-    def test_successful(self, mock_msg_mgr):
+    @patch('ingest.views.CommandMessageManager')
+    @patch('ingest.views.create_requeue_jobs_messages')
+    def test_successful(self, mock_msg_mgr, mock_create):
         """Tests successfully calling the get Strike process details view."""
 
         url = '/%s/strikes/%d/' % (self.version, self.strike.id)
@@ -1217,8 +1218,9 @@ class TestStrikeDetailsViewV6(APITestCase):
         self.assertIsNotNone(result['job'])
         self.assertDictEqual(result['configuration'], self.secret_config)
 
-    @patch('ingest.models.CommandMessageManager')
-    def test_edit_simple(self, mock_msg_mgr):
+    @patch('ingest.views.CommandMessageManager')
+    @patch('ingest.views.create_requeue_jobs_messages')
+    def test_edit_simple(self, mock_msg_mgr, mock_create):
         """Tests editing only the basic attributes of a Strike process"""
 
         json_data = {
@@ -1230,8 +1232,9 @@ class TestStrikeDetailsViewV6(APITestCase):
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
 
-    @patch('ingest.models.CommandMessageManager')
-    def test_edit_config(self, mock_msg_mgr):
+    @patch('ingest.views.CommandMessageManager')
+    @patch('ingest.views.create_requeue_jobs_messages')
+    def test_edit_config(self, mock_msg_mgr, mock_create):
         """Tests editing the configuration of a Strike process"""
 
         recipe_type = recipe_test_utils.create_recipe_type_v6()
@@ -1261,8 +1264,9 @@ class TestStrikeDetailsViewV6(APITestCase):
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
 
-    @patch('ingest.models.CommandMessageManager')
-    def test_edit_config_v6(self, mock_msg_mgr):
+    @patch('ingest.views.CommandMessageManager')
+    @patch('ingest.views.create_requeue_jobs_messages')
+    def test_edit_config_v6(self, mock_msg_mgr, mock_create):
         """Tests attempting to edit a Strike process adding a recipe configuration"""
         new_workspace = storage_test_utils.create_workspace(name='prods')
 
@@ -1317,7 +1321,9 @@ class TestStrikeDetailsViewV6(APITestCase):
         strike = Strike.objects.get(pk=self.strike.id)
         self.assertDictEqual(strike.get_v6_configuration_json(), config)
 
-    def test_edit_bad_config(self):
+    @patch('ingest.views.CommandMessageManager')
+    @patch('ingest.views.create_requeue_jobs_messages')
+    def test_edit_bad_config(self, mock_msg_mgr, mock_create):
         """Tests attempting to edit a Strike process using an invalid configuration"""
 
         config = {
@@ -1340,7 +1346,9 @@ class TestStrikeDetailsViewV6(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
 
-    def test_edit_invalid_recipe(self):
+    @patch('ingest.views.CommandMessageManager')
+    @patch('ingest.views.create_requeue_jobs_messages')
+    def test_edit_invalid_recipe(self, mock_msg_mgr, mock_create):
         """Tests attempting to edit a Strike process with a nonexistant recipe"""
         config = {
             'workspace': self.workspace.name,

--- a/scale/ingest/test/test_views.py
+++ b/scale/ingest/test/test_views.py
@@ -1263,6 +1263,8 @@ class TestStrikeDetailsViewV6(APITestCase):
         url = '/%s/strikes/%d/' % (self.version, self.strike.id)
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+        mock_msg_mgr.assert_called_once()
+        mock_create.assert_called_once()
 
     @patch('ingest.views.CommandMessageManager')
     @patch('ingest.views.create_requeue_jobs_messages')
@@ -1320,10 +1322,10 @@ class TestStrikeDetailsViewV6(APITestCase):
 
         strike = Strike.objects.get(pk=self.strike.id)
         self.assertDictEqual(strike.get_v6_configuration_json(), config)
+        mock_msg_mgr.assert_called_once()
+        mock_create.assert_called_once()
 
-    @patch('ingest.views.CommandMessageManager')
-    @patch('ingest.views.create_requeue_jobs_messages')
-    def test_edit_bad_config(self, mock_msg_mgr, mock_create):
+    def test_edit_bad_config(self):
         """Tests attempting to edit a Strike process using an invalid configuration"""
 
         config = {
@@ -1346,9 +1348,7 @@ class TestStrikeDetailsViewV6(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
 
-    @patch('ingest.views.CommandMessageManager')
-    @patch('ingest.views.create_requeue_jobs_messages')
-    def test_edit_invalid_recipe(self, mock_msg_mgr, mock_create):
+    def test_edit_invalid_recipe(self):
         """Tests attempting to edit a Strike process with a nonexistant recipe"""
         config = {
             'workspace': self.workspace.name,

--- a/scale/ingest/test/test_views.py
+++ b/scale/ingest/test/test_views.py
@@ -1183,9 +1183,7 @@ class TestStrikeDetailsViewV6(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
 
-    @patch('ingest.views.CommandMessageManager')
-    @patch('ingest.views.create_requeue_jobs_messages')
-    def test_successful(self, mock_msg_mgr, mock_create):
+    def test_successful(self):
         """Tests successfully calling the get Strike process details view."""
 
         url = '/%s/strikes/%d/' % (self.version, self.strike.id)
@@ -1218,9 +1216,7 @@ class TestStrikeDetailsViewV6(APITestCase):
         self.assertIsNotNone(result['job'])
         self.assertDictEqual(result['configuration'], self.secret_config)
 
-    @patch('ingest.views.CommandMessageManager')
-    @patch('ingest.views.create_requeue_jobs_messages')
-    def test_edit_simple(self, mock_msg_mgr, mock_create):
+    def test_edit_simple(self):
         """Tests editing only the basic attributes of a Strike process"""
 
         json_data = {

--- a/scale/ingest/test/test_views.py
+++ b/scale/ingest/test/test_views.py
@@ -1183,7 +1183,8 @@ class TestStrikeDetailsViewV6(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
 
-    def test_successful(self):
+    @patch('ingest.models.CommandMessageManager')
+    def test_successful(self, mock_msg_mgr):
         """Tests successfully calling the get Strike process details view."""
 
         url = '/%s/strikes/%d/' % (self.version, self.strike.id)
@@ -1216,7 +1217,8 @@ class TestStrikeDetailsViewV6(APITestCase):
         self.assertIsNotNone(result['job'])
         self.assertDictEqual(result['configuration'], self.secret_config)
 
-    def test_edit_simple(self):
+    @patch('ingest.models.CommandMessageManager')
+    def test_edit_simple(self, mock_msg_mgr):
         """Tests editing only the basic attributes of a Strike process"""
 
         json_data = {
@@ -1228,7 +1230,8 @@ class TestStrikeDetailsViewV6(APITestCase):
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
 
-    def test_edit_config(self):
+    @patch('ingest.models.CommandMessageManager')
+    def test_edit_config(self, mock_msg_mgr):
         """Tests editing the configuration of a Strike process"""
 
         recipe_type = recipe_test_utils.create_recipe_type_v6()
@@ -1258,7 +1261,8 @@ class TestStrikeDetailsViewV6(APITestCase):
         response = self.client.generic('PATCH', url, json.dumps(json_data), 'application/json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
 
-    def test_edit_config_v6(self):
+    @patch('ingest.models.CommandMessageManager')
+    def test_edit_config_v6(self, mock_msg_mgr):
         """Tests attempting to edit a Strike process adding a recipe configuration"""
         new_workspace = storage_test_utils.create_workspace(name='prods')
 

--- a/scale/ingest/views.py
+++ b/scale/ingest/views.py
@@ -683,11 +683,11 @@ class StrikeDetailsView(GenericAPIView):
 
             # if workspace has changed strike job must be restarted for changes to take effect
             if config and old_config.configuration["workspace"] != new_config["workspace"]:
-                current_strike_job = Strike.objects.get_details(strike_id).job
-                Job.objects.update_jobs_to_canceled([current_strike_job], timezone.now())
+                strike_job = old_config.job
+                Job.objects.update_jobs_to_canceled([strike_job], timezone.now())
 
                 requeue_jobs = []
-                requeue_jobs.append(QueuedJob(current_strike_job.id, current_strike_job.num_exes))
+                requeue_jobs.append(QueuedJob(strike_job.id, strike_job.num_exes))
                 msg = create_requeue_jobs_messages(requeue_jobs)
                 CommandMessageManager().send_messages(msg)
             

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,7 +15,7 @@ then
     psql -d scale -U postgres -c "create extension postgis_topology;"
 
     export COVERAGE_FILE=$root/.coverage
-    coverage run --source='.' manage.py test -v 2
+    coverage run --source='.' manage.py test
 fi
 
 if [ "${BUILD_DOCS}" == "true" ]

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,7 +15,7 @@ then
     psql -d scale -U postgres -c "create extension postgis_topology;"
 
     export COVERAGE_FILE=$root/.coverage
-    coverage run --source='.' manage.py test
+    coverage run --source='.' manage.py test -v 2
 fi
 
 if [ "${BUILD_DOCS}" == "true" ]


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
ingest

### Description of change
whenever the workspace of a strike is changed, the strike job will now stop and restart to apply the new workspace. 
