### PR TITLE
Checking optional outputs for existence before accessing

### DIFF
--- a/scale/recipe/definition/node.py
+++ b/scale/recipe/definition/node.py
@@ -86,11 +86,12 @@ class NodeDefinition(object):
             try:
                 connection.add_value_to_data(input_data, recipe_input_data, node_outputs)
             except InvalidData as ex:
-                if not connection.output_name in optional_outputs:
-                    logger.warning("output name %s not found in optional_outputs", connection.output_name)
-                    raise
-                else:
-                    logger.info("InvalidData exception occured due to optional output not present. Proceeding with job execution.")
+                if optional_outputs:
+                    if not connection.output_name in optional_outputs:
+                        logger.warning("Output name %s not found in optional outputs", connection.output_name)
+                        raise
+                    else:
+                        logger.info("InvalidData exception occured due to optional output not present. Proceeding with job execution.")
         
 
         return input_data

--- a/scale/recipe/definition/node.py
+++ b/scale/recipe/definition/node.py
@@ -92,7 +92,8 @@ class NodeDefinition(object):
                         raise
                     else:
                         logger.info("InvalidData exception occured due to optional output not present. Proceeding with job execution.")
-        
+                else:
+                    logger.exception("InvalidData exception occurred generating input data")
 
         return input_data
 


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
recipe
### Description of change
<!-- Please provide a description of the change here. -->
Support for checking optional output existence was added a while back, however we weren't checking the existence of the object before trying to access it.