### PR TITLE
#1741, #1822 - Can't Cancel Scan, get ingest details with no associated strike causes server error

### DIFF
--- a/scale/docs/rest/v6/scan.rst
+++ b/scale/docs/rest/v6/scan.rst
@@ -632,6 +632,31 @@ Response: 200 OK
 |                    |                   | (See :ref:`rest_v6_scan_configuration`)                                        |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 
+.. _rest_v6_scan_cancel:
+
+v6 Cancel Scan
+---------------
+
+This call will send a cancel job request for the job associated with the scan, as well as all queued or running ingest jobs spawned from the scan.
+recipes triggered by completed ingest jobs will not be effected. Returns the job ids of all canceled jobs. 
+
+**Example POST /v6/scans/cancel/{id} API call**
+
+Request: POST http://.../v6/scans/cancel/{id}/
+
+.. code-block:: javascript
+
+    {
+    }
+
+Response: 202 Accepted
+
+.. code-block:: javascript
+
+    {
+    "[1,2,3]"
+    }
+
 .. _rest_v6_scan_configuration:
 
 Scan Configuration JSON

--- a/scale/docs/rest/v6/scan.rst
+++ b/scale/docs/rest/v6/scan.rst
@@ -644,11 +644,6 @@ recipes triggered by completed ingest jobs will not be effected. Returns the job
 
 Request: POST http://.../v6/scans/cancel/{id}/
 
-.. code-block:: javascript
-
-    {
-    }
-
 Response: 202 Accepted
 
 .. code-block:: javascript
@@ -656,6 +651,8 @@ Response: 202 Accepted
     {
     "[1,2,3]"
     }
+
+Returns a list of canceled job ids.
 
 .. _rest_v6_scan_configuration:
 

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -1004,8 +1004,13 @@ class ScanManager(models.Manager):
             try:
                 if ingest.job and ingest.job.status in ['RUNNING', 'PENDING', 'QUEUED']:
                     job_ids.append(ingest.job.id)
-            except:
-                throw()
+                else:
+                    if not ingest.job:
+                        logger.info("ingest %d not canceled due to no job existing", ingest.id)
+            except ex:
+                if ingest.job: 
+                    logger.warning("Job %d was not canceled.", ingest.job.id)
+                logger.exception("error in attempting to cancel ingest job")
         if len(job_ids) > 0:
             msgs = create_cancel_jobs_messages(job_ids, timezone.now())
             CommandMessageManager().send_messages(msgs)

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -1006,11 +1006,11 @@ class ScanManager(models.Manager):
                     job_ids.append(ingest.job.id)
                 else:
                     if not ingest.job:
-                        logger.info("ingest %d not canceled due to no job existing", ingest.id)
+                        logger.info("Ingest %d not canceled due to no job existing.", ingest.id)
             except ex:
                 if ingest.job: 
                     logger.warning("Job %d was not canceled.", ingest.job.id)
-                logger.exception("error in attempting to cancel ingest job")
+                logger.exception("Error in attempting to cancel ingest job.")
         if len(job_ids) > 0:
             msgs = create_cancel_jobs_messages(job_ids, timezone.now())
             CommandMessageManager().send_messages(msgs)

--- a/scale/ingest/test/test_views.py
+++ b/scale/ingest/test/test_views.py
@@ -34,6 +34,8 @@ class TestIngestsViewV6(APITestCase):
                                                        status='QUEUED')
         self.ingest2 = ingest_test_utils.create_ingest(strike=ingest_test_utils.create_strike(), file_name='test2.txt',
                                                        status='INGESTED', data_type_tags=['type1', 'type2'])
+        self.ingest3 = ingest_test_utils.create_ingest(scan=ingest_test_utils.create_scan(), file_name='test3.txt',
+                                                       status='QUEUED')
 
         rest.login_client(self.client)
 
@@ -45,13 +47,15 @@ class TestIngestsViewV6(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         result = json.loads(response.content)
-        self.assertEqual(len(result['results']), 2)
+        self.assertEqual(len(result['results']), 3)
         for entry in result['results']:
             expected = None
             if entry['id'] == self.ingest1.id:
                 expected = self.ingest1
             elif entry['id'] == self.ingest2.id:
                 expected = self.ingest2
+            elif entry['id'] == self.ingest3.id:
+                expected = self.ingest3
             else:
                 self.fail('Found unexpected result: %s' % entry['id'])
             self.assertEqual(entry['file_name'], expected.file_name)
@@ -66,7 +70,7 @@ class TestIngestsViewV6(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         result = json.loads(response.content)
-        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(len(result['results']), 2)
         self.assertEqual(result['results'][0]['status'], self.ingest1.status)
 
     def test_strike_id(self):
@@ -79,6 +83,17 @@ class TestIngestsViewV6(APITestCase):
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(result['results'][0]['strike']['id'], self.ingest1.strike.id)
+
+    def test_scan_id(self):
+        """Tests successfully calling the ingests view filtered by scan processor."""
+
+        url = '/%s/ingests/?scan_id=%i' % (self.version, self.ingest3.scan.id)
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 1)
+        self.assertEqual(result['results'][0]['scan']['id'], self.ingest3.scan.id)
 
     def test_file_name(self):
         """Tests successfully calling the ingests view filtered by file name."""
@@ -95,9 +110,9 @@ class TestIngestsViewV6(APITestCase):
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         result = json.loads(response.content)
-        self.assertEqual(len(result['results']), 2)
+        self.assertEqual(len(result['results']), 3)
         for file in result['results']:
-            self.assertIn(file['file_name'], [self.ingest1.file_name, self.ingest2.file_name])
+            self.assertIn(file['file_name'], [self.ingest1.file_name, self.ingest2.file_name, self.ingest3.file_name])
 
 class TestIngestDetailsViewV6(APITestCase):
     version = 'v6'
@@ -911,6 +926,52 @@ class TestScansProcessViewV6(APITestCase):
         result = json.loads(response.content)
         self.assertTrue(isinstance(result, dict), 'result  must be a dictionary')
         self.assertIsNotNone(result['job'])
+
+    @patch('ingest.models.CommandMessageManager')
+    @patch('ingest.models.create_cancel_jobs_messages')
+    def test_cancel_scan_job(self, msg_create, mock_msg_mgr):
+        """Tests successfully calling the Scan process view for an ingest Scan. following dry run"""
+
+        self.scan.job = job_utils.create_job()
+        self.scan.save()
+        self.ingest = ingest_test_utils.create_ingest(scan=self.scan, file_name='test3.txt',
+                                                       status='QUEUED')
+
+        url = '/%s/scans/cancel/%d/' % (self.api, self.scan.id)
+        response = self.client.generic('POST', url, json.dumps({ 'ingest': True }), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
+        
+        result = json.loads(response.data)
+
+        msg_create.assert_called()
+        mock_msg_mgr.assert_called()
+
+        self.assertEqual(len(result), 2)
+
+    @patch('ingest.models.CommandMessageManager')
+    @patch('ingest.models.create_cancel_jobs_messages')
+    def test_cancel_scan_job_nothing_to_cancel(self, msg_create, mock_msg_mgr):
+        """Tests no cancel messages generated when jobs are not in a cancelable state"""
+
+        self.scan.job = job_utils.create_job()
+        self.scan.job.status = "COMPLETED"
+        self.scan.job.save()
+        self.scan.save()
+        self.ingest = ingest_test_utils.create_ingest(scan=self.scan, file_name='test3.txt',
+                                                       status='QUEUED')
+        self.ingest.job.status = "CANCELED"
+        self.ingest.job.save()
+
+        url = '/%s/scans/cancel/%d/' % (self.api, self.scan.id)
+        response = self.client.generic('POST', url, json.dumps({ 'ingest': True }), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
+        
+        result = json.loads(response.data)
+
+        msg_create.assert_not_called()
+        mock_msg_mgr.assert_not_called()
+
+        self.assertEqual(len(result), 0)
 
 class TestStrikesViewV6(APITestCase):
 

--- a/scale/ingest/urls.py
+++ b/scale/ingest/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     url(r'^scans/(\d+)/$', views.ScansDetailsView.as_view(), name='scans_details_view'),
     url(r'^scans/(\d+)/process/$', views.ScansProcessView.as_view(), name='scans_process_view'),
     url(r'^scans/validation/$', views.ScansValidationView.as_view(), name='scans_validation_view'),
+    url(r'^scans/cancel/(\d+)/$', views.CancelScansView.as_view(), name='cancel_scans_view'),
 
     # Strike views
     url(r'^strikes/$', views.StrikesView.as_view(), name='strikes_view'),

--- a/scale/ingest/views.py
+++ b/scale/ingest/views.py
@@ -355,7 +355,10 @@ class CancelScansView(GenericAPIView):
 
     def post(self, request, scan_id):
         try:
-            canceled_ids = Scan.objects.cancel_scan(scan_id)
+            if self.request.version == 'v6' or self.request.version == 'v7':
+                canceled_ids = Scan.objects.cancel_scan(scan_id)
+            else:
+                raise Http404    
         except Scan.DoesNotExist:
             raise Http404
         return Response(JSONRenderer().render(canceled_ids), status=status.HTTP_202_ACCEPTED)

--- a/scale/ingest/views.py
+++ b/scale/ingest/views.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 
 import rest_framework.status as status
+from rest_framework.renderers import JSONRenderer
 from django.http.response import Http404
 import django.utils.timezone as timezone
 from rest_framework.generics import GenericAPIView, ListAPIView, ListCreateAPIView, RetrieveAPIView
@@ -338,6 +339,26 @@ class ScansView(ListCreateAPIView):
         scan_url = reverse('scans_details_view', args=[scan.id], request=request)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=dict(location=scan_url))
 
+
+
+class CancelScansView(GenericAPIView):
+    """This view is the endpoint for canceling a scan in progress."""
+    queryset = Scan.objects.all()
+    
+    def get_serializer_class(self):
+        """Returns the appropriate serializer based off the requests version of the REST API. """
+
+        if self.request.version == 'v6':
+            return ScanSerializerV6
+        elif self.request.version == 'v7':
+            return ScanSerializerV6
+
+    def post(self, request, scan_id):
+        try:
+            canceled_ids = Scan.objects.cancel_scan(scan_id)
+        except Scan.DoesNotExist:
+            raise Http404
+        return Response(JSONRenderer().render(canceled_ids), status=status.HTTP_202_ACCEPTED)
 
 class ScansDetailsView(GenericAPIView):
     """This view is the endpoint for retrieving/updating details of a Scan process."""


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
ingest/scan
### Description of change
<!-- Please provide a description of the change here. -->
added scan cancel API endpoint, during development ended up fixing an ingest/scan bug as well. 