### PR TITLE
Dependency: Restrict marathon library version

### DIFF
--- a/scale/pip/production.txt
+++ b/scale/pip/production.txt
@@ -14,7 +14,7 @@ django-rest-framework-social-oauth2
 elasticsearch>=6.3.0,<7
 jsonschema>=2.3,<3
 kombu>=4.0.2,<5
-marathon>=0.11.0,<1
+marathon>=0.11.0,<0.12.0
 mesoshttp>=0.3.2,<0.4
 more-itertools<6
 psycopg2>=2.7.1,<3

--- a/scale/pip/requirements.txt
+++ b/scale/pip/requirements.txt
@@ -14,7 +14,7 @@ django-rest-framework-social-oauth2>=1.1.0,<2
 elasticsearch>=6.3.0,<7
 jsonschema>=2.3,<3
 kombu>=4.0.2,<5
-marathon>=0.11.0,<1
+marathon>=0.11.0,<0.12.0
 mesoshttp>=0.3.2,<0.4
 more-itertools<6
 psycopg2>=2.7.1,<3


### PR DESCRIPTION
The `marathon` library was causing builds to fail because it had python 3 code that was trying to execute.  