### PR TITLE
#1835 Return Ingest Status By Given Started/End Dates

### DIFF
--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -414,8 +414,22 @@ class IngestManager(models.Manager):
 
         # Build a list of values for each hourly time slot including zero value place holders where needed
         duration = ended.date() - started.date()
+
         for day in range(duration.days + 1):
-            for hour in range(24):
+            start_hour = 0
+            end_hour = 24
+
+            # if on the first day
+            if day == 0:
+                start_hour = started.hour
+                # if start and end are on the same date
+                if started.date() == ended.date():
+                    end_hour = ended.hour + 1
+            # if on the last day
+            elif day == duration.days and ended.hour != 24:
+                end_hour = ended.hour + 1
+
+            for hour in range(start_hour, end_hour):
                 dated = started + datetime.timedelta(days=day)
                 time_slot = datetime.datetime(dated.year, dated.month, dated.day, hour, tzinfo=timezone.utc)
                 status_vals = time_slots[time_slot] if time_slot in time_slots else IngestCounts(time_slot)

--- a/scale/ingest/test/test_views.py
+++ b/scale/ingest/test/test_views.py
@@ -199,8 +199,8 @@ class TestIngestStatusViewV6(TestCase):
         self.ingest2 = ingest_test_utils.create_ingest(file_name='test2.txt', status='INGESTED', strike=self.strike)
         self.ingest3 = ingest_test_utils.create_ingest(file_name='test3.txt', status='INGESTED', strike=self.strike)
         self.ingest4 = ingest_test_utils.create_ingest(file_name='test4.txt', status='INGESTED', strike=self.strike,
-                                                       data_started=datetime.datetime(2015, 1, 1, tzinfo=utc),
-                                                       ingest_ended=datetime.datetime(2015, 2, 1, tzinfo=utc))
+                                                       data_started=datetime.datetime(2015, 1, 1, 5, tzinfo=utc),
+                                                       ingest_ended=datetime.datetime(2015, 2, 1, 5, tzinfo=utc))
 
         rest.login_client(self.client)
 
@@ -217,13 +217,13 @@ class TestIngestStatusViewV6(TestCase):
         entry = result['results'][0]
         self.assertEqual(entry['strike']['id'], self.strike.id)
         self.assertIsNotNone(entry['most_recent'])
-        self.assertEqual(entry['files'], 2)
-        self.assertEqual(entry['size'], self.ingest2.file_size + self.ingest3.file_size)
+        self.assertEqual(entry['files'], 3)
+        self.assertEqual(entry['size'], self.ingest2.file_size + self.ingest3.file_size + self.ingest4.file_size)
 
     def test_time_range(self):
         """Tests successfully calling the ingest status view with a time range filter."""
 
-        url = '/%s/ingests/status/?started=2015-01-01T00:00:00Z' % self.version
+        url = '/%s/ingests/status/?started=2015-01-01T05:00:00Z' % self.version
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -235,6 +235,19 @@ class TestIngestStatusViewV6(TestCase):
         self.assertIsNotNone(entry['most_recent'])
         self.assertEqual(entry['files'], 3)
         self.assertEqual(entry['size'], self.ingest2.file_size + self.ingest3.file_size + self.ingest4.file_size)
+
+        url = '/%s/ingests/status/?started=2015-01-01T05:00:00Z&ended=2015-01-02T05:00:00Z' % self.version
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 1)
+
+        entry = result['results'][0]
+        self.assertEqual(entry['strike']['id'], self.strike.id)
+        self.assertIsNotNone(entry['most_recent'])
+        self.assertEqual(entry['files'], 1)
+        self.assertEqual(entry['size'], self.ingest4.file_size)
 
     def test_use_ingest_time(self):
         """Tests successfully calling the ingest status view grouped by ingest time instead of data time."""
@@ -249,14 +262,14 @@ class TestIngestStatusViewV6(TestCase):
 
         entry = result['results'][0]
         self.assertEqual(entry['strike']['id'], self.strike.id)
-        self.assertEqual(entry['most_recent'], '2015-02-01T00:00:00Z')
+        self.assertEqual(entry['most_recent'], '2015-02-01T05:00:00Z')
         self.assertEqual(entry['files'], 1)
         self.assertEqual(entry['size'], self.ingest3.file_size)
 
-    def test_fill_empty_slots(self):
-        """Tests successfully calling the ingest status view with place holder zero values when no data exists."""
+    def test_dont_fill_empty_slots(self):
+        """Tests successfully calling the ingest status view ensuring no place holder zero values when no data exists."""
 
-        url = '/%s/ingests/status/?started=2015-01-01T00:00:00Z&ended=2015-01-01T10:00:00Z' % self.version
+        url = '/%s/ingests/status/?started=2015-01-01T00:00:00Z&ended=2015-01-02T05:00:00Z' % self.version
         response = self.client.generic('GET', url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
@@ -268,7 +281,7 @@ class TestIngestStatusViewV6(TestCase):
         self.assertIsNotNone(entry['most_recent'])
         self.assertEqual(entry['files'], 1)
         self.assertEqual(entry['size'], self.ingest3.file_size)
-        self.assertEqual(len(entry['values']), 24)
+        self.assertEqual(len(entry['values']), 30)
 
     def test_multiple_strikes(self):
         """Tests successfully calling the ingest status view with multiple strike process groupings."""
@@ -935,18 +948,17 @@ class TestScansProcessViewV6(APITestCase):
         self.scan.job = job_utils.create_job()
         self.scan.save()
         self.ingest = ingest_test_utils.create_ingest(scan=self.scan, file_name='test3.txt',
-                                                       status='QUEUED')
+                                                      status='QUEUED')
 
         url = '/%s/scans/cancel/%d/' % (self.api, self.scan.id)
-        response = self.client.generic('POST', url, json.dumps({ 'ingest': True }), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
-        
-        result = json.loads(response.data)
+        response = self.client.generic('POST', url, json.dumps({'ingest': True}), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        result = json.loads(response.content)
+        self.assertEqual(result['id'], unicode(self.scan.id))
+        self.assertEqual(len(result['canceled_jobs']), 2)
 
         msg_create.assert_called()
         mock_msg_mgr.assert_called()
-
-        self.assertEqual(len(result), 2)
 
     @patch('ingest.models.CommandMessageManager')
     @patch('ingest.models.create_cancel_jobs_messages')
@@ -958,20 +970,20 @@ class TestScansProcessViewV6(APITestCase):
         self.scan.job.save()
         self.scan.save()
         self.ingest = ingest_test_utils.create_ingest(scan=self.scan, file_name='test3.txt',
-                                                       status='QUEUED')
+                                                      status='QUEUED')
         self.ingest.job.status = "CANCELED"
         self.ingest.job.save()
 
         url = '/%s/scans/cancel/%d/' % (self.api, self.scan.id)
-        response = self.client.generic('POST', url, json.dumps({ 'ingest': True }), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
-        
-        result = json.loads(response.data)
+        response = self.client.generic('POST', url, json.dumps({'ingest': True}), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+
+        result = json.loads(response.content)
+        self.assertEqual(result['id'], unicode(self.scan.id))
+        self.assertEqual(len(result['canceled_jobs']), 0)
 
         msg_create.assert_not_called()
         mock_msg_mgr.assert_not_called()
-
-        self.assertEqual(len(result), 0)
 
     @patch('ingest.models.CommandMessageManager')
     @patch('ingest.models.create_cancel_jobs_messages')
@@ -981,20 +993,21 @@ class TestScansProcessViewV6(APITestCase):
         self.scan.job = job_utils.create_job()
         self.scan.save()
         self.ingest = ingest_test_utils.create_ingest(scan=self.scan, file_name='test3.txt',
-                                                       status='QUEUED')
+                                                      status='QUEUED')
         self.ingest.job = None
         self.ingest.save()
 
         url = '/%s/scans/cancel/%d/' % (self.api, self.scan.id)
-        response = self.client.generic('POST', url, json.dumps({ 'ingest': True }), 'application/json')
-        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED, response.content)
+        response = self.client.generic('POST', url, json.dumps({'ingest': True}), 'application/json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         
-        result = json.loads(response.data)
+        result = json.loads(response.content)
+        self.assertEqual(result['id'], unicode(self.scan.id))
+        self.assertEqual(len(result['canceled_jobs']), 1)
 
         msg_create.assert_called()
         mock_msg_mgr.assert_called()
 
-        self.assertEqual(len(result), 1)
 
 class TestStrikesViewV6(APITestCase):
 

--- a/scale/ingest/views.py
+++ b/scale/ingest/views.py
@@ -3,9 +3,11 @@ from __future__ import unicode_literals
 
 import datetime
 import logging
+import json
 
 import rest_framework.status as status
 from rest_framework.renderers import JSONRenderer
+from django.http import JsonResponse
 from django.http.response import Http404
 import django.utils.timezone as timezone
 from rest_framework.generics import GenericAPIView, ListAPIView, ListCreateAPIView, RetrieveAPIView
@@ -179,8 +181,7 @@ class IngestsStatusView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
-
-        started = rest_util.parse_timestamp(request, 'started', rest_util.get_relative_days(7))
+        started = rest_util.parse_timestamp(request, 'started', required=False)
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended, max_duration=datetime.timedelta(days=31))
 
@@ -191,7 +192,6 @@ class IngestsStatusView(ListAPIView):
         page = self.paginate_queryset(ingests)
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
-
 
 class ScansProcessView(GenericAPIView):
     """This view is the endpoint for launching a scan execution to ingest"""
@@ -356,12 +356,29 @@ class CancelScansView(GenericAPIView):
     def post(self, request, scan_id):
         try:
             if self.request.version == 'v6' or self.request.version == 'v7':
-                canceled_ids = Scan.objects.cancel_scan(scan_id)
+                return self._cancel_v6(request, scan_id)
             else:
                 raise Http404    
         except Scan.DoesNotExist:
             raise Http404
-        return Response(JSONRenderer().render(canceled_ids), status=status.HTTP_202_ACCEPTED)
+
+    def _cancel_v6(self, request, scan_id):
+        """Cancels a scan job
+
+        :param request: the HTTP POST request
+        :type request: :class:`rest_framework.request.Request`
+        :param scan_id: The ID of the Scan process
+        :type scan_id: int encoded as a str
+        :returns: The HTTP response to send back to the user
+        :rtype: :class:`rest_framework.response.Response`
+        """
+
+        canceled_ids = Scan.objects.cancel_scan(scan_id)
+
+        resp_dict = {'id': scan_id, 'canceled_jobs': canceled_ids}
+        return JsonResponse(resp_dict, status=status.HTTP_202_ACCEPTED)
+        # return Response(resp_dict, status=status.HTTP_202_ACCEPTED)
+        # return Response(JSONRenderer().render(canceled_ids), status=status.HTTP_202_ACCEPTED)
 
 class ScansDetailsView(GenericAPIView):
     """This view is the endpoint for retrieving/updating details of a Scan process."""


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
ingest

### Description of change
<!-- Please provide a description of the change here. -->
Updated the logic that returned the ingest status to only include values from the given time range instead of the beginning of the start day and end of the end day.