### PR TITLE
Add inputmap to batch configuration

### DIFF
--- a/scale/batch/configuration/configuration.py
+++ b/scale/batch/configuration/configuration.py
@@ -1,6 +1,7 @@
 """Defines the class for managing a batch configuration"""
 from __future__ import unicode_literals
 
+from batch.configuration.exceptions import InvalidConfiguration
 
 class BatchConfiguration(object):
     """Represents a batch configuration"""
@@ -10,6 +11,7 @@ class BatchConfiguration(object):
         """
 
         self.priority = None
+        self.input_map = None
 
     def validate(self, batch):
         """Validates the given batch to make sure it is valid with respect to this batch configuration. This method will
@@ -23,5 +25,16 @@ class BatchConfiguration(object):
         :raises :class:`batch.configuration.exceptions.InvalidConfiguration`: If the configuration is invalid
         """
 
-        # Currently nothing to do
-        return []
+        warnings = []
+
+        # Verify the configuration input map matches the dataset parameters
+        if self.input_map and batch.get_definition().dataset:
+            from data.models import DataSet
+            the_dataset = DataSet.objects.get(pk=batch.get_definition().dataset)
+            for input in self.input_map:
+                param_name = input['datasetParameter']
+                if param_name not in the_dataset.get_definition().param_names:
+                    msg = '%s does not exist in the dataset parameter list' % param_name
+                    raise InvalidConfiguration('INVALID_INPUT_MAP', msg)
+
+        return warnings

--- a/scale/batch/configuration/json/configuration_v6.py
+++ b/scale/batch/configuration/json/configuration_v6.py
@@ -23,6 +23,25 @@ BATCH_CONFIGURATION_SCHEMA = {
         'priority': {
             'description': 'The ID of the previous batch',
             'type': 'integer',
+        },
+        'inputMap': {
+            'description': 'Maps the inputs of the batch to the dataset inputs',
+            'type': 'array',
+            'minItems': 1,
+            'items':  {
+                'type': 'object',
+                'required': ['input', 'datasetParameter'],
+                'properties': {
+                    'input': {
+                        'description': 'The name of the input the dataset parameter maps to',
+                        'type': 'string',
+                    },
+                    'datasetParameter': {
+                        'description': 'The name of the dataset parameter the input maps to',
+                        'type': 'string',
+                    }
+                }
+            }
         }
     },
 }
@@ -40,6 +59,8 @@ def convert_configuration_to_v6(configuration):
     json_dict = {'version': SCHEMA_VERSION}
     if configuration.priority is not None:
         json_dict['priority'] = configuration.priority
+    if configuration.input_map is not None:
+        json_dict['inputMap'] = configuration.input_map
     return BatchConfigurationV6(configuration=json_dict, do_validate=False)
 
 
@@ -84,6 +105,9 @@ class BatchConfigurationV6(object):
         configuration = BatchConfiguration()
         if 'priority' in self._configuration:
             configuration.priority = self._configuration['priority']
+
+        if 'inputMap' in self._configuration:
+            configuration.input_map = self._configuration['inputMap']
 
         return configuration
 

--- a/scale/batch/definition/definition.py
+++ b/scale/batch/definition/definition.py
@@ -65,6 +65,25 @@ class BatchDefinition(object):
             for param in dataset_definition.parameters.parameters:
                 dataset_parameters.add_parameter(dataset_definition.parameters.parameters[param])
 
+            # map dataset param to inputs if applicable
+            if batch.get_configuration().input_map:
+                from data.interface.interface import Interface
+                from data.interface.parameter import FileParameter, JsonParameter
+                parameters = Interface()
+                for param_name in dataset_parameters.parameters:
+                    param = dataset_parameters.parameters[param_name]
+                    for map_param in batch.get_configuration().input_map:
+                        if param_name == map_param['datasetParameter']:
+                            if param.PARAM_TYPE == 'file':
+                                parameters.add_parameter(FileParameter(map_param['input'], param.media_types,
+                                                                       required=param.required, multiple=param.multiple))
+                            elif param.PARAM_TYPE == 'json':
+                                parameters.add_parameter(JsonParameter(map_param['input'], param.json_type,
+                                                                       required=param.required, multiple=param.multiple))
+                        else:
+                            parameters.add_parameter(param)
+                dataset_parameters = parameters
+
             try:
                 recipe_type_rev.get_definition().input_interface.validate_connection(dataset_parameters)
             except InvalidInterfaceConnection as ex:

--- a/scale/batch/models.py
+++ b/scale/batch/models.py
@@ -135,7 +135,28 @@ class BatchManager(models.Manager):
         dataset_parameters = dataset_definition.global_parameters
         for param in dataset_definition.parameters.parameters:
             dataset_parameters.add_parameter(dataset_definition.parameters.parameters[param])
-        
+
+        # map dataset param to inputs if applicable
+        if batch.get_configuration().input_map:
+            from data.interface.interface import Interface
+            from data.interface.parameter import FileParameter, JsonParameter
+            parameters = Interface()
+            for param_name in dataset_parameters.parameters:
+                param = dataset_parameters.parameters[param_name]
+                for map_param in batch.get_configuration().input_map:
+                    if param_name == map_param['datasetParameter']:
+                        if param.PARAM_TYPE == 'file':
+                            parameters.add_parameter(FileParameter(map_param['input'], param.media_types,
+                                                                   required=param.required,
+                                                                   multiple=param.multiple))
+                        elif param.PARAM_TYPE == 'json':
+                            parameters.add_parameter(JsonParameter(map_param['input'], param.json_type,
+                                                                   required=param.required,
+                                                                   multiple=param.multiple))
+                    else:
+                        parameters.add_parameter(param)
+            dataset_parameters = parameters
+
         try:
             recipe_type.get_definition().input_interface.validate_connection(dataset_parameters)
         except InvalidInterfaceConnection as ex:

--- a/scale/batch/models.py
+++ b/scale/batch/models.py
@@ -69,7 +69,6 @@ class BatchManager(models.Manager):
         batch.event = event
         batch.definition = convert_definition_to_v6(definition).get_dict()
         batch.configuration = convert_configuration_to_v6(configuration).get_dict()
-
         with transaction.atomic():
             if definition.root_batch_id is not None:
                 # Find latest batch with the root ID and supersede it
@@ -126,36 +125,12 @@ class BatchManager(models.Manager):
         #        type, count the number of files in each member that matches the parameter
         
         from data.interface.exceptions import InvalidInterfaceConnection
-        from data.models import DataSet, DataSetMember, DataSetFile
+        from data.models import DataSet, DataSetFile
         dataset = DataSet.objects.get(pk=definition.dataset)
-        dataset_definition = dataset.get_definition()
         recipe_type = RecipeTypeRevision.objects.get_revision(name=batch.recipe_type.name, revision_num=batch.recipe_type_rev.revision_num).recipe_type
 
         # combine the parameters
-        dataset_parameters = dataset_definition.global_parameters
-        for param in dataset_definition.parameters.parameters:
-            dataset_parameters.add_parameter(dataset_definition.parameters.parameters[param])
-
-        # map dataset param to inputs if applicable
-        if batch.get_configuration().input_map:
-            from data.interface.interface import Interface
-            from data.interface.parameter import FileParameter, JsonParameter
-            parameters = Interface()
-            for param_name in dataset_parameters.parameters:
-                param = dataset_parameters.parameters[param_name]
-                for map_param in batch.get_configuration().input_map:
-                    if param_name == map_param['datasetParameter']:
-                        if param.PARAM_TYPE == 'file':
-                            parameters.add_parameter(FileParameter(map_param['input'], param.media_types,
-                                                                   required=param.required,
-                                                                   multiple=param.multiple))
-                        elif param.PARAM_TYPE == 'json':
-                            parameters.add_parameter(JsonParameter(map_param['input'], param.json_type,
-                                                                   required=param.required,
-                                                                   multiple=param.multiple))
-                    else:
-                        parameters.add_parameter(param)
-            dataset_parameters = parameters
+        dataset_parameters = Batch.objects.merge_parameter_map(batch, dataset)
 
         try:
             recipe_type.get_definition().input_interface.validate_connection(dataset_parameters)
@@ -164,6 +139,12 @@ class BatchManager(models.Manager):
             return 0
         
         recipe_inputs = recipe_type.get_definition().get_input_keys()
+
+        if batch.get_configuration().input_map:
+            for map_param in batch.get_configuration().input_map:
+                idx = recipe_inputs.index(map_param['input'])
+                if idx > -1:
+                    recipe_inputs[idx] = map_param['datasetParameter']
 
         # Base count of recipes are number of files in the dataset that match the recipe inputs
         files = DataSetFile.objects.get_files([dataset.id], recipe_inputs)
@@ -197,6 +178,45 @@ class BatchManager(models.Manager):
                             estimated_recipes += (1 + RecipeTypeSubLink.objects.count_subrecipes(sub_type_id, recurse=True)) * num_files
       
         return estimated_recipes
+
+    def merge_parameter_map(self, batch, dataset):
+        """Returns the dataset parameters merged with the batch configuration input map
+
+        :param batch: The batch
+        :type batch: :class:`batch.models.Batch`
+        :param dataset: The dataset of the batch
+        :type dataset: :class:`data.models.DataSet`
+        :returns: The map of datasest parameters
+        :rtype:  :class:`data.interface.Interface`
+        """
+        # combine the parameters
+        dataset_definition = dataset.get_definition()
+        dataset_parameters = dataset_definition.global_parameters
+        for param in dataset_definition.parameters.parameters:
+            dataset_parameters.add_parameter(dataset_definition.parameters.parameters[param])
+
+        # map dataset param to inputs if applicable
+        if batch.get_configuration().input_map:
+            from data.interface.interface import Interface
+            from data.interface.parameter import FileParameter, JsonParameter
+            parameters = Interface()
+            for param_name in dataset_parameters.parameters:
+                param = dataset_parameters.parameters[param_name]
+                for map_param in batch.get_configuration().input_map:
+                    if param_name == map_param['datasetParameter']:
+                        if param.PARAM_TYPE == 'file':
+                            parameters.add_parameter(FileParameter(map_param['input'], param.media_types,
+                                                                   required=param.required,
+                                                                   multiple=param.multiple))
+                        elif param.PARAM_TYPE == 'json':
+                            parameters.add_parameter(JsonParameter(map_param['input'], param.json_type,
+                                                                   required=param.required,
+                                                                   multiple=param.multiple))
+                    else:
+                        parameters.add_parameter(param)
+            dataset_parameters = parameters
+
+        return dataset_parameters
 
     def get_batch_from_root(self, root_batch_id):
         """Returns the latest (non-superseded) batch model with the given root batch ID. The returned model

--- a/scale/batch/test/configuration/test_configuration.py
+++ b/scale/batch/test/configuration/test_configuration.py
@@ -1,10 +1,16 @@
 from __future__ import unicode_literals
 
+import copy
 import django
 from django.test import TestCase
 
+from batch.definition.definition import BatchDefinition
+from batch.configuration.exceptions import InvalidConfiguration
 from batch.configuration.json.configuration_v6 import BatchConfigurationV6
 from batch.test import utils as batch_test_utils
+from data.data.json.data_v6 import DataV6
+from data.test import utils as data_test_utils
+from storage.test import utils as storage_test_utils
 
 
 class TestBatchDefinition(TestCase):
@@ -31,3 +37,60 @@ class TestBatchDefinition(TestCase):
         json = BatchConfigurationV6(configuration=json_dict)
         configuration = json.get_configuration()
         configuration.validate(batch)
+
+    def test_inputmap(self):
+        dataset_def = {
+            'parameters': {
+                'files': [{'media_types': ['image/png'], 'required': True, 'multiple': False, 'name': 'INPUT_IMAGE'}],
+                'json': []}
+        }
+        the_dataset = data_test_utils.create_dataset(definition=dataset_def)
+        workspace = storage_test_utils.create_workspace()
+        src_file_a = storage_test_utils.create_file(file_name='input_a.PNG', file_type='SOURCE', media_type='image/png',
+                                                    file_size=10, data_type_tags=['type'], file_path='the_path',
+                                                    workspace=workspace)
+        src_file_b = storage_test_utils.create_file(file_name='input_b.PNG', file_type='SOURCE', media_type='image/png',
+                                                    file_size=10, data_type_tags=['type'], file_path='the_path',
+                                                    workspace=workspace)
+        data_list = []
+        data_dict = {
+            'version': '6',
+            'files': {'FILE_INPUT': [src_file_a.id]},
+            'json': {}
+        }
+        data_list.append(DataV6(data=data_dict).get_dict())
+        data_dict = {
+            'version': '6',
+            'files': {'FILE_INPUT': [src_file_b.id]},
+            'json': {}
+        }
+        data_list.append(DataV6(data=data_dict).get_dict())
+        members = data_test_utils.create_dataset_members(dataset=the_dataset, data_list=data_list)
+
+        batch_def = BatchDefinition()
+        batch_def.dataset = the_dataset.id
+        batch = batch_test_utils.create_batch(definition=batch_def)
+
+        json_dict = {
+            'version': '6',
+            'priority': 100,
+            'inputMap': [{
+                'input': 'FILE_INPUT',
+                'datasetParameter': 'INPUT_IMAGE'
+            }]
+        }
+        json = BatchConfigurationV6(configuration=json_dict)
+        configuration = json.get_configuration()
+        configuration.validate(batch)
+
+        json_dict = {
+            'version': '6',
+            'priority': 100,
+            'inputMap': [{
+                'input': 'FILE_INPUT',
+                'datasetParameter': 'FILE_INPUT'
+            }]
+        }
+        json = BatchConfigurationV6(configuration=json_dict)
+        configuration = json.get_configuration()
+        self.assertRaises(InvalidConfiguration, configuration.validate, batch)

--- a/scale/batch/test/definition/test_definition.py
+++ b/scale/batch/test/definition/test_definition.py
@@ -33,7 +33,6 @@ class TestBatchDefinition(TestCase):
         still_creating_prev_batch = batch_test_utils.create_batch(recipe_type=recipe_type_2)
         prev_batch = batch_test_utils.create_batch(recipe_type=recipe_type_2, is_creation_done=True, recipes_total=10)
         batch = batch_test_utils.create_batch(recipe_type=recipe_type_2)
-        
 
         # No recipes would be created
         json_dict = {'version': '6'}

--- a/scale/batch/test/messages/test_create_batch_recipes.py
+++ b/scale/batch/test/messages/test_create_batch_recipes.py
@@ -816,7 +816,7 @@ class TestCreateBatchRecipes(TestCase):
             src_file_ids.append(src_file.id)
             data_dict = {
                 'version': '6',
-                'files': {'INPUT_IMAGE': [src_file.id]},
+                'files': {'INPUT_FILE': [src_file.id]},
                 'json': {}
             }
             data_list.append(DataV6(data=data_dict).get_dict())

--- a/scale/batch/test/messages/test_create_batch_recipes.py
+++ b/scale/batch/test/messages/test_create_batch_recipes.py
@@ -4,6 +4,7 @@ import django
 import copy
 from django.test import TestCase
 
+from batch.configuration.json.configuration_v6 import BatchConfigurationV6
 from batch.definition.definition import BatchDefinition
 from batch.messages.create_batch_recipes import create_batch_recipes_message, CreateBatchRecipes
 from batch.test import utils as batch_test_utils
@@ -539,7 +540,6 @@ class TestCreateBatchRecipes(TestCase):
         self.assertEqual(create_recipes_message_3.recipe_type_name, new_batch_2.recipe_type.name)
         self.assertEqual(create_recipes_message_3.recipe_type_rev_num, new_batch_2.recipe_type.revision_num)
         
-        
     def test_execute_forced_nodes(self):
         """Tests calling CreateBatchRecipes.execute() when only specific nodes are forced"""
         
@@ -718,3 +718,181 @@ class TestCreateBatchRecipes(TestCase):
         self.assertIsNone(create_recipes_message.forced_nodes)
         self.assertEqual(create_recipes_message.recipe_type_name, new_batch.recipe_type.name)
         self.assertEqual(create_recipes_message.recipe_type_rev_num, new_batch.recipe_type.revision_num)
+
+    def test_execute_inputmap(self):
+        """Tests executing a new batch with an inputMap specified in the configuration"""
+        # Importing module here to patch the max recipe num
+        import batch.messages.create_batch_recipes
+        batch.messages.create_batch_recipes.MAX_RECIPE_NUM = 5
+
+        jt_1 = job_test_utils.create_seed_job_type()
+        jt_2 = job_test_utils.create_seed_job_type()
+        jt_3 = job_test_utils.create_seed_job_type()
+        jt_4 = job_test_utils.create_seed_job_type()
+
+        recipe_def = {'version': '7',
+                      'input': {'files': [{'name': 'INPUT_IMAGE', 'media_types': ['image/png'], 'required': True,
+                                           'multiple': False}],
+                                'json': []},
+                      'nodes': {'node_a': {'dependencies': [],
+                                           'input': {'input_a': {'type': 'recipe', 'input': 'INPUT_IMAGE'}},
+                                           'node_type': {'node_type': 'job',
+                                                         'job_type_name': jt_1.name,
+                                                         'job_type_version': jt_1.version,
+                                                         'job_type_revision': jt_1.revision_num}},
+                                'node_b': {'dependencies': [],
+                                           'input': {'input_a': {'type': 'recipe', 'input': 'INPUT_IMAGE'}},
+                                           'node_type': {'node_type': 'job',
+                                                         'job_type_name': jt_2.name,
+                                                         'job_type_version': jt_2.version,
+                                                         'job_type_revision': jt_2.revision_num}}}}
+        sub_recipe_type_1 = recipe_test_utils.create_recipe_type_v6(definition=recipe_def)
+
+        recipe_def = {'version': '7',
+                      'input': {'files': [{'name': 'INPUT_IMAGE', 'media_types': ['image/png'], 'required': True,
+                                           'multiple': False}],
+                                'json': []},
+                      'nodes': {'node_a': {'dependencies': [],
+                                           'input': {'input_a': {'type': 'recipe', 'input': 'INPUT_IMAGE'}},
+                                           'node_type': {'node_type': 'job',
+                                                         'job_type_name': jt_3.name,
+                                                         'job_type_version': jt_3.version,
+                                                         'job_type_revision': jt_3.revision_num}},
+                                'node_b': {'dependencies': [],
+                                           'input': {'input_a': {'type': 'recipe', 'input': 'INPUT_IMAGE'}},
+                                           'node_type': {'node_type': 'job',
+                                                         'job_type_name': jt_4.name,
+                                                         'job_type_version': jt_4.version,
+                                                         'job_type_revision': jt_4.revision_num}}}}
+        sub_recipe_type_2 = recipe_test_utils.create_recipe_type_v6(definition=recipe_def)
+
+        jt_5 = job_test_utils.create_seed_job_type()
+        jt_6 = job_test_utils.create_seed_job_type()
+        recipe_def = {'version': '7',
+                      'input': {'files': [{'name': 'INPUT_IMAGE', 'media_types': ['image/png'], 'required': True,
+                                           'multiple': False}],
+                                'json': []},
+                      'nodes': {'recipe_node_a': {'dependencies': [],
+                                                  'input': {'input_a': {'type': 'recipe', 'input': 'INPUT_IMAGE'}},
+                                                  'node_type': {'node_type': 'recipe',
+                                                                'recipe_type_name': sub_recipe_type_1.name,
+                                                                'recipe_type_revision': sub_recipe_type_1.revision_num}},
+                                'recipe_node_b': {'dependencies': [{'name': 'node_d', 'acceptance': True}],
+                                                  'input': {'input_a': {'type': 'dependency', 'node': 'node_d',
+                                                                        'output': 'OUTPUT_IMAGE'}},
+                                                  'node_type': {'node_type': 'recipe',
+                                                                'recipe_type_name': sub_recipe_type_2.name,
+                                                                'recipe_type_revision': sub_recipe_type_2.revision_num}},
+                                'node_c': {'dependencies': [],
+                                           'input': {'INPUT_IMAGE': {'type': 'recipe', 'input': 'INPUT_IMAGE'}},
+                                           'node_type': {'node_type': 'job', 'job_type_name': jt_5.name,
+                                                         'job_type_version': jt_5.version,
+                                                         'job_type_revision': jt_5.revision_num}},
+                                'node_d': {'dependencies': [{'name': 'node_c', 'acceptance': True}],
+                                           'input': {'INPUT_IMAGE': {'type': 'dependency', 'node': 'node_c',
+                                                                     'output': 'OUTPUT_IMAGE'}},
+                                           'node_type': {'node_type': 'job', 'job_type_name': jt_6.name,
+                                                         'job_type_version': jt_6.version,
+                                                         'job_type_revision': jt_6.revision_num}}}}
+        recipe_type = recipe_test_utils.create_recipe_type_v6(definition=recipe_def)
+
+        # Create a dataset of 6 files
+        dataset_def = {
+            'parameters': {
+                'files': [{'media_types': ['image/png'], 'required': True, 'multiple': False, 'name': 'INPUT_FILE'}],
+                'json': []}
+        }
+        the_dataset = data_test_utils.create_dataset(definition=dataset_def)
+        workspace = storage_test_utils.create_workspace()
+
+        # Create 6 files
+        src_file_ids = []
+        data_list = []
+        for i in range(0, 6):
+            file_name = 'input_%d.png' % i
+            src_file = storage_test_utils.create_file(file_name=file_name, file_type='SOURCE', media_type='image/png',
+                                                      file_size=10, data_type_tags=['type'], file_path='the_path',
+                                                      workspace=workspace)
+            src_file_ids.append(src_file.id)
+            data_dict = {
+                'version': '6',
+                'files': {'INPUT_IMAGE': [src_file.id]},
+                'json': {}
+            }
+            data_list.append(DataV6(data=data_dict).get_dict())
+        members = data_test_utils.create_dataset_members(dataset=the_dataset, data_list=data_list)
+
+        batch_definition = BatchDefinition()
+        batch_definition.dataset = the_dataset.id
+        forced_nodes = ForcedNodes()
+        forced_nodes.all_nodes = True
+        batch_definition.forced_nodes = forced_nodes
+        config_dict = {
+            'version': '7',
+            'priority': '100',
+            'inputMap': [
+                {'input': 'INPUT_IMAGE', 'datasetParameter': 'INPUT_FILE'}
+            ]
+        }
+        batch_config = BatchConfigurationV6(config_dict, False).get_configuration()
+        new_batch = batch_test_utils.create_batch(recipe_type=recipe_type, definition=batch_definition,
+                                                  configuration=batch_config)
+
+        # Create message
+        message = batch.messages.create_batch_recipes.CreateBatchRecipes()
+        message.batch_id = new_batch.id
+
+        # Copy JSON for running same message again later
+        message_json = message.to_json()
+
+        # Execute message
+        result = message.execute()
+        self.assertTrue(result)
+
+        # Should be 6 messages, one for next create_batch_recipes and 5 for creating new recipes
+        self.assertEqual(len(message.new_messages), 6)
+
+        # Create batch message
+        batch_recipes_message = message.new_messages[0]
+        self.assertEqual(batch_recipes_message.type, 'create_batch_recipes')
+        self.assertEqual(batch_recipes_message.current_dataset_file_id, src_file_ids[1])
+        self.assertFalse(batch_recipes_message.is_prev_batch_done)
+
+        from recipe.models import Recipe
+        # Verify each message has a different input and execute
+        src_ids = copy.deepcopy(src_file_ids)
+        for msg in message.new_messages[1:]:
+            self.assertEqual(msg.type, 'create_recipes')
+            self.assertEqual(msg.create_recipes_type, 'new-recipe')
+            file_id = DataV6(msg.recipe_input_data).get_data().values['INPUT_IMAGE'].file_ids[0]
+            self.assertTrue(file_id in src_ids)
+            src_ids.remove(file_id)
+
+            # Execute the create_recipes messages
+            result = msg.execute()
+            self.assertTrue(result)
+
+        # Verify 5 recipes have been created and they have the proper input files:
+        recipes = Recipe.objects.all()
+        self.assertEqual(len(recipes), 5)
+        src_ids = copy.deepcopy(src_file_ids)
+        for recipe in recipes:
+            self.assertEqual(recipe.recipe_type.name, new_batch.recipe_type.name)
+            file_id = recipe.get_input_data().values['INPUT_IMAGE'].file_ids[0]
+            self.assertTrue(file_id in src_ids)
+            src_ids.remove(file_id)
+
+        # Execute next create_batch_recipes messages
+        result = batch_recipes_message.execute()
+        self.assertTrue(result)
+        # Should only have one last create_recipes message
+        self.assertEqual(len(batch_recipes_message.new_messages), 1)
+        create_recipes_message = batch_recipes_message.new_messages[0]
+        self.assertTrue(batch_recipes_message.is_prev_batch_done)
+        self.assertEqual(create_recipes_message.type, 'create_recipes')
+        self.assertEqual(create_recipes_message.create_recipes_type, 'new-recipe')
+        self.assertEqual(create_recipes_message.batch_id, new_batch.id)
+        self.assertEqual(create_recipes_message.event_id, new_batch.event_id)
+        self.assertEqual(create_recipes_message.recipe_type_name, new_batch.recipe_type.name)
+        self.assertEqual(create_recipes_message.recipe_type_rev_num, new_batch.recipe_type.revision_num)
+

--- a/scale/batch/views.py
+++ b/scale/batch/views.py
@@ -124,6 +124,7 @@ class BatchesView(ListCreateAPIView):
             raise BadParameter('Unknown recipe type: %d' % recipe_type_id)
 
         # Validate and create the batch
+        import pdb; pdb.set_trace()
         try:
             definition = BatchDefinitionV6(definition=definition_dict, do_validate=True).get_definition()
             configuration = BatchConfigurationV6(configuration=configuration_dict, do_validate=True).get_configuration()

--- a/scale/batch/views.py
+++ b/scale/batch/views.py
@@ -124,7 +124,6 @@ class BatchesView(ListCreateAPIView):
             raise BadParameter('Unknown recipe type: %d' % recipe_type_id)
 
         # Validate and create the batch
-        import pdb; pdb.set_trace()
         try:
             definition = BatchDefinitionV6(definition=definition_dict, do_validate=True).get_definition()
             configuration = BatchConfigurationV6(configuration=configuration_dict, do_validate=True).get_configuration()

--- a/scale/data/models.py
+++ b/scale/data/models.py
@@ -233,6 +233,7 @@ class DataSet(models.Model):
         :returns: Returns the outgoing primitive representation.
         :rtype: dict?
         """
+
         members = DataSet.objects.get_dataset_members(dataset_id=self.id)
         serializer = DataSetMemberSerializerV6(members, many=True)
         return serializer.data
@@ -243,6 +244,7 @@ class DataSet(models.Model):
         :returns: Returns the outgoing primitive representation.
         :rtype: dict?
         """
+
         files = DataSet.objects.get_dataset_files(self.id)
         serializer = DataSetFileSerializerV6(files, many=True)
         return serializer.data
@@ -334,11 +336,11 @@ class DataSetMemberManager(models.Manager):
         
         return data_list
 
-    def validate_data_list(self, dataset, data_list):
+    def validate_data_list(self, dataset_def, data_list):
         """Validates a list of data objects against a dataset
 
-        :param dataset: The dataset the member is a part of
-        :type dataset: :class:`data.models.DataSet`
+        :param dataset_def: The dataset definition the member is a part of
+        :type dataset_def:
         :param data_list: Data definitions of the dataset members
         :type data_list: [:class:`data.data.data.Data`]
         """
@@ -346,10 +348,10 @@ class DataSetMemberManager(models.Manager):
         is_valid = True
         errors = []
         warnings = []
-        
+
         for data in data_list:
             try:
-                dataset.get_definition().validate(data)
+                dataset_def.validate(data)
             except (InvalidData, InvalidDataSetMember) as ex:
                 is_valid = False
                 errors.append(ex.error)

--- a/scale/data/serializers.py
+++ b/scale/data/serializers.py
@@ -32,14 +32,16 @@ class DataSetListSerializerV6(DataSetBaseSerializerV6):
     files = serializers.IntegerField()
 
 class DataSetMemberSerializerV6(ModelIdSerializer):
+    """Converts datasetmember model fields to REST output"""
     created = serializers.DateTimeField()
-    data = serializers.JSONField(source='get_v6_data_json', default=None)
+    data = serializers.JSONField(source='get_v6_data_json', required=False)
+    file_ids = serializers.ListField(child=serializers.IntegerField())
 
 class DataSetDetailsSerializerV6(DataSetBaseSerializerV6):
-    """Converts dataset model feields to REST output"""
+    """Converts dataset model fields to REST output"""
     definition = serializers.JSONField(source='get_v6_definition_json')
-    members = DataSetMemberSerializerV6(required=False, many=True)
-    files = DataSetFileBaseSerializerV6(required=False, many=True)
+    members = DataSetMemberSerializerV6(source='get_dataset_members_json', required=False, many=True)
+    files = DataSetFileBaseSerializerV6(source='get_dataset_files_json', required=False, many=True)
 
 class DataSetMemberDetailsSerializerV6(DataSetMemberSerializerV6):
     dataset = ModelIdSerializer()

--- a/scale/data/test/test_models.py
+++ b/scale/data/test/test_models.py
@@ -176,7 +176,7 @@ class TestDataSetMemberManager(TransactionTestCase):
         data_dict['files']['input_e'] = [self.file1.id]
         data_dict['files']['input_f'] = [self.file2.id, self.file3.id]
         data = DataV6(data=data_dict).get_data()
-        validation = DataSetMember.objects.validate_data_list(dataset=self.dataset, data_list=[data])
+        validation = DataSetMember.objects.validate_data_list(dataset_def=self.dataset.get_definition(), data_list=[data])
         self.assertTrue(validation.is_valid)
 
         data_dict = copy.deepcopy(dataset_test_utils.DATA_DEFINITION)
@@ -184,7 +184,7 @@ class TestDataSetMemberManager(TransactionTestCase):
         data = DataV6(data=data_dict).get_data()
 
         # call test
-        validation = DataSetMember.objects.validate_data_list(dataset=self.dataset, data_list=[data])
+        validation = DataSetMember.objects.validate_data_list(dataset_def=self.dataset.get_definition(), data_list=[data])
         self.assertFalse(validation.is_valid)
         self.assertEqual(validation.errors[0].name, 'PARAM_REQUIRED')
 

--- a/scale/docs/rest/v6/batch.rst
+++ b/scale/docs/rest/v6/batch.rst
@@ -982,11 +982,20 @@ A batch configuration JSON configures how the jobs and recipes within a batch sh
 .. code-block:: javascript
 
    {
-      "priority": 100
+      "priority": 100,
+      "inputMap": [
+         {"input": "FILE_NAME", "datasetParameter": "NAME_FILE"}
+      ]
    }
 
 +-----------------------------------------------------------------------------------------------------------------------------+
 | **Batch Configuration**                                                                                                     |
 +=========================+===================+==========+====================================================================+
 | priority                | Integer           | Optional | Sets a new priority to use for all jobs within the batch           |
++-------------------------+-------------------+----------+--------------------------------------------------------------------+
+| inputMap                | Array             | Optional | Maps the batch recipe input to the dataset parameter names         |
++-------------------------+-------------------+----------+--------------------------------------------------------------------+
+| .input                  | String            | Required | The recipe input file name                                         |
++-------------------------+-------------------+----------+--------------------------------------------------------------------+
+| .datasetParameter       | String            | Required | The dataset parameter name that maps to the input                  |
 +-------------------------+-------------------+----------+--------------------------------------------------------------------+

--- a/scale/docs/rest/v6/batch.yml
+++ b/scale/docs/rest/v6/batch.yml
@@ -384,6 +384,20 @@ components:
             objects that recursively define the nodes with the sub-recipe to |
             force to reprocess.
 
+    input_map:
+      title: Input Map Definition
+      type: object
+      required: [all]
+      properties:
+        input:
+          type: string
+          description: The recipe type input the dataset parameter should map to
+          example: INPUT_FILE
+        datasetParameter:
+          type: string
+          description: The dataset parameter name the input maps to
+          example: FILE_INPUT
+
     batch_config:
       title: Batch Configuration
       type: object
@@ -391,6 +405,13 @@ components:
         priority:
           type: integer
           description: Sets a new priority to use for all jobs within the batch
+        inputMap:
+          type: array
+          description: Maps the recipe inputs to the proper dataset parameters
+          items:
+            type: object
+            additionalProperties:
+               $ref: '#/components/schemas/input_map'
 
     job_metrics:
       title: Job Metrics

--- a/scale/docs/rest/v6/data.rst
+++ b/scale/docs/rest/v6/data.rst
@@ -479,6 +479,72 @@ Location http://.../v6/datasets/105/
 | **Body**           | JSON containing the details of the newly created batch, see :ref:`rest_v6_dataset_details`         |
 +--------------------+----------------------------------------------------------------------------------------------------+
 
+
+.. _rest_v6_dataset_with_members:
+
+v6 Create Dataset with Members
+------------------------------
+
+**Example POST /v6/datasets API call**
+
+Request: POST http://.../v6/datasets/
+
+.. code-block:: javascript
+    {
+        "title": "My Dataset",
+        "description": "My Dataset Description",
+        "definition": <:ref:`Dataset JSON <rest_v6_data_dataset>`>,
+        "data": <:ref:`Data JSON <rest_v6_data_data>`>
+    }
+
+Response: 201 Ok
+Headers:
+Location http://.../v6/datasets/106
+
+.. code-block:: javascript
+
+   {
+      "id": 106,
+      "title": "My Dataset",
+      "description": "My Dataset Description",
+      "definition": <:ref:`Dataset JSON <rest_v6_data_dataset>`>,
+      "created": "1970-01-01T00:00:00Z",
+      "members": [<:ref:`Dataset Member <rest_v6_data_dataset_member>`>],
+      "files": [<:ref:`Dataset File <rest_v6_data_dataset_file>`>]
+   }
+
++-------------------------------------------------------------------------------------------------------------------------+
+| **Create Dataset*                                                                                                       |
++=========================================================================================================================+
+| Creates a new dataset with the given fields                                                                             |
++-------------------------------------------------------------------------------------------------------------------------+
+| **POST** /v6/datasets/                                                                                                  |
++---------------------+---------------------------------------------------------------------------------------------------+
+| **Content Type**    | *application/json*                                                                                |
++---------------------+---------------------------------------------------------------------------------------------------+
+| **JSON Fields**                                                                                                         |
++---------------------+-------------------+----------+--------------------------------------------------------------------+
+| title               | String            | Optional | The human-readable name of the dataset                             |
++---------------------+-------------------+----------+--------------------------------------------------------------------+
+| description         | String            | Optional | A human-readable description of the dataset                        |
++---------------------+-------------------+----------+--------------------------------------------------------------------+
+| definition          | JSON Object       | Required | JSON definition for the dataset                                    |
+|                     |                   |          | See :ref:`rest_v6_data_dataset`                                    |
++---------------------+-------------------+----------+--------------------------------------------------------------------+
+| data                | JSON Object       | Optional | JSON definition for the dataset members                            |
+|                     |                   |          | See :ref:`rest_v6_data_data`                                            |
++---------------------+-------------------+----------+--------------------------------------------------------------------+
+| **Successful Response**                                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Status**         | 201 Created                                                                                        |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Location**       | URL for retrieving the details of the newly created dataset                                        |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Content Type**   | *application/json*                                                                                 |
++--------------------+----------------------------------------------------------------------------------------------------+
+| **Body**           | JSON containing the details of the newly created batch, see :ref:`rest_v6_dataset_details`         |
++--------------------+----------------------------------------------------------------------------------------------------+
+
 .. _rest_v6_dataset_validation:
 
 v6 Validate Dataset


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
batch

### Description of change
<!-- Please provide a description of the change here. -->
Added an optional `inputMap` to the batch configuration. This configuration value maps the recipe input name to a dataset parameter name, therefore allowing datasets with parameters named differently than recipe inputs to be used in a batch.