### PR TITLE
#1839 Daily Metrics Binned by Hour

### DIFF
--- a/scale/metrics/fixtures/metrics_job_types.json
+++ b/scale/metrics/fixtures/metrics_job_types.json
@@ -4,7 +4,7 @@
 		"pk": null,
 		"fields": {
 			"name": "scale-daily-metrics",
-			"version": "1.0",
+			"version": "1.0.0",
 			"is_system": true,
 			"is_long_running": false,
 			"is_active": true,
@@ -53,7 +53,7 @@
         "model": "job.JobTypeRevision",
         "pk": null,
         "fields": {
-            "job_type": ["scale-daily-metrics", "1.0"],
+            "job_type": ["scale-daily-metrics", "1.0.0"],
             "revision_num": 1,
             "manifest": {
                 "seedVersion": "1.0.0",

--- a/scale/metrics/test/test_models.py
+++ b/scale/metrics/test/test_models.py
@@ -98,13 +98,13 @@ class TestMetricsError(TestCase):
 
         MetricsError.objects.calculate(datetime.datetime(2015, 1, 1, tzinfo=utc))
 
-        entries = MetricsError.objects.filter(occurred=datetime.datetime(2015, 1, 1, tzinfo=utc))
-        self.assertEqual(len(entries), 4)
+        entries = MetricsError.objects.filter(occurred__gte=datetime.datetime(2015, 1, 1, tzinfo=utc))
+        self.assertEqual(len(entries), 5)
 
         for entry in entries:
-            self.assertEqual(entry.occurred, datetime.datetime(2015, 1, 1, tzinfo=utc))
+            self.assertEqual(entry.occurred.date(), datetime.datetime(2015, 1, 1, tzinfo=utc).date())
             if entry.error == error:
-                self.assertEqual(entry.total_count, 2)
+                self.assertEqual(entry.total_count, 1)
             else:
                 self.assertEqual(entry.total_count, 1)
 
@@ -243,31 +243,77 @@ class TestMetricsIngest(TestCase):
 
         MetricsIngest.objects.calculate(datetime.datetime(2015, 1, 1, tzinfo=utc))
 
-        entries = MetricsIngest.objects.filter(occurred=datetime.datetime(2015, 1, 1, tzinfo=utc))
-        self.assertEqual(len(entries), 1)
+        entries = MetricsIngest.objects.filter(occurred__gte=datetime.datetime(2015, 1, 1, tzinfo=utc))
+        self.assertEqual(len(entries), 5)
+        for entry in entries:
+            if entry.occurred == datetime.datetime(2015, 1, 1, 1, tzinfo=utc):
+                self.assertEqual(entry.ingested_count, 1)
+                self.assertEqual(entry.total_count, 1)
+                self.assertEqual(entry.file_size_sum, 200)
+                self.assertEqual(entry.file_size_min, 200)
+                self.assertEqual(entry.file_size_max, 200)
+                self.assertEqual(entry.file_size_avg, 200)
+                self.assertEqual(entry.transfer_time_sum, 600)
+                self.assertEqual(entry.transfer_time_min, 600)
+                self.assertEqual(entry.transfer_time_max, 600)
+                self.assertEqual(entry.transfer_time_avg, 600)
+                self.assertEqual(entry.ingest_time_sum, 3600)
+                self.assertEqual(entry.ingest_time_min, 3600)
+                self.assertEqual(entry.ingest_time_max, 3600)
+                self.assertEqual(entry.ingest_time_avg, 3600)
 
-        entry = entries.first()
-        self.assertEqual(entry.occurred, datetime.datetime(2015, 1, 1, tzinfo=utc))
-        self.assertEqual(entry.deferred_count, 1)
-        self.assertEqual(entry.ingested_count, 2)
-        self.assertEqual(entry.errored_count, 1)
-        self.assertEqual(entry.duplicate_count, 1)
-        self.assertEqual(entry.total_count, 5)
+            elif entry.occurred == datetime.datetime(2015, 1, 1, 2, tzinfo=utc):
+                self.assertEqual(entry.ingested_count, 1)
+                self.assertEqual(entry.total_count, 1)
+                self.assertEqual(entry.file_size_sum, 100)
+                self.assertEqual(entry.file_size_min, 100)
+                self.assertEqual(entry.file_size_max, 100)
+                self.assertEqual(entry.file_size_avg, 100)
+                self.assertEqual(entry.transfer_time_sum, 1200)
+                self.assertEqual(entry.transfer_time_min, 1200)
+                self.assertEqual(entry.transfer_time_max, 1200)
+                self.assertEqual(entry.transfer_time_avg, 1200)
+                self.assertEqual(entry.ingest_time_sum, 7200)
+                self.assertEqual(entry.ingest_time_min, 7200)
+                self.assertEqual(entry.ingest_time_max, 7200)
+                self.assertEqual(entry.ingest_time_avg, 7200)
 
-        self.assertEqual(entry.file_size_sum, 600)
-        self.assertEqual(entry.file_size_min, 100)
-        self.assertEqual(entry.file_size_max, 200)
-        self.assertEqual(entry.file_size_avg, 120)
+            elif entry.occurred == datetime.datetime(2015, 1, 1, 3, tzinfo=utc):
+                self.assertEqual(entry.errored_count, 1)
+                self.assertEqual(entry.total_count, 1)
+                self.assertEqual(entry.file_size_sum, 100)
+                self.assertEqual(entry.file_size_min, 100)
+                self.assertEqual(entry.file_size_max, 100)
+                self.assertEqual(entry.file_size_avg, 100)
+                self.assertEqual(entry.transfer_time_sum, 1800)
+                self.assertEqual(entry.transfer_time_min, 1800)
+                self.assertEqual(entry.transfer_time_max, 1800)
+                self.assertEqual(entry.transfer_time_avg, 1800)
 
-        self.assertEqual(entry.transfer_time_sum, 9000)
-        self.assertEqual(entry.transfer_time_min, 600)
-        self.assertEqual(entry.transfer_time_max, 3000)
-        self.assertEqual(entry.transfer_time_avg, 1800)
+            elif entry.occurred == datetime.datetime(2015, 1, 1, 4, tzinfo=utc):
+                self.assertEqual(entry.deferred_count, 1)
+                self.assertEqual(entry.total_count, 1)
+                self.assertEqual(entry.file_size_sum, 100)
+                self.assertEqual(entry.file_size_min, 100)
+                self.assertEqual(entry.file_size_max, 100)
+                self.assertEqual(entry.file_size_avg, 100)
+                self.assertEqual(entry.transfer_time_sum, 2400)
+                self.assertEqual(entry.transfer_time_min, 2400)
+                self.assertEqual(entry.transfer_time_max, 2400)
+                self.assertEqual(entry.transfer_time_avg, 2400)
 
-        self.assertEqual(entry.ingest_time_sum, 10800)
-        self.assertEqual(entry.ingest_time_min, 3600)
-        self.assertEqual(entry.ingest_time_max, 7200)
-        self.assertEqual(entry.ingest_time_avg, 5400)
+            elif entry.occurred == datetime.datetime(2015, 1, 1, 5, tzinfo=utc):
+                self.assertEqual(entry.duplicate_count, 1)
+                self.assertEqual(entry.total_count, 1)
+                self.assertEqual(entry.file_size_sum, 100)
+                self.assertEqual(entry.file_size_min, 100)
+                self.assertEqual(entry.file_size_max, 100)
+                self.assertEqual(entry.file_size_avg, 100)
+                self.assertEqual(entry.transfer_time_sum, 3000)
+                self.assertEqual(entry.transfer_time_min, 3000)
+                self.assertEqual(entry.transfer_time_max, 3000)
+                self.assertEqual(entry.transfer_time_avg, 3000)
+
 
     def test_calculate_stats_partial(self):
         """Tests individual statistics are null when information is unavailable."""

--- a/scale/metrics/test/test_models.py
+++ b/scale/metrics/test/test_models.py
@@ -365,6 +365,41 @@ class TestMetricsJobType(TestCase):
 
         self.assertEqual(len(entries), 0)
 
+    def test_calculate_range(self):
+        """Tests generating metrics for a specific date range"""
+        # 4 failed, 5 completed
+        job_test_utils.create_job(status='FAILED')
+        job_test_utils.create_job(status='FAILED')
+        job_test_utils.create_job(status='FAILED')
+        job_test_utils.create_job(status='COMPLETED')
+        job_test_utils.create_job(status='COMPLETED')
+        job_test_utils.create_job(status='COMPLETED')
+        job_test_utils.create_job(status='COMPLETED')
+
+        job1 = job_test_utils.create_job(status='FAILED', ended=datetime.datetime(2015, 1, 1, 10, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job1, status=job1.status, ended=job1.ended)
+        job2 = job_test_utils.create_job(status='FAILED', ended=datetime.datetime(2015, 1, 1, 11, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job2, status=job2.status, ended=job2.ended)
+        job3 = job_test_utils.create_job(status='FAILED', ended=datetime.datetime(2015, 1, 1, 12, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job3, status=job3.status, ended=job3.ended)
+        job4 = job_test_utils.create_job(status='FAILED', ended=datetime.datetime(2015, 1, 1, 13, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job4, status=job4.status, ended=job4.ended)
+
+        job5 = job_test_utils.create_job(status='COMPLETED', ended=datetime.datetime(2015, 1, 1, 10, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job5, status=job5.status, ended=job5.ended)
+        job6 = job_test_utils.create_job(status='COMPLETED', ended=datetime.datetime(2015, 1, 1, 11, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job6, status=job6.status, ended=job6.ended)
+        job7 = job_test_utils.create_job(status='COMPLETED', ended=datetime.datetime(2015, 1, 1, 12, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job7, status=job7.status, ended=job7.ended)
+        job8 = job_test_utils.create_job(status='COMPLETED', ended=datetime.datetime(2015, 1, 1, 13, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job8, status=job8.status, ended=job8.ended)
+        job9 = job_test_utils.create_job(status='COMPLETED', ended=datetime.datetime(2015, 1, 1, 14, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job9, status=job9.status, ended=job9.ended)
+
+        MetricsJobType.objects.calculate(datetime.datetime(2015, 1, 1, tzinfo=utc))
+        entries = MetricsJobType.objects.filter(occurred__gt=datetime.datetime(2015, 1, 1, tzinfo=utc))
+        self.assertEqual(len(entries), 9)
+
     def test_calculate_filtered(self):
         """Tests generating metrics with only certain job executions."""
         job_test_utils.create_job(status='QUEUED')

--- a/scale/metrics/test/test_views.py
+++ b/scale/metrics/test/test_views.py
@@ -254,13 +254,13 @@ class TestMetricPlotViewV6(APITransactionTestCase):
 
         from django.utils.timezone import utc
         job1 = job_test_utils.create_job(status='FAILED', ended=datetime.datetime(2015, 1, 1, 10, tzinfo=utc))
-        job_test_utils.create_job_exe(job=job1, status=job1.status, ended=job1.ended)
+        job_test_utils.create_job_exe(job=job1, status='FAILED', ended=job1.ended)
         job2 = job_test_utils.create_job(status='FAILED', ended=datetime.datetime(2015, 1, 1, 11, tzinfo=utc))
-        job_test_utils.create_job_exe(job=job2, status=job2.status, ended=job2.ended)
+        job_test_utils.create_job_exe(job=job2, status='FAILED', ended=job2.ended)
         job3 = job_test_utils.create_job(status='FAILED', ended=datetime.datetime(2015, 1, 1, 12, tzinfo=utc))
-        job_test_utils.create_job_exe(job=job3, status=job3.status, ended=job3.ended)
+        job_test_utils.create_job_exe(job=job3, status='FAILED', ended=job3.ended)
         job4 = job_test_utils.create_job(status='FAILED', ended=datetime.datetime(2015, 1, 1, 13, tzinfo=utc))
-        job_test_utils.create_job_exe(job=job4, status=job4.status, ended=job4.ended)
+        job_test_utils.create_job_exe(job=job4, status='FAILED', ended=job4.ended)
 
         job5 = job_test_utils.create_job(status='COMPLETED', ended=datetime.datetime(2015, 1, 1, 10, tzinfo=utc))
         job_test_utils.create_job_exe(job=job5, status=job5.status, ended=job5.ended)
@@ -282,4 +282,16 @@ class TestMetricPlotViewV6(APITransactionTestCase):
 
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 2)
+        self.assertEqual(result['results'][0]['min_x'], unicode('2015-01-01T11:00:00Z'))
+        self.assertEqual(result['results'][0]['max_x'], unicode('2015-01-01T13:00:00Z'))
+        self.assertEqual(len(result['results'][0]['values']), 3)
+        for value in result['results'][0]['values']:
+            self.assertEqual(value['value'], 1)
+
+        self.assertEqual(len(result['results'][1]['values']), 3)
+        self.assertEqual(result['results'][1]['min_x'], unicode('2015-01-01T11:00:00Z'))
+        self.assertEqual(result['results'][1]['max_x'], unicode('2015-01-01T13:00:00Z'))
+        for value in result['results'][1]['values']:
+            self.assertEqual(value['value'], 1)
+
 

--- a/scale/metrics/test/test_views.py
+++ b/scale/metrics/test/test_views.py
@@ -248,4 +248,38 @@ class TestMetricPlotViewV6(APITransactionTestCase):
         result = json.loads(response.content)
         self.assertEqual(len(result['results']), 1)
         self.assertEqual(len(result['results'][0]['values']), 3)
-        
+
+    def test_completed_failed(self):
+        """Tests the metrics plot view completed and failed"""
+
+        from django.utils.timezone import utc
+        job1 = job_test_utils.create_job(status='FAILED', ended=datetime.datetime(2015, 1, 1, 10, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job1, status=job1.status, ended=job1.ended)
+        job2 = job_test_utils.create_job(status='FAILED', ended=datetime.datetime(2015, 1, 1, 11, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job2, status=job2.status, ended=job2.ended)
+        job3 = job_test_utils.create_job(status='FAILED', ended=datetime.datetime(2015, 1, 1, 12, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job3, status=job3.status, ended=job3.ended)
+        job4 = job_test_utils.create_job(status='FAILED', ended=datetime.datetime(2015, 1, 1, 13, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job4, status=job4.status, ended=job4.ended)
+
+        job5 = job_test_utils.create_job(status='COMPLETED', ended=datetime.datetime(2015, 1, 1, 10, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job5, status=job5.status, ended=job5.ended)
+        job6 = job_test_utils.create_job(status='COMPLETED', ended=datetime.datetime(2015, 1, 1, 11, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job6, status=job6.status, ended=job6.ended)
+        job7 = job_test_utils.create_job(status='COMPLETED', ended=datetime.datetime(2015, 1, 1, 12, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job7, status=job7.status, ended=job7.ended)
+        job8 = job_test_utils.create_job(status='COMPLETED', ended=datetime.datetime(2015, 1, 1, 13, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job8, status=job8.status, ended=job8.ended)
+        job9 = job_test_utils.create_job(status='COMPLETED', ended=datetime.datetime(2015, 1, 1, 14, tzinfo=utc))
+        job_test_utils.create_job_exe(job=job9, status=job9.status, ended=job9.ended)
+
+        from metrics.models import MetricsJobType
+        MetricsJobType.objects.calculate(datetime.datetime(2015, 1, 1, tzinfo=utc))
+
+        url = '/v6/metrics/job-types/plot-data/?column=completed_count&column=failed_count&dataType=job-types&started=2015-01-01T11:00:00Z&ended=2015-01-01T13:00:00Z'
+        response = self.client.generic('GET', url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        result = json.loads(response.content)
+        self.assertEqual(len(result['results']), 2)
+


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
metrics

### Description of change
<!-- Please provide a description of the change here. -->
Updated the calculation method of the daily metrics (ingest, error, and job-type) to bin the metrics data by hour instead of simply daily totals. One thing to consider is this will expand the database records significantly since we are now storing records for each hour per job type instead of each day per job type.