### PR TITLE
Scheduler node fix

### DIFF
--- a/scale/job/test/utils.py
+++ b/scale/job/test/utils.py
@@ -209,7 +209,7 @@ def create_clock_event(rule=None, occurred=None):
     return trigger_test_utils.create_trigger_event(trigger_type=event_type, rule=rule, occurred=occurred)
 
 
-def create_job(job_type=None, event=None, status='PENDING', error=None, input=None, num_exes=1, max_tries=None,
+def create_job(job_type=None, event=None, status='PENDING', error=None, input=None, num_exes=1, max_tries=None, node=None,
                queued=None, started=None, ended=None, last_status_change=None, priority=100, output=None, job_config=None,
                superseded_job=None, is_superseded=False, superseded=None, input_file_size=10.0, recipe=None, save=True):
     """Creates a job model for unit testing
@@ -254,6 +254,11 @@ def create_job(job_type=None, event=None, status='PENDING', error=None, input=No
     job.is_superseded = is_superseded
     job.superseded = superseded
     job.input_file_size = input_file_size
+    if status in ['RUNNING', 'FAILED', 'COMPLETED', 'CANCELED ']:
+        if not node:
+            node = node_utils.create_node()
+        job.node = node
+
     if save:
         job.save()
     return job

--- a/scale/node/models.py
+++ b/scale/node/models.py
@@ -6,7 +6,7 @@ import logging
 from django.db import models, transaction
 from django.utils.timezone import now
 
-from job.models import JobExecution, JobExecutionEnd
+from job.models import Job
 
 logger = logging.getLogger(__name__)
 
@@ -78,17 +78,16 @@ class NodeManager(models.Manager):
             nodes = nodes.order_by('last_modified')
         return nodes
 
-    def get_nodes_running_job_exes(self):
-        """Returns a list of nodes that are currently running job_exes.
+    def get_nodes_running_jobs(self):
+        """Returns a list of nodes that are currently running jobs.
 
-        :returns: The list of node ids running job_exes
+        :returns: The list of node ids running jobs
         :rtype: list
         """
 
-        job_exe_end = JobExecutionEnd.objects.all().values_list('job_exe', flat=True)
-        job_exes = JobExecution.objects.exclude(id__in=job_exe_end).values_list('node_id', flat=True)
+        jobs = Job.objects.filter(status='RUNNING').values_list('node_id', flat=True)
 
-        return list(Node.objects.filter(id__in=job_exes, is_active=True).values_list('id', flat=True))
+        return list(Node.objects.filter(id__in=jobs, is_active=True).values_list('id', flat=True))
 
     def get_scheduler_nodes(self, hostnames):
         """Returns a list of all nodes that either have one of the given host names or is active.

--- a/scale/node/test/test_models.py
+++ b/scale/node/test/test_models.py
@@ -10,8 +10,8 @@ from node.test import utils as node_test_utils
 
 class TestNodeManager(TransactionTestCase):
 
-    def test_get_nodes_running_job_exes(self):
-        """Tests calling NodeManager.get_nodes_running_job_exes()"""
+    def test_get_nodes_running_jobs(self):
+        """Tests calling NodeManager.get_nodes_running_jobs()"""
 
         # Create nodes
         node_1 = node_test_utils.create_node(hostname='node_1')
@@ -19,7 +19,7 @@ class TestNodeManager(TransactionTestCase):
         node_3 = node_test_utils.create_node(hostname='node_3')
 
         # No running jobs; should be empty
-        nodes_w_jobs = Node.objects.get_nodes_running_job_exes()
+        nodes_w_jobs = Node.objects.get_nodes_running_jobs()
         self.assertEqual(nodes_w_jobs, [])
 
         job_test_utils.create_job_exe(node=node_3, status='COMPLETED')
@@ -27,21 +27,23 @@ class TestNodeManager(TransactionTestCase):
         job_test_utils.create_job_exe(node=node_3, status='CANCELED')
 
         # 0 running jobs
-        self.assertEqual(Node.objects.get_nodes_running_job_exes(), [])
+        self.assertEqual(Node.objects.get_nodes_running_jobs(), [])
         
         # Create a running job_exe
-        job_test_utils.create_running_job_exe(node=node_1)
+        job = job_test_utils.create_job(status='RUNNING', node=node_1)
+        job_test_utils.create_running_job_exe(job=job, node=node_1)
 
         # 1 running job on node_1
-        nodes_w_jobs = Node.objects.get_nodes_running_job_exes()
+        nodes_w_jobs = Node.objects.get_nodes_running_jobs()
         self.assertEqual(len(nodes_w_jobs), 1)
         self.assertEqual(nodes_w_jobs[0], node_1.id)
 
         # Create another running job_exe (using a different way to create running job_exe for testing completeness)
-        job_test_utils.create_job_exe(node=node_2, status='RUNNING')
+        job = job_test_utils.create_job(status='RUNNING', node=node_2)
+        job_test_utils.create_job_exe(job=job, node=node_2, status='RUNNING')
 
         # 2 running job_exes
-        nodes_w_jobs = Node.objects.get_nodes_running_job_exes()
+        nodes_w_jobs = Node.objects.get_nodes_running_jobs()
         self.assertEqual(len(nodes_w_jobs), 2)
         self.assertIn(node_1.id, nodes_w_jobs)
         self.assertIn(node_2.id, nodes_w_jobs)

--- a/scale/scheduler/node/manager.py
+++ b/scale/scheduler/node/manager.py
@@ -201,8 +201,8 @@ class NodeManager(object):
                     self._nodes[hostname].update_from_mesos(is_online=is_online)
                 self._agents[agent_id] = new_agent
 
-            # Get list of nodes that are currently running job_exes
-            nodes_running_job_exes = Node.objects.get_nodes_running_job_exes()
+            # Get list of nodes that are currently running jobs
+            nodes_running_jobs = Node.objects.get_nodes_running_jobs()
 
             # Update nodes from database models
             for node_model in node_models.values():
@@ -211,7 +211,7 @@ class NodeManager(object):
                     # Host name already exists, update model information
                     node = self._nodes[hostname]
                     node.update_from_model(node_model, scheduler_config)
-                    if node.id not in nodes_running_job_exes and node.should_be_removed():
+                    if node.id not in nodes_running_jobs and node.should_be_removed():
                         logger.info('Node %s removed due to being offline or not offering resources', hostname)
                         self._nodes[hostname].update_from_mesos(is_online=False)
                         del self._nodes[hostname]

--- a/scale/scheduler/test/node/test_manager.py
+++ b/scale/scheduler/test/node/test_manager.py
@@ -273,7 +273,8 @@ class TestNodeManager(TestCase):
         node_mgr.sync_with_database(scheduler_mgr.config)
 
         # Add job to node
-        job_test_utils.create_running_job_exe(agent_id=self.agent_1, node=self.node_1)
+        job = job_test_utils.create_job(status='RUNNING', node=self.node_1)
+        job_test_utils.create_running_job_exe(agent_id=self.agent_1, node=self.node_1, job=job)
 
         # Set last_offer_received to 1 hour ago
         Node.objects.filter(id=self.node_1.id).update(last_offer_received=last_offer)


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
- node
- scheduler

### Description of change
<!-- Please provide a description of the change here. -->
The original `job_exe_end` and `job_exe` query was terrible for many reasons.  I changed it to just get the node to job relation which should be much faster.  Fixed tests and added `node` assignment to the the test utils. 