### PR TITLE
Pinning zipp to < 2.0.0

### DIFF
--- a/scale/pip/production.txt
+++ b/scale/pip/production.txt
@@ -2,6 +2,7 @@
 # Use command: pip install -r prod_linux.txt
 
 # Main requirements
+zipp<2.0.0
 boto3>=1.4.0,<2
 cryptography>=2.3,<3
 dj-database-url

--- a/scale/pip/requirements.txt
+++ b/scale/pip/requirements.txt
@@ -2,6 +2,7 @@
 # Use command: pip install -r requirements.txt
 
 # Main requirements
+zipp<2.0.0
 boto3>=1.4.0,<2
 cryptography>=2.3,<3
 dj-database-url


### PR DESCRIPTION
Pinning the zipp version to less than 2.0.0 due to support for Python 2.7 was discontinued in >= 2.0.0

<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
pip/production.txt
pip/requirements.txt

### Description of change
<!-- Please provide a description of the change here. -->
Zipp >= 2.0.0 discontinued support for Python 2.7. Due to dependencies on this library, we need to pin the version of zipp we're pulling to < 2.0.0