### PR TITLE
Adding is_system to jobtype base serializer

### DIFF
--- a/scale/docs/rest/v6/job.rst
+++ b/scale/docs/rest/v6/job.rst
@@ -33,6 +33,7 @@ Response: 200 OK
             "title": "Scale Ingest",
             "description": "Ingests a source file into a workspace",
             "is_active": true,
+            "is_system": true,
             "is_paused": false,
             "is_published": false,
             "icon_code": "f013",
@@ -284,6 +285,7 @@ Location http://.../v6/job/1/
           "description": null,
           "is_active": true,
           "is_paused": false,
+          "is_system": true,
           "is_published": false,
           "icon_code": null,
           "unmet_resources": "chocolate,vanilla"
@@ -299,6 +301,7 @@ Location http://.../v6/job/1/
               "description": null,
               "is_active": true,
               "is_paused": false,
+              "is_system": true,
               "is_published": false,
               "icon_code": null,
               "unmet_resources": "chocolate,vanilla"
@@ -440,6 +443,7 @@ Response: 200 OK
         "description": "Ingests a source file into a workspace",
         "is_active": true,
         "is_paused": false,
+        "is_system": true,
         "is_published": false,
         "icon_code": "f013",
         "unmet_resources": "chocolate,vanilla"
@@ -530,6 +534,7 @@ Response: 200 OK
             "description": "Ingests a source file into a workspace",
             "is_active": true,
             "is_paused": false,
+            "is_system": true,
             "is_published": false,
             "icon_code": "f013",
             "unmet_resources": "chocolate,vanilla"
@@ -798,6 +803,7 @@ Response: 200 OK
             "description": "Ingests a source file into a workspace",
             "is_active": true,
             "is_paused": false,
+            "is_system": true,
             "is_published": false,
             "icon_code": "f013",
             "unmet_resources": "chocolate,vanilla"
@@ -926,6 +932,7 @@ Response: 200 OK
       "description": "Ingests a source file into a workspace",
       "is_active": true,
       "is_paused": false,
+      "is_system": true,
       "is_published": false,
       "icon_code": "f013",
       "unmet_resources": "chocolate,vanilla"

--- a/scale/job/job_type_serializers.py
+++ b/scale/job/job_type_serializers.py
@@ -17,6 +17,7 @@ class JobTypeBaseSerializerV6(ModelIdSerializer):
     title = serializers.CharField(source='get_title')
     description = serializers.CharField(source='get_description')
     is_active = serializers.BooleanField()
+    is_system = serializers.BooleanField()
     is_paused = serializers.BooleanField()
     is_published = serializers.BooleanField()
     icon_code = serializers.CharField()
@@ -36,7 +37,6 @@ class JobTypeSerializerV6(JobTypeBaseSerializerV6):
 
     is_active = serializers.BooleanField()
     is_paused = serializers.BooleanField()
-    is_system = serializers.BooleanField()
     max_scheduled = serializers.IntegerField()
     max_tries = serializers.IntegerField()
     revision_num = serializers.IntegerField()


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
job

### Description of change
<!-- Please provide a description of the change here. -->
Added `is_system` to the serializer for the base jobtype. This should add this field to the serializer utilized by the /jobs endpoint to satisfy #1843.