### PR TITLE
Adding SCHEDULER_QUEUE_LIMIT as environment variable

### DIFF
--- a/dockerfiles/framework/scale/bootstrap.py
+++ b/dockerfiles/framework/scale/bootstrap.py
@@ -22,6 +22,7 @@ SERVICE_SECRET = os.getenv('SERVICE_SECRET')
 FLUENTD_BUFFER_WARN = int(os.getenv('FLUENTD_BUFFER_WARN', 10)) #10 items backed up in the logging queue
 FLUENTD_BUFFER_SIZE_WARN = int(os.getenv('FLUENTD_BUFFER_SIZE_WARN', 1000000000)) #1GB
 MESSSAGE_QUEUE_DEPTH_WARN = int(os.getenv('MESSSAGE_QUEUE_DEPTH_WARN', 100)) #100 messages in the message broker queue
+SCHEDULER_QUEUE_LIMIT = int(os.getenv('SCHEDULER_QUEUE_LIMIT', 500)) # Queue limit of 500
 
 # used to look for other env vars prefixed with this value
 SCALEUI_ENV_PREFIX = os.getenv('SCALEUI_ENV_PREFIX', 'SCALEUI_')

--- a/scale/README.md
+++ b/scale/README.md
@@ -260,6 +260,7 @@ below for reference.
 | SCALE_WEBSERVER_CPU         | 1                               | UI/API CPU allocation during bootstrap     |
 | SCALE_WEBSERVER_MEMORY      | 2048                            | UI/API memory allocation during bootstrap  |
 | SCALE_ZK_URL                | None                            | Scale master location                      |
+| SCHEDULER_QUEUE_LIMIT       | 500                             | Number of queues processed at a time       |
 | SERVICE_SECRET              | None                            | JSON object used for DCOS EE Strict Auth   |
 | SECRETS_SSL_WARNINGS        | 'true'                          | Should secrets SSL warnings be raised?     |
 | SECRETS_TOKEN               | None                            | Authentication token for secrets service   |

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -87,6 +87,9 @@ BROKER_URL = 'amqp://guest:guest@localhost:5672//'
 QUEUE_NAME = 'scale-command-messages'
 MESSSAGE_QUEUE_DEPTH_WARN = int(os.environ.get('MESSSAGE_QUEUE_DEPTH_WARN', -1))
 
+# Queue limit
+SCHEDULER_QUEUE_LIMIT = int(os.environ.get('SCHEDULER_QUEUE_LIMIT', 500))
+
 # Base URL of vault or DCOS secrets store, or None to disable secrets
 SECRETS_URL = None
 # Public token if DCOS secrets store, or privleged token for vault

--- a/scale/scheduler/scheduling/manager.py
+++ b/scale/scheduler/scheduling/manager.py
@@ -20,6 +20,7 @@ from mesos_api.tasks import create_mesos_task
 from node.resources.node_resources import NodeResources
 from queue.job_exe import QueuedJobExecution
 from queue.models import Queue
+from scale import settings as scale_settings
 from scheduler.cleanup.manager import cleanup_mgr
 from scheduler.manager import scheduler_mgr, SchedulerWarning
 from scheduler.node.manager import node_mgr
@@ -34,7 +35,7 @@ from util.retry import retry_database_query
 # Warning threshold for queue processing duration
 PROCESS_QUEUE_WARN_THRESHOLD = datetime.timedelta(milliseconds=300)
 # Maximum number of jobs to grab off of the queue at one time
-QUEUE_LIMIT = 500
+QUEUE_LIMIT = scale_settings.SCHEDULER_QUEUE_LIMIT
 # Warning threshold for scheduling query duration
 SCHEDULE_QUERY_WARN_THRESHOLD = datetime.timedelta(milliseconds=300)
 # Warning threshold for task launch duration


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
settings

### Description of change
<!-- Please provide a description of the change here. -->
Added a SCHEDULER_QUEUE_LIMIT variable in order to dynamically update the number of queues we process at a time (rather than hard code 500). This is to temporarily address #1801 by allowing us to up the queue limit in order to bypass the unschedulable jobs blocking the queue.