### PR TITLE
Basic setup for django-debug-toolbar

### DIFF
--- a/scale/pip/production.txt
+++ b/scale/pip/production.txt
@@ -8,6 +8,7 @@ cryptography>=2.3,<3
 dj-database-url
 Django>=1.11.0,<1.12.0
 djangorestframework>=3.9.1,<3.10.0
+django-debug-toolbar==1.11
 django-filter>=1.1,<2
 django-geoaxis>=0.0.2,<1
 django-oauth-toolkit>=1.1.3,<1.2

--- a/scale/pip/requirements.txt
+++ b/scale/pip/requirements.txt
@@ -8,6 +8,7 @@ cryptography>=2.3,<3
 dj-database-url
 Django>=1.11.0,<1.12.0
 djangorestframework>=3.9.1,<3.10.0
+django-debug-toolbar==1.11
 django-filter>=1.1,<2
 django-geoaxis>=0.0.2,<1
 django-oauth-toolkit>=1.1.3,<1.2

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -121,6 +121,10 @@ AUTHENTICATION_ENABLED = get_env_boolean('AUTHENTICATION_ENABLED', True)
 
 ALLOWED_HOSTS = ['localhost', '127.0.0.1']
 
+# used primarily by debug-toolbar to dictate what client url has access
+if os.environ.get('INTERNAL_IP'):
+    INTERNAL_IPS = [os.environ.get('INTERNAL_IP')]
+
 # Application definition
 INSTALLED_APPS = (
     'django.contrib.admin',
@@ -132,6 +136,7 @@ INSTALLED_APPS = (
     'django.contrib.gis',
     'rest_framework',
     'rest_framework.authtoken',
+    'debug_toolbar',
 
     ###############
     # Social Auth #
@@ -166,6 +171,7 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE = [
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'util.middleware.MultipleProxyMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/scale/scale/urls.py
+++ b/scale/scale/urls.py
@@ -52,3 +52,10 @@ unversioned_urls = [
 
 # Add unversioned_urls to URL regex pattern matcher
 urlpatterns.extend(unversioned_urls)
+
+# add debug toolbar urls
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ] + urlpatterns


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


### Affected app(s)
<!-- Please list affected Scale app(s). -->
- global change

### Description of change
<!-- Please provide a description of the change here. -->
This adds support for [django-debug-toolbar](https://django-debug-toolbar.readthedocs.io). This provides a collapsible sidebar ([panels](https://django-debug-toolbar.readthedocs.io/en/latest/panels.html))on the right side of any HTML encoded response. Primarily, this will expose the ability to see the exact SQL query and timing data directly on an API endpoint.

This is enabled in production, but will only be visible by setting `INTERNAL_IP` environment variable to your client's IP (ex, your laptop is set to 192.168.1.100). This has not been tested with the many layers of proxies in our various prod environments, but I think it should work. Alternatively, I usually have a separate `requirements.dev.txt` that only installs the package, then in `settings.py`:

```py
try:
    import debug_toolbar
except ImportError:
    pass
else:
    INSTALLED_APPS += ['debug_toolbar']
    # ...remaining setup
```

This method fully ensures the package is not even installed in production environments. Open to suggestions here, but `INTERNAL_IPS` should be sufficient.