### PR TITLE
#1859 Add input file info to /jobs API

### DIFF
--- a/scale/docs/rest/v6/job.rst
+++ b/scale/docs/rest/v6/job.rst
@@ -83,6 +83,9 @@ Response: 200 OK
           "error": null,
           "num_exes": 1,
           "input_file_size": 64,
+          "input_files": {
+              "INPUT_FILE": ["my-file.file"]
+          },
           "source_started": "2015-08-28T17:55:41.005Z",
           "source_ended": "2015-08-28T17:56:41.005Z",
           "source_sensor_class": "classA",
@@ -225,6 +228,8 @@ Response: 200 OK
 +---------------------+-------------------+-------------------------------------------------------------------------------+
 | .input_file_size    | Decimal           | The amount of disk space in MiB required for input files for this job.        |
 +---------------------+-------------------+-------------------------------------------------------------------------------+
+| .input_files        | JSON Object       | The input files associated with the job.                                      |
++---------------------+-------------------+-------------------------------------------------------------------------------+
 | .source_started     | ISO-8601 Datetime | When collection of the source file started.                                   |
 +---------------------+-------------------+-------------------------------------------------------------------------------+
 | .source_ended       | ISO-8601 Datetime | When collection of the source file ended.                                     |
@@ -357,6 +362,9 @@ Location http://.../v6/job/1/
       "error": null,
       "num_exes": 1,
       "input_file_size": 1.0,
+      "input_files": {
+          "input_a": ["my-file.file"]
+      },
       "source_started": null,
       "source_ended": null,
       "created": "2018-11-01T13:30:22.530638Z",
@@ -566,6 +574,9 @@ Response: 200 OK
         "json": {'input_c': 999, 'input_d': {'hello'}}
       },
       "input_file_size": 64,
+      "input_files": {
+          "INPUT_FILE": ["my-file.file"]
+      },
       "output": {
         "files": {'output_a': [456]},
         "json": {'output_b': 'success'}
@@ -656,6 +667,8 @@ Response: 200 OK
 |                    |                   | (See :ref:`Data <rest_v6_data_data>`)                                          |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | input_file_size    | Decimal           | The amount of disk space in MiB required for input files for this job.         |
++---------------------+-------------------+-------------------------------------------------------------------------------+
+| input_files        | JSON Object       | The input files associated with the job.                                      |
 +--------------------+-------------------+--------------------------------------------------------------------------------+
 | output             | JSON Object       | The output data for the job.                                                   |
 |                    |                   | (See :ref:`Data <rest_v6_data_data>`)                                          |

--- a/scale/docs/rest/v6/job.yml
+++ b/scale/docs/rest/v6/job.yml
@@ -459,6 +459,11 @@ components:
               type: number
               description: The amount of disk space in MiB required for input files for this job. 
               example: 1.0
+            input_files:
+              description: The input file names for the associated job
+              type: array
+              items:
+                type: string
             source_started:
               type: string
               format: date-time
@@ -520,6 +525,13 @@ components:
               format: date-time
               description: When the associated database model was last saved.
               example: 2015-09-10T15:24:53.987Z
+
+    job_input_files:
+      title: Job Input Files
+      type: object
+      properties:
+
+
 
     job_details:
       title: Job Details

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -921,7 +921,6 @@ class Job(models.Model):
     source_collection = models.TextField(blank=True, null=True, db_index=True)
     source_task = models.TextField(blank=True, null=True, db_index=True)
 
-
     created = models.DateTimeField(auto_now_add=True)
     queued = models.DateTimeField(blank=True, null=True)
     started = models.DateTimeField(blank=True, null=True)
@@ -1030,6 +1029,8 @@ class Job(models.Model):
         else:
             return self.job_type.get_job_configuration()
 
+
+
     def get_v6_configuration_json(self):
         """Returns the job configuration in v6 of the JSON schema
 
@@ -1053,6 +1054,21 @@ class Job(models.Model):
         """
 
         return DataV6(data=self.input, do_validate=False).get_data()
+
+    def get_input_files_json(self):
+        """Returns the input files data with more details
+
+        :returns: The detailed input files dict for this job
+        :rtype: dict
+        """
+
+        input_files = {}
+        input_data = self.get_input_data()
+        for data_value in input_data.values.values():
+            if data_value.param_type == FileParameter.PARAM_TYPE:
+                input_files[data_value.name] = [f.file_name for f in ScaleFile.objects.filter(
+                    id__in=data_value.file_ids).only('file_name')]
+        return input_files
 
     def get_v6_input_data_json(self):
         """Returns the input data for this job as v6 json with the version stripped

--- a/scale/job/serializers.py
+++ b/scale/job/serializers.py
@@ -49,6 +49,7 @@ class JobSerializerV6(JobBaseSerializerV6):
     max_tries = serializers.IntegerField()
     num_exes = serializers.IntegerField()
     input_file_size = serializers.FloatField()
+    input_files = serializers.JSONField(source='get_input_files_json')
 
     source_started = serializers.DateTimeField()
     source_ended = serializers.DateTimeField()


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
job

### Description of change
<!-- Please provide a description of the change here. -->
#1859 
Updated the JobSerializerV6 to include an `input_files` JSON field that lists all input file names for each input in the format: 
```
{
   "input_files": {"INPUT_FILE": ["file1-name.filext"], "INPUT_FILE_2": ["file2-name.filext", "file3-name.filext"]}
   ...
}
```
This change allows the input file list to be displayed in the Jobs table to satisfy the requirements of https://github.com/ngageoint/scale-ui/issues/414