### PR TITLE
Removing Unnecessary Scale Ingest Process Job Input Messages

### DIFF
--- a/scale/ingest/messages/create_ingest_jobs.py
+++ b/scale/ingest/messages/create_ingest_jobs.py
@@ -136,12 +136,6 @@ class CreateIngest(CommandMessage):
             ingest.job = ingest_job
             ingest.status = 'QUEUED'
             ingest.save()
-            
-        # Send message to start processing job input (done outside the transaction to hope the job exists)
-        # This can cause a race condition with a slow DB.
-        job = Job.objects.get_details(ingest_job.id)
-        self.new_messages.extend(create_process_job_input_messages([job.id]))
         
         return True
  
-        

--- a/scale/ingest/test/messages/test_create_ingest_jobs.py
+++ b/scale/ingest/test/messages/test_create_ingest_jobs.py
@@ -70,6 +70,4 @@ class TestCreateIngest(TestCase):
         result = message.execute()
         
         self.assertTrue(result)
-        self.assertEqual(len(message.new_messages), 1)
-        self.assertEqual(message.new_messages[0].type, 'process_job_input')
         


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `manage.py test` passes

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
ingest

### Description of change
<!-- Please provide a description of the change here. -->
The Scale Ingest processing message was creating unnecessary extra process_job_input messages after creating the ingest job resulting in 'input file for job xxx already processed' being logged in the message handler. I thought this had already been taken care of but apparently not?