### PR TITLE
Issue 1788 - Better login form

### DIFF
--- a/scale/accounts/templates/accounts/login.html
+++ b/scale/accounts/templates/accounts/login.html
@@ -2,17 +2,97 @@
 {% load static %}
 {% block title %}Login{% endblock %}
 
+{% block breadcrumbs %}
+    {% comment %}no need to show breadcrumbs, just use this as a spacer for the navbar{% endcomment %}
+    <div style="margin-top: 70px;"></div>
+{% endblock %}
+
 {% block content %}
-    <h2>Login</h2>
-    <form method="post">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <button type="submit">Login</button>
-    </form>
-    {% if GEOAXIS_ENABLED %}
-        <h3>Single sign-on providers:</h3>
-        <a class="btn-geoaxis btn-social btn bg-ms btn-block" href="{% url 'social:begin' 'geoaxis' %}?{{ redirect_field_name }}={{ redirect_field_value }}">
-            <i class="fa fa-lock"></i><img src="{% static 'accounts/geoaxis.png' %}" alt="Log In with GeoAxis"/>
-        </a>
-    {% endif %}
+    <div class="row">
+        <div class="col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Login</h3>
+                </div>
+                <div class="panel-body">
+                    <form method="post">
+                        {% csrf_token %}
+
+                        {% for error in form.non_field_errors %}
+                            <p class="text-danger text-center">
+                                {{ error }}
+                            </p>
+                        {% endfor %}
+
+                        <div class="form-group {% if form.username.errors %}has-error{% endif %}">
+                            <label for="{{ form.username.id_for_label }}"
+                                   class="control-label">
+                                {{ form.username.label | safe }}
+                            </label>
+
+                            <div class="controls">
+                                <input type="text"
+                                       name="{{ form.username.name }}"
+                                       {% if form.username.value %}value="{{ form.username.value }}"{% endif %}
+                                       class="form-control"
+                                       id="{{ form.username.id_for_label }}"
+                                       autofocus
+                                       autocomplete="username"
+                                       maxlength="{{ form.username.field.max_length }}">
+
+                                {% for error in form.username.errors %}
+                                    <p id="error_{{ forloop.counter }}_{{ form.username.id_for_label }}"
+                                       class="help-block">
+                                        <strong>{{ error }}</strong>
+                                    </p>
+                                {% endfor %}
+                            </div>
+                        </div>
+
+                        <div class="form-group {% if form.password.errors %}has-error{% endif %}">
+                            <label for="{{ form.password.id_for_label }}"
+                                   class="control-label">
+                                {{ form.password.label | safe }}
+                            </label>
+
+                            <div class="controls">
+                                <input type="password"
+                                       name="{{ form.password.name }}"
+                                       class="form-control"
+                                       id="{{ form.password.id_for_label }}"
+                                       autocomplete="current-password">
+
+                                {% for error in form.password.errors %}
+                                    <p id="error_{{ forloop.counter }}_{{ form.password.id_for_label }}"
+                                       class="help-block">
+                                        <strong>{{ error }}</strong>
+                                    </p>
+                                {% endfor %}
+                            </div>
+                        </div>
+
+                        <button type="submit"
+                                class="btn btn-primary btn-block btn-lg">
+                            Login
+                        </button>
+                    </form>
+
+                    {% if GEOAXIS_ENABLED %}
+                        <hr>
+                        <h5>Single sign-on providers</h5>
+
+                        <a class="btn btn-default btn-block"
+                           href="{% url 'social:begin' 'geoaxis' %}?{{ redirect_field_name }}={{ redirect_field_value }}">
+                            <img src="{% static 'accounts/geoaxis.png' %}"
+                                 alt="GEOAxIS"
+                                 style="max-width: 100px;">
+                            <br>
+                            NGA GEOAxIS
+                        </a>
+                    {% endif %}
+
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}


### PR DESCRIPTION
Fixes #1788 

<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [ ] tests are included
- [ ] migrations are included
- [ ] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
- Django's auth

### Description of change
<!-- Please provide a description of the change here. -->
This creates a bit more of a standard login form for SSO-enabled auth. Template logic was based on django-crispy-forms.

Normal login:
![Screenshot_2020-03-18 Login](https://user-images.githubusercontent.com/2390428/76998386-622f5200-692b-11ea-9d51-3da2b217ebc0.png)

Field-level validation:
![Screenshot_2020-03-18 Login(1)](https://user-images.githubusercontent.com/2390428/76998405-6c515080-692b-11ea-8420-c4004caa7644.png)

Form-level validation:
![Screenshot_2020-03-18 Login(2)](https://user-images.githubusercontent.com/2390428/76998439-7a06d600-692b-11ea-80b2-261843c9a28b.png)

With GEOAxIS enabled:
![Screenshot_2020-03-18 Login(3)](https://user-images.githubusercontent.com/2390428/76998464-855a0180-692b-11ea-8add-273aea4021db.png)

We can also move the single sign on section to the right (split the main box into two columns).

