### PR TITLE
Remove Command Messages for Ingests

### DIFF
--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -322,6 +322,7 @@ class IngestManager(models.Manager):
                 desc['scan_id'] = scan_id
                 event = TriggerEvent.objects.create_trigger_event('SCAN_TRANSFER', None, desc, when)
             elif strike_id:
+                ingest_id = ingest.id
                 desc['strike_id'] = strike_id
                 event = TriggerEvent.objects.create_trigger_event('STRIKE_TRANSFER', None, desc, when)
             else:

--- a/scale/ingest/models.py
+++ b/scale/ingest/models.py
@@ -319,10 +319,10 @@ class IngestManager(models.Manager):
 
             if scan_id:
                 ingest_id = Ingest.objects.get(scan_id=ingest.scan_id, file_name=ingest.file_name).id
-                desc['scan_id'] = self.scan_id
+                desc['scan_id'] = scan_id
                 event = TriggerEvent.objects.create_trigger_event('SCAN_TRANSFER', None, desc, when)
             elif strike_id:
-                desc['strike_id'] = self.strike_id
+                desc['strike_id'] = strike_id
                 event = TriggerEvent.objects.create_trigger_event('STRIKE_TRANSFER', None, desc, when)
             else:
                 raise Exception('One of scan_id or strike_id must be set')

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -66,10 +66,10 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
                                                               'job_type_revision': 1}}}}
         self.recipe_v7 = recipe_test_utils.create_recipe_type_v6(name='test-recipe-v7', definition=v7_recipe_type_def)
 
-
+    @patch('queue.models.CommandMessageManager')
     @patch('recipe.models.CommandMessageManager')
     @patch('ingest.models.CommandMessageManager')
-    def test_successful_recipe_kickoff(self, mock_msg_mgr, mock_msg_mgr_rc):
+    def test_successful_recipe_kickoff(self, mock_msg_mgr, mock_msg_mgr_rc, mock_msg_mgr_q):
         """Tests successfully producing an ingest that immediately calls a recipe"""
 
         strike_config = {
@@ -171,7 +171,8 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
         self.assertEqual(len(events), 3)
         self.assertEqual(events[2]['type'], 'STRIKE')
 
-    def test_successful_manual_kickoff(self):
+    @patch('queue.models.CommandMessageManager')
+    def test_successful_manual_kickoff(self, mock_msg_mgr):
         """Tests successfully producing an ingest that immediately calls a recipe"""
         
         ingest = ingest_test_utils.create_ingest(source_file=self.source_file)

--- a/scale/ingest/test/triggers/test_ingest_recipe_handler.py
+++ b/scale/ingest/test/triggers/test_ingest_recipe_handler.py
@@ -68,10 +68,8 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
 
 
     @patch('recipe.models.CommandMessageManager')
-    @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')
-    @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
     @patch('ingest.models.CommandMessageManager')
-    def test_successful_recipe_kickoff(self, mock_msg_mgr, mock_create, mock_msg_mgr_tr, mock_msg_mgr_rc):
+    def test_successful_recipe_kickoff(self, mock_msg_mgr, mock_msg_mgr_rc):
         """Tests successfully producing an ingest that immediately calls a recipe"""
 
         strike_config = {
@@ -94,9 +92,9 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
 
         # Call method to test
         IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-        mock_msg_mgr_tr.assert_called_once()
-        mock_create.assert_called_once()
-        
+        self.assertEqual(Recipe.objects.count(), 1)
+        self.assertEqual(Recipe.objects.first().recipe_type.name, self.recipe_v7.name)
+
         # Verify ingest event and trigger event objects were created
         from ingest.models import IngestEvent
         events = IngestEvent.objects.all().values()
@@ -124,9 +122,9 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
 
         # Call method to test
         IngestRecipeHandler().process_ingested_source_file(ingest.id, scan, self.source_file, now())
-        self.assertEqual(mock_msg_mgr_tr.call_count, 2)
-        self.assertEqual(mock_create.call_count, 2)
-        
+        self.assertEqual(Recipe.objects.count(), 2)
+        self.assertEqual(Recipe.objects.last().recipe_type.name, self.recipe_v7.name)
+
         # Verify events were created
         events = IngestEvent.objects.all().values()
         self.assertEqual(len(events), 2)
@@ -165,18 +163,15 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
 
         # Call method to test
         IngestRecipeHandler().process_ingested_source_file(ingest.id, strike, self.source_file, now())
-        self.assertEqual(mock_msg_mgr_tr.call_count, 3)
-        self.assertEqual(mock_create.call_count, 3)
-        
+        self.assertEqual(Recipe.objects.count(), 3)
+        self.assertEqual(Recipe.objects.last().recipe_type.name, self.recipe.name)
+
         # Verify events were created
         events = IngestEvent.objects.all().values()
         self.assertEqual(len(events), 3)
         self.assertEqual(events[2]['type'], 'STRIKE')
-        
 
-    @patch('ingest.triggers.ingest_recipe_handler.CommandMessageManager')
-    @patch('ingest.triggers.ingest_recipe_handler.create_recipes_messages')
-    def test_successful_manual_kickoff(self, mock_create, mock_msg_mgr):
+    def test_successful_manual_kickoff(self):
         """Tests successfully producing an ingest that immediately calls a recipe"""
         
         ingest = ingest_test_utils.create_ingest(source_file=self.source_file)
@@ -184,5 +179,5 @@ class TestIngestRecipeHandlerProcessIngestedSourceFile(TransactionTestCase):
 
         # Call method to test
         IngestRecipeHandler().process_manual_ingested_source_file(ingest.id, self.source_file, now(), recipe_type.id)
-        mock_msg_mgr.assert_called_once()
-        mock_create.assert_called_once()
+        self.assertEqual(Recipe.objects.all().count(), 1)
+        self.assertEqual(Recipe.objects.first().recipe_type.name, recipe_type.name)

--- a/scale/ingest/triggers/ingest_recipe_handler.py
+++ b/scale/ingest/triggers/ingest_recipe_handler.py
@@ -52,15 +52,67 @@ class IngestRecipeHandler(object):
             recipe_data.add_value(FileValue(input_name, [source_file.id]))
             event = self._create_trigger_event(None, source_file, when)
             ingest_event = self._create_ingest_event(ingest_id, None, source_file, when)
-            messages = create_recipes_messages(recipe_type.name, recipe_type.revision_num,
-                                               convert_data_to_v6_json(recipe_data).get_dict(), 
-                                               event.id, ingest_event.id)
-            CommandMessageManager().send_messages(messages)
+
+            logger.info('Queueing new recipe of type %s %s', recipe_type.name, recipe_type.revision_num)
+            from queue.models import Queue
+            Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
+
+            # messages = create_recipes_messages(recipe_type.name, recipe_type.revision_num,
+            #                                    convert_data_to_v6_json(recipe_data).get_dict(),
+            #                                    event.id, ingest_event.id)
+            # CommandMessageManager().send_messages(messages)
             
         else:
             logger.info('No recipe type found for id %s or recipe type is inactive' % recipe_type_id)
 
     def process_ingested_source_file(self, ingest_id, source, source_file, when):
+        """Processes the given ingested source file by kicking off its recipe.
+        All database changes are made in an atomic transaction.
+
+        :param source: The strike that triggered the ingest
+        :type scan: `object`
+
+        :param source_file: The source file that was ingested
+        :type source_file: :class:`source.models.SourceFile`
+        :param when: When the source file was ingested
+        :type when: :class:`datetime.datetime`
+        """
+
+        # Create the recipe handler associated with the ingest strike/scan
+        source_recipe_config = source.configuration['recipe']
+        recipe_name = source_recipe_config['name']
+        recipe_revision = source_recipe_config['revision_num'] if 'revision_num' in source_recipe_config else None
+
+        recipe_type = RecipeType.objects.get(name=recipe_name)
+        if recipe_revision:
+            recipe_type = RecipeTypeRevision.objects.get_revision(recipe_name, recipe_revision).recipe_type
+
+        if len(recipe_type.get_definition().get_input_keys()) == 0:
+            logger.info('No inputs defined for recipe %s. Recipe will not be run.' % recipe_name)
+            return
+
+        if recipe_type and recipe_type.is_active:
+            # Assuming one input per recipe, so pull the first defined input you find
+            recipe_data = Data()
+            input_name = recipe_type.get_definition().get_input_keys()[0]
+            recipe_data.add_value(FileValue(input_name, [source_file.id]))
+            event = self._create_trigger_event(source, source_file, when)
+            ingest_event = self._create_ingest_event(ingest_id, source, source_file, when)
+
+            logger.info('Queueing new recipe of type %s %s', recipe_type.name, recipe_type.revision_num)
+            from queue.models import Queue
+            Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
+
+            # This can cause a race condition with a slow DB.
+            # messages = create_recipes_messages(recipe_type.name, recipe_type.revision_num,
+            #                                    convert_data_to_v6_json(recipe_data).get_dict(),
+            #                                    event.id, ingest_event.id)
+            # CommandMessageManager().send_messages(messages)
+
+        else:
+            logger.info('No recipe type found for %s %s or recipe type is inactive' % (recipe_name, recipe_revision))
+
+    def process_ingested_source_file_cm(self, ingest_id, source, source_file, when):
         """Processes the given ingested source file by kicking off its recipe.
         All database changes are made in an atomic transaction.
 

--- a/scale/ingest/triggers/ingest_recipe_handler.py
+++ b/scale/ingest/triggers/ingest_recipe_handler.py
@@ -10,6 +10,7 @@ from data.data.json.data_v6 import convert_data_to_v6_json
 from data.data.value import FileValue
 from ingest.models import IngestEvent, Scan, Strike
 from messaging.manager import CommandMessageManager
+from queue.models import Queue
 from recipe.messages.create_recipes import create_recipes_messages
 from recipe.models import RecipeType, RecipeTypeRevision
 from trigger.models import TriggerEvent
@@ -54,13 +55,7 @@ class IngestRecipeHandler(object):
             ingest_event = self._create_ingest_event(ingest_id, None, source_file, when)
 
             logger.info('Queueing new recipe of type %s %s', recipe_type.name, recipe_type.revision_num)
-            from queue.models import Queue
             Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
-
-            # messages = create_recipes_messages(recipe_type.name, recipe_type.revision_num,
-            #                                    convert_data_to_v6_json(recipe_data).get_dict(),
-            #                                    event.id, ingest_event.id)
-            # CommandMessageManager().send_messages(messages)
             
         else:
             logger.info('No recipe type found for id %s or recipe type is inactive' % recipe_type_id)
@@ -100,14 +95,7 @@ class IngestRecipeHandler(object):
             ingest_event = self._create_ingest_event(ingest_id, source, source_file, when)
 
             logger.info('Queueing new recipe of type %s %s', recipe_type.name, recipe_type.revision_num)
-            from queue.models import Queue
             Queue.objects.queue_new_recipe_v6(recipe_type, recipe_data, event, ingest_event)
-
-            # This can cause a race condition with a slow DB.
-            # messages = create_recipes_messages(recipe_type.name, recipe_type.revision_num,
-            #                                    convert_data_to_v6_json(recipe_data).get_dict(),
-            #                                    event.id, ingest_event.id)
-            # CommandMessageManager().send_messages(messages)
 
         else:
             logger.info('No recipe type found for %s %s or recipe type is inactive' % (recipe_name, recipe_revision))

--- a/scale/queue/models.py
+++ b/scale/queue/models.py
@@ -430,6 +430,7 @@ class QueueManager(models.Manager):
             ingest_event_pk = ingest_event.pk
         if event:
             event_pk = event.pk
+        recipe = None
         with transaction.atomic():
             recipe = Recipe.objects.create_recipe_v6(recipe_type_rev=recipe_type_rev, event_id=event_pk, ingest_id=ingest_event_pk, input_data=recipe_input,
                                                      recipe_config=recipe_config, batch_id=batch_id, superseded_recipe=superseded_recipe)
@@ -441,8 +442,9 @@ class QueueManager(models.Manager):
                 recipe.root_recipe_id = recipe.pk
                 recipe.save()
 
-            # This can cause a race condition with a slow DB.
-            CommandMessageManager().send_messages(create_process_recipe_input_messages([recipe.pk]))
+        # This can cause a race condition with a slow DB.
+        if recipe:
+            CommandMessageManager().send_messages(create_process_recipe_input_messages([recipe.id]))
 
         return recipe
 

--- a/scale/recipe/messages/process_recipe_input.py
+++ b/scale/recipe/messages/process_recipe_input.py
@@ -75,7 +75,7 @@ class ProcessRecipeInput(CommandMessage):
     def execute(self):
         """See :meth:`messaging.messages.message.CommandMessage.execute`
         """
-
+        logger.info('Processing input for recipe %d', self.recipe_id)
         recipe = Recipe.objects.get_recipe_with_interfaces(self.recipe_id)
 
         if not recipe.has_input():

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,7 +15,7 @@ then
     psql -d scale -U postgres -c "create extension postgis_topology;"
 
     export COVERAGE_FILE=$root/.coverage
-    coverage run --source='.' manage.py test -v 2
+    coverage run --source='.' manage.py test
 fi
 
 if [ "${BUILD_DOCS}" == "true" ]

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,7 +15,7 @@ then
     psql -d scale -U postgres -c "create extension postgis_topology;"
 
     export COVERAGE_FILE=$root/.coverage
-    coverage run --source='.' manage.py test
+    coverage run --source='.' manage.py test -v 2
 fi
 
 if [ "${BUILD_DOCS}" == "true" ]


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] tests are included

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
ingest

### Description of change
<!-- Please provide a description of the change here. -->
Once upon a time, a long time ago, a developer relatively new to the project noticed there seemed to be inconsistencies with getting jobs to schedule. 
Aha! They thought. Most of the communication seems to happen with messaging! I shall create a command message to create ingest jobs since that seems to be how the rest of the project works! 
And so it came to pass every Scale ingest required first a message to create the ingest task, then a message to complete the task and process the corresponding recipes. This appeared to work for a while, until it became clear these messages served no purpose and were contributing to a large message backlog the handlers struggled to get through. 
That same developer, now wiser (hopefully) in the ways of the codebase, has created this attempt to silence a portion of the messages, and get those ingests done in a more efficient manner.