### PR TITLE
Cooling off on the logging

### DIFF
--- a/scale/scheduler/scheduling/manager.py
+++ b/scale/scheduler/scheduling/manager.py
@@ -374,7 +374,6 @@ class SchedulingManager(object):
                             }
                         continue
                     if resource.name not in max_cluster_resources._resources:
-                        # logger.warning('Job type %s could not be scheduled as resource %s does not exist in the available cluster resources', jt.name, resource.name)
                         if jt.name in type_warnings:
                             type_warnings[jt.name]['count'] += 1
                         else:
@@ -427,7 +426,6 @@ class SchedulingManager(object):
                             'warning': '%s job types could not be scheduled due to missing workspace' % jt.name,
                             'count': 1
                         }
-                    # logger.warning('Job type %s could not be scheduled due to missing workspace', jt.name)
                     continue
 
                 # Check limit for this execution's job type

--- a/scale/scheduler/scheduling/manager.py
+++ b/scale/scheduler/scheduling/manager.py
@@ -340,112 +340,113 @@ class SchedulingManager(object):
         type_warnings = {}
 
         # We can schedule as long as there are nodes
-        if nodes:
-            ignore_job_type_ids = self._calculate_job_types_to_ignore(job_types, job_type_limits)
-            max_cluster_resources = resource_mgr.get_max_available_resources()
-            for queue in Queue.objects.get_queue(scheduler_mgr.config.queue_mode, ignore_job_type_ids)[:QUEUE_LIMIT]:
-                job_exe = QueuedJobExecution(queue)
-
-                # Canceled job executions get processed as scheduled executions
-                if job_exe.is_canceled:
-                    scheduled_job_executions.append(job_exe)
-                    continue
-
-                jt = job_type_mgr.get_job_type(queue.job_type.id)
-                name = INVALID_RESOURCES.name + jt.name
-                title = INVALID_RESOURCES.title % jt.name
-                warning = SchedulerWarning(name=name, title=title, description=None)
-                if jt.unmet_resources and scheduler_mgr.is_warning_active(warning):
-                    # previously checked this job type and found we lacked resources; wait until warning is inactive to check again
-                    continue
-
-                invalid_resources = []
-                insufficient_resources = []
-                # get resource names offered and compare to job type resources
-                for resource in job_exe.required_resources.resources:
-                    # skip sharedmem
-                    if resource.name.lower() == 'sharedmem':
-                        if jt.name in type_warnings:
-                            type_warnings[jt.name]['count'] += 1
-                        else:
-                            type_warnings[jt.name] = {
-                                'warning': '%s job types could not be scheduled due to required sharedmem resource' % jt.name,
-                                'count': 1
-                            }
-                        continue
-                    if resource.name not in max_cluster_resources._resources:
-                        if jt.name in type_warnings:
-                            type_warnings[jt.name]['count'] += 1
-                        else:
-                            type_warnings[jt.name] = {
-                                'warning': '%s job types could not be scheduled as resource %s does not exist in the available cluster resources' % (jt.name, resource.name),
-                                'count': 1
-                            }
-                        # resource does not exist in cluster
-                        invalid_resources.append(resource.name)
-                    elif resource.value > max_cluster_resources._resources[resource.name].value:
-                        # resource exceeds the max available from any node
-                        insufficient_resources.append(resource.name)
-
-                if invalid_resources:
-                    description = INVALID_RESOURCES.description % invalid_resources
-                    scheduler_mgr.warning_active(warning, description)
-
-                if insufficient_resources:
-                    description = INSUFFICIENT_RESOURCES.description % insufficient_resources
-                    scheduler_mgr.warning_active(warning, description)
-
-                if invalid_resources or insufficient_resources:
-                    invalid_resources.extend(insufficient_resources)
-                    jt.unmet_resources = ','.join(invalid_resources)
-                    jt.save(update_fields=["unmet_resources"])
-                    continue
-                else:
-                    # reset unmet_resources flag
-                    jt.unmet_resources = None
-                    scheduler_mgr.warning_inactive(warning)
-                    jt.save(update_fields=["unmet_resources"])
-
-                # Make sure execution's job type and workspaces have been synced to the scheduler
-                job_type_id = queue.job_type_id
-                if job_type_id not in job_types:
-                    scheduler_mgr.warning_active(UNKNOWN_JOB_TYPE, description=UNKNOWN_JOB_TYPE.description % job_type_id)
-                    continue
-
-                workspace_names = job_exe.configuration.get_input_workspace_names()
-                workspace_names.extend(job_exe.configuration.get_output_workspace_names())
-
-                missing_workspace = False
-                for name in workspace_names:
-                    missing_workspace = missing_workspace or name not in workspaces
-                if missing_workspace:
-                    if jt.name in type_warnings:
-                        type_warnings[jt.name]['count'] += 1
-                    else:
-                        type_warnings[jt.name] = {
-                            'warning': '%s job types could not be scheduled due to missing workspace' % jt.name,
-                            'count': 1
-                        }
-                    continue
-
-                # Check limit for this execution's job type
-                if job_type_id in job_type_limits and job_type_limits[job_type_id] < 1:
-                    if jt.name in type_warnings:
-                        type_warnings[jt.name]['count'] += 1
-                    else:
-                        type_warnings[jt.name] = {
-                            'warning': '%s job types could not be scheduled due to scheduling limit reached' % jt.name,
-                            'count': 1
-                        }
-                    continue
-
-                # Try to schedule job execution and adjust job type limit if needed
-                if self._schedule_new_job_exe(job_exe, nodes, job_type_resources):
-                    scheduled_job_executions.append(job_exe)
-                    if job_type_id in job_type_limits:
-                        job_type_limits[job_type_id] -= 1
-        else:
+        if not nodes:
             logger.warning('There are no nodes available. Waiting to schedule until there are free resources...')
+            return scheduled_job_executions
+          
+        ignore_job_type_ids = self._calculate_job_types_to_ignore(job_types, job_type_limits)
+        max_cluster_resources = resource_mgr.get_max_available_resources()
+        for queue in Queue.objects.get_queue(scheduler_mgr.config.queue_mode, ignore_job_type_ids)[:QUEUE_LIMIT]:
+            job_exe = QueuedJobExecution(queue)
+
+            # Canceled job executions get processed as scheduled executions
+            if job_exe.is_canceled:
+                scheduled_job_executions.append(job_exe)
+                continue
+
+            jt = job_type_mgr.get_job_type(queue.job_type.id)
+            name = INVALID_RESOURCES.name + jt.name
+            title = INVALID_RESOURCES.title % jt.name
+            warning = SchedulerWarning(name=name, title=title, description=None)
+            if jt.unmet_resources and scheduler_mgr.is_warning_active(warning):
+                # previously checked this job type and found we lacked resources; wait until warning is inactive to check again
+                continue
+
+            invalid_resources = []
+            insufficient_resources = []
+            # get resource names offered and compare to job type resources
+            for resource in job_exe.required_resources.resources:
+                # skip sharedmem
+                if resource.name.lower() == 'sharedmem':
+                    if jt.name in type_warnings:
+                        type_warnings[jt.name]['count'] += 1
+                    else:
+                        type_warnings[jt.name] = {
+                            'warning': '%s job types could not be scheduled due to required sharedmem resource' % jt.name,
+                            'count': 1
+                        }
+                    continue
+                if resource.name not in max_cluster_resources._resources:
+                    if jt.name in type_warnings:
+                        type_warnings[jt.name]['count'] += 1
+                    else:
+                        type_warnings[jt.name] = {
+                            'warning': '%s job types could not be scheduled as resource %s does not exist in the available cluster resources' % (jt.name, resource.name),
+                            'count': 1
+                        }
+                    # resource does not exist in cluster
+                    invalid_resources.append(resource.name)
+                elif resource.value > max_cluster_resources._resources[resource.name].value:
+                    # resource exceeds the max available from any node
+                    insufficient_resources.append(resource.name)
+
+            if invalid_resources:
+                description = INVALID_RESOURCES.description % invalid_resources
+                scheduler_mgr.warning_active(warning, description)
+
+            if insufficient_resources:
+                description = INSUFFICIENT_RESOURCES.description % insufficient_resources
+                scheduler_mgr.warning_active(warning, description)
+
+            if invalid_resources or insufficient_resources:
+                invalid_resources.extend(insufficient_resources)
+                jt.unmet_resources = ','.join(invalid_resources)
+                jt.save(update_fields=["unmet_resources"])
+                continue
+            else:
+                # reset unmet_resources flag
+                jt.unmet_resources = None
+                scheduler_mgr.warning_inactive(warning)
+                jt.save(update_fields=["unmet_resources"])
+
+            # Make sure execution's job type and workspaces have been synced to the scheduler
+            job_type_id = queue.job_type_id
+            if job_type_id not in job_types:
+                scheduler_mgr.warning_active(UNKNOWN_JOB_TYPE, description=UNKNOWN_JOB_TYPE.description % job_type_id)
+                continue
+
+            workspace_names = job_exe.configuration.get_input_workspace_names()
+            workspace_names.extend(job_exe.configuration.get_output_workspace_names())
+
+            missing_workspace = False
+            for name in workspace_names:
+                missing_workspace = missing_workspace or name not in workspaces
+            if missing_workspace:
+                if jt.name in type_warnings:
+                    type_warnings[jt.name]['count'] += 1
+                else:
+                    type_warnings[jt.name] = {
+                        'warning': '%s job types could not be scheduled due to missing workspace' % jt.name,
+                        'count': 1
+                    }
+                continue
+
+            # Check limit for this execution's job type
+            if job_type_id in job_type_limits and job_type_limits[job_type_id] < 1:
+                if jt.name in type_warnings:
+                    type_warnings[jt.name]['count'] += 1
+                else:
+                    type_warnings[jt.name] = {
+                        'warning': '%s job types could not be scheduled due to scheduling limit reached' % jt.name,
+                        'count': 1
+                    }
+                continue
+
+            # Try to schedule job execution and adjust job type limit if needed
+            if self._schedule_new_job_exe(job_exe, nodes, job_type_resources):
+                scheduled_job_executions.append(job_exe)
+                if job_type_id in job_type_limits:
+                    job_type_limits[job_type_id] -= 1
 
         duration = now() - started
         if type_warnings:

--- a/scale/scheduler/scheduling/manager.py
+++ b/scale/scheduler/scheduling/manager.py
@@ -336,94 +336,124 @@ class SchedulingManager(object):
         """
 
         scheduled_job_executions = []
-        ignore_job_type_ids = self._calculate_job_types_to_ignore(job_types, job_type_limits)
         started = now()
+        type_warnings = {}
 
-        max_cluster_resources = resource_mgr.get_max_available_resources()
-        for queue in Queue.objects.get_queue(scheduler_mgr.config.queue_mode, ignore_job_type_ids)[:QUEUE_LIMIT]:
-            job_exe = QueuedJobExecution(queue)
+        # We can schedule as long as there are nodes
+        if nodes:
+            ignore_job_type_ids = self._calculate_job_types_to_ignore(job_types, job_type_limits)
+            max_cluster_resources = resource_mgr.get_max_available_resources()
+            for queue in Queue.objects.get_queue(scheduler_mgr.config.queue_mode, ignore_job_type_ids)[:QUEUE_LIMIT]:
+                job_exe = QueuedJobExecution(queue)
 
-            # Canceled job executions get processed as scheduled executions
-            if job_exe.is_canceled:
-                scheduled_job_executions.append(job_exe)
-                continue
-
-            # If there are no longer any available nodes, break
-            if not nodes:
-                logger.warning('There are no nodes available. Waiting to schedule until there are free resources...')
-                break
-
-            jt = job_type_mgr.get_job_type(queue.job_type.id)
-            name = INVALID_RESOURCES.name + jt.name
-            title = INVALID_RESOURCES.title % jt.name
-            warning = SchedulerWarning(name=name, title=title, description=None)
-            if jt.unmet_resources and scheduler_mgr.is_warning_active(warning):
-                # previously checked this job type and found we lacked resources; wait until warning is inactive to check again
-                continue
-
-            invalid_resources = []
-            insufficient_resources = []
-            # get resource names offered and compare to job type resources
-            for resource in job_exe.required_resources.resources:
-                # skip sharedmem
-                if resource.name.lower() == 'sharedmem':
-                    logger.warning('Job type %s could not be scheduled due to required sharedmem resource', jt.name)
+                # Canceled job executions get processed as scheduled executions
+                if job_exe.is_canceled:
+                    scheduled_job_executions.append(job_exe)
                     continue
-                if resource.name not in max_cluster_resources._resources:
-                    logger.warning('Job type %s could not be scheduled as resource %s does not exist in the available cluster resources', jt.name, resource.name)
-                    # resource does not exist in cluster
-                    invalid_resources.append(resource.name)
-                elif resource.value > max_cluster_resources._resources[resource.name].value:
-                    # resource exceeds the max available from any node
-                    insufficient_resources.append(resource.name)
 
-            if invalid_resources:
-                description = INVALID_RESOURCES.description % invalid_resources
-                scheduler_mgr.warning_active(warning, description)
+                jt = job_type_mgr.get_job_type(queue.job_type.id)
+                name = INVALID_RESOURCES.name + jt.name
+                title = INVALID_RESOURCES.title % jt.name
+                warning = SchedulerWarning(name=name, title=title, description=None)
+                if jt.unmet_resources and scheduler_mgr.is_warning_active(warning):
+                    # previously checked this job type and found we lacked resources; wait until warning is inactive to check again
+                    continue
 
-            if insufficient_resources:
-                description = INSUFFICIENT_RESOURCES.description % insufficient_resources
-                scheduler_mgr.warning_active(warning, description)
+                invalid_resources = []
+                insufficient_resources = []
+                # get resource names offered and compare to job type resources
+                for resource in job_exe.required_resources.resources:
+                    # skip sharedmem
+                    if resource.name.lower() == 'sharedmem':
+                        if jt.name in type_warnings:
+                            type_warnings[jt.name]['count'] += 1
+                        else:
+                            type_warnings[jt.name] = {
+                                'warning': '%s job types could not be scheduled due to required sharedmem resource' % jt.name,
+                                'count': 1
+                            }
+                        continue
+                    if resource.name not in max_cluster_resources._resources:
+                        # logger.warning('Job type %s could not be scheduled as resource %s does not exist in the available cluster resources', jt.name, resource.name)
+                        if jt.name in type_warnings:
+                            type_warnings[jt.name]['count'] += 1
+                        else:
+                            type_warnings[jt.name] = {
+                                'warning': '%s job types could not be scheduled as resource %s does not exist in the available cluster resources' % (jt.name, resource.name),
+                                'count': 1
+                            }
+                        # resource does not exist in cluster
+                        invalid_resources.append(resource.name)
+                    elif resource.value > max_cluster_resources._resources[resource.name].value:
+                        # resource exceeds the max available from any node
+                        insufficient_resources.append(resource.name)
 
-            if invalid_resources or insufficient_resources:
-                invalid_resources.extend(insufficient_resources)
-                jt.unmet_resources = ','.join(invalid_resources)
-                jt.save(update_fields=["unmet_resources"])
-                continue
-            else:
-                # reset unmet_resources flag
-                jt.unmet_resources = None
-                scheduler_mgr.warning_inactive(warning)
-                jt.save(update_fields=["unmet_resources"])
+                if invalid_resources:
+                    description = INVALID_RESOURCES.description % invalid_resources
+                    scheduler_mgr.warning_active(warning, description)
 
-            # Make sure execution's job type and workspaces have been synced to the scheduler
-            job_type_id = queue.job_type_id
-            if job_type_id not in job_types:
-                scheduler_mgr.warning_active(UNKNOWN_JOB_TYPE, description=UNKNOWN_JOB_TYPE.description % job_type_id)
-                continue
+                if insufficient_resources:
+                    description = INSUFFICIENT_RESOURCES.description % insufficient_resources
+                    scheduler_mgr.warning_active(warning, description)
 
-            workspace_names = job_exe.configuration.get_input_workspace_names()
-            workspace_names.extend(job_exe.configuration.get_output_workspace_names())
+                if invalid_resources or insufficient_resources:
+                    invalid_resources.extend(insufficient_resources)
+                    jt.unmet_resources = ','.join(invalid_resources)
+                    jt.save(update_fields=["unmet_resources"])
+                    continue
+                else:
+                    # reset unmet_resources flag
+                    jt.unmet_resources = None
+                    scheduler_mgr.warning_inactive(warning)
+                    jt.save(update_fields=["unmet_resources"])
 
-            missing_workspace = False
-            for name in workspace_names:
-                missing_workspace = missing_workspace or name not in workspaces
-            if missing_workspace:
-                logger.warning('Job type %s could not be scheduled due to missing workspace', jt.name)
-                continue
+                # Make sure execution's job type and workspaces have been synced to the scheduler
+                job_type_id = queue.job_type_id
+                if job_type_id not in job_types:
+                    scheduler_mgr.warning_active(UNKNOWN_JOB_TYPE, description=UNKNOWN_JOB_TYPE.description % job_type_id)
+                    continue
 
-            # Check limit for this execution's job type
-            if job_type_id in job_type_limits and job_type_limits[job_type_id] < 1:
-                logger.warning('Job type %s could not be scheduled due to type scheduling limit reached ', jt.name)
-                continue
+                workspace_names = job_exe.configuration.get_input_workspace_names()
+                workspace_names.extend(job_exe.configuration.get_output_workspace_names())
 
-            # Try to schedule job execution and adjust job type limit if needed
-            if self._schedule_new_job_exe(job_exe, nodes, job_type_resources):
-                scheduled_job_executions.append(job_exe)
-                if job_type_id in job_type_limits:
-                    job_type_limits[job_type_id] -= 1
+                missing_workspace = False
+                for name in workspace_names:
+                    missing_workspace = missing_workspace or name not in workspaces
+                if missing_workspace:
+                    if jt.name in type_warnings:
+                        type_warnings[jt.name]['count'] += 1
+                    else:
+                        type_warnings[jt.name] = {
+                            'warning': '%s job types could not be scheduled due to missing workspace' % jt.name,
+                            'count': 1
+                        }
+                    # logger.warning('Job type %s could not be scheduled due to missing workspace', jt.name)
+                    continue
+
+                # Check limit for this execution's job type
+                if job_type_id in job_type_limits and job_type_limits[job_type_id] < 1:
+                    if jt.name in type_warnings:
+                        type_warnings[jt.name]['count'] += 1
+                    else:
+                        type_warnings[jt.name] = {
+                            'warning': '%s job types could not be scheduled due to scheduling limit reached' % jt.name,
+                            'count': 1
+                        }
+                    continue
+
+                # Try to schedule job execution and adjust job type limit if needed
+                if self._schedule_new_job_exe(job_exe, nodes, job_type_resources):
+                    scheduled_job_executions.append(job_exe)
+                    if job_type_id in job_type_limits:
+                        job_type_limits[job_type_id] -= 1
+        else:
+            logger.warning('There are no nodes available. Waiting to schedule until there are free resources...')
 
         duration = now() - started
+        if type_warnings:
+            for warn in type_warnings:
+                logger.warning('%d %s', type_warnings[warn]['count'], type_warnings[warn]['warning'])
+
         msg = 'Processing queue took %.3f seconds'
         if duration > PROCESS_QUEUE_WARN_THRESHOLD:
             logger.warning(msg, duration.total_seconds())

--- a/scale/scheduler/scheduling/manager.py
+++ b/scale/scheduler/scheduling/manager.py
@@ -368,20 +368,15 @@ class SchedulingManager(object):
             for resource in job_exe.required_resources.resources:
                 # skip sharedmem
                 if resource.name.lower() == 'sharedmem':
-                    if jt.name in type_warnings:
-                        type_warnings[jt.name]['count'] += 1
-                    else:
-                        type_warnings[jt.name] = {
-                            'warning': '%s job types could not be scheduled due to required sharedmem resource' % jt.name,
-                            'count': 1
-                        }
                     continue
                 if resource.name not in max_cluster_resources._resources:
                     if jt.name in type_warnings:
                         type_warnings[jt.name]['count'] += 1
+                        if resource.name not in type_warnings[jt.name]['warning']:
+                            type_warnings[jt.name]['warning'] += (', %s' % resource.name)
                     else:
                         type_warnings[jt.name] = {
-                            'warning': '%s job types could not be scheduled as resource %s does not exist in the available cluster resources' % (jt.name, resource.name),
+                            'warning': '%s job types could not be scheduled as the following resources do not exist in the available cluster resources: %s' % (jt.name, resource.name),
                             'count': 1
                         }
                     # resource does not exist in cluster


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
scheduler 

### Description of change
<!-- Please provide a description of the change here. -->
Removed the warnings on every pass of the process queue loop in favor of a "[count] [job_type_name] job types could not be scheduled due to [reason]" warning at the end of the processing loop. scale-ingests exceeding their scheduling limit were overrunning the output logs.