### PR TITLE
Resolving AH01630 Error

### DIFF
--- a/dockerfiles/framework/scale/scale.conf
+++ b/dockerfiles/framework/scale/scale.conf
@@ -1,5 +1,9 @@
 DocumentRoot "/opt/scale/docs/"
 
+<Directory "/opt/scale/docs">
+  Require all granted
+</Directory>
+
 <Directory "/opt/scale/static">
   Require all granted
 </Directory>

--- a/scale/pip/docs.txt
+++ b/scale/pip/docs.txt
@@ -9,5 +9,5 @@ sphinx_rtd_theme>=0.1.9,<1
 
 # Needed for new wiki docs
 mkdocs>0.16.0,<1.0.0
-mkdocs-material>=3.0.0
-pymdown-extensions>=6.0
+mkdocs-material<=3.0.0
+pymdown-extensions<=6.0


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `manage.py test` passes

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Affected app(s)
<!-- Please list affected Scale app(s). -->
framework/../scale.conf
scale/pip/docs.txt

### Description of change
<!-- Please provide a description of the change here. -->
Had to add a "Require all granted" clause for the scale/docs directory in order to resolve an AH01630 client denied by server configuration error that was being logged in the webserver.
Updated the mkdocs versions requirements as the latest versions of dependencies did not support Python 2.7 and were therefore failing to build the docs.