### PR TITLE
Update Scale Walkthrough to eliminate use of ENTRYPOINT

### DIFF
--- a/web-docs/flow.html
+++ b/web-docs/flow.html
@@ -106,7 +106,7 @@
 <!-- Footer -->
 <footer>
     <div class="container">
-        &copy; 2016 National Geospatial Intelligence Agency. <a href="http://www.apache.org/licenses/">Apache License Version 2.0</a>
+        &copy; 2020 National Geospatial Intelligence Agency. <a href="http://www.apache.org/licenses/">Apache License Version 2.0</a>
     </div>
     <!-- /.container -->
 </footer>

--- a/web-docs/index.html
+++ b/web-docs/index.html
@@ -190,7 +190,7 @@
 <!-- Footer -->
 <footer>
     <div class="container text-center">
-        &copy; 2016 National Geospatial Intelligence Agency. <a href="http://www.apache.org/licenses/">Apache License Version 2.0</a>
+        &copy; 2020 National Geospatial Intelligence Agency. <a href="http://www.apache.org/licenses/">Apache License Version 2.0</a>
     </div>
 </footer>
 

--- a/web-docs/quickstart.html
+++ b/web-docs/quickstart.html
@@ -661,7 +661,7 @@ curl -X POST -H "Authorization: token=${DCOS_TOKEN}" -H "Content-Type: applicati
 <!-- Footer -->
 <footer>
     <div class="container text-center">
-&copy; 2016 National Geospatial Intelligence Agency. <a href="http://www.apache.org/licenses/">Apache License Version 2.0</a>
+&copy; 2020 National Geospatial Intelligence Agency. <a href="http://www.apache.org/licenses/">Apache License Version 2.0</a>
     </div>
 </footer>
 

--- a/web-docs/walkthrough/index.adoc
+++ b/web-docs/walkthrough/index.adoc
@@ -92,7 +92,7 @@ You will find the latest version of Seed here: {seed-releases-url}
 
 [TIP]
 ====
-Use `seed-windows-amd64` for Windows, `seed-linux-amd64` for Linux, and `seed-linux-amd64` for Mac.
+Use `seed-linux-amd64` for Linux or WSL 2 on Windows, `seed-darwin-amd64` for Mac, or `seed-windows-amd64` for native Windows.
 ====
 
 For more detailed instructions, refer to the Seed {seed-install-url}[installation instructions].
@@ -113,22 +113,19 @@ As an example, here is a Dockerfile to accompany the `input-output.py` file from
 ----
 FROM alpine:3.9
 
-RUN apk -U add python
-
-COPY ./input-output.py /app
+RUN apk -U add python3
 
 WORKDIR /app
 
-ENTRYPOINT ["python", "input-output.py"]
+COPY ./input-output.py .
 ----
 
 The Dockerfile defined in this example takes the following steps:
 
 * Start `FROM` the pre-existing `alpine:3.9` Linux image. This is an official image, validated by Docker.
-* `RUN` the command `apk -U add python` inside your image filesystem, which will install Python.
-* `COPY` the file input-output.py to your work directory.
+* `RUN` the command `apk -U add python3` inside your image filesystem, which will install Python 3.
 * Use `WORKDIR` to create the `/app` directory and specify that all subsequent actions should be taken from within `/app` _in your image filesystem_ (never the host’s filesystem).
-* Use `ENTRYPOINT` to describe how to run the container. In this case, it will run `python input-output.py`. The arguments will be specified at runtime.
+* `COPY` the file input-output.py to your work directory.
 
 === Create a Seed Manifest
 
@@ -166,7 +163,7 @@ Here is an example of the seed manifest file for our input-output.py file:
     },
     "timeout": 3600,
     "interface": {
-      "command": "${INPUT_FILE} ${OUTPUT_DIR}",
+      "command": "python3 input-output.py ${INPUT_FILE} ${OUTPUT_DIR}",
       "inputs": {
         "files": [
           {

--- a/web-docs/walkthrough/index.adoc
+++ b/web-docs/walkthrough/index.adoc
@@ -1,5 +1,5 @@
 = Scale Walkthrough
-Nikkala Thomson <nikkala.thomson@appliedis.com>
+
 :toc: left
 :toclevels: 5
 :imagesdir: images/

--- a/web-docs/walkthrough/index.adoc
+++ b/web-docs/walkthrough/index.adoc
@@ -92,7 +92,7 @@ You will find the latest version of Seed here: {seed-releases-url}
 
 [TIP]
 ====
-Use `seed-linux-amd64` for Linux or WSL 2 on Windows, `seed-darwin-amd64` for Mac, or `seed-windows-amd64` for native Windows.
+Use `seed-linux-amd64` for Linux or WSL 2 on Windows or `seed-darwin-amd64` for Mac.
 ====
 
 For more detailed instructions, refer to the Seed {seed-install-url}[installation instructions].


### PR DESCRIPTION
#1890 - Eliminate use of ENTRYPOINT in Scale Walkthrough

##### Checklist

- [x] documentation is changed or added

### Affected app(s)
Documentation

### Description of change
Update the example in the Scale walkthrough to eliminate the use of `ENTRYPOINT` in the Dockerfile to more closely match the Seed user guide example.
