### PR TITLE
virtualenv command is not found by default on mac. 

### DIFF
--- a/scale/environment/mac-init.sh
+++ b/scale/environment/mac-init.sh
@@ -39,7 +39,7 @@ EOF
 
 # Initialize virtual environment
 pip install virtualenv
-virtualenv -p $(which python2) environment/scale
+python2 -m virtualenv -p $(which python2) environment/scale
 cat pip/requirements.txt | sed 's^psycopg2^psycopg2-binary^' > pip/mac.txt
 environment/scale/bin/pip install -r pip/mac.txt
 


### PR DESCRIPTION
##### Checklist

- [x ] `manage.py test` passes
- [x ] tests are included
- [x ] migrations are included
- [x ] documentation is changed or added

##### Affected app(s)

- Scale

### Description of change

Fixed issue by calling virtualenv from python2.