### PR TITLE
Add table of contents to Scale walkthrough 

### DIFF
--- a/web-docs/walkthrough/generate-pdf.sh
+++ b/web-docs/walkthrough/generate-pdf.sh
@@ -1,5 +1,5 @@
 echo Generating PDF...
-asciidoctor-pdf -D /documents/output index.adoc
+asciidoctor-pdf -a stylesdir=./styles -a stylesheet=walkthrough.css -D /documents/output index.adoc
 
 echo Rename output PDF...
 mv /documents/output/index.pdf /documents/output/scale-walkthrough.pdf

--- a/web-docs/walkthrough/index.adoc
+++ b/web-docs/walkthrough/index.adoc
@@ -1,5 +1,4 @@
 = Scale Walkthrough
-
 :toc: left
 :toclevels: 5
 :imagesdir: images/


### PR DESCRIPTION
Add Scale [walkthrough](https://ngageoint.github.io/scale/walkthrough/output/index.html) table of contents.

##### Checklist

- [x] documentation is changed or added

### Affected app(s)
Documentation

### Description of change
Apparently when I removed the author line from the Scale walkthrough and left a blank line between the document title and attributes, that broke an AsciiDoc convention, causing the table of contents to not get rendered. This PR removes that blank line. I have also applied the walkthrough stylesheet to the generated PDF.
