### PR TITLE
Moved value to environment variable.

### DIFF
--- a/scale/README.md
+++ b/scale/README.md
@@ -261,6 +261,7 @@ below for reference.
 | SCALE_WEBSERVER_MEMORY      | 2048                            | UI/API memory allocation during bootstrap  |
 | SCALE_ZK_URL                | None                            | Scale master location                      |
 | SCHEDULER_QUEUE_LIMIT       | 500                             | Number of queues processed at a time       |
+| SCHEDULER_MAX_RECONNECT     | 3                               | Max tries to reconnect to mesos            |
 | SERVICE_SECRET              | None                            | JSON object used for DCOS EE Strict Auth   |
 | SECRETS_SSL_WARNINGS        | 'true'                          | Should secrets SSL warnings be raised?     |
 | SECRETS_TOKEN               | None                            | Authentication token for secrets service   |

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -90,6 +90,8 @@ MESSSAGE_QUEUE_DEPTH_WARN = int(os.environ.get('MESSSAGE_QUEUE_DEPTH_WARN', -1))
 # Queue limit
 SCHEDULER_QUEUE_LIMIT = int(os.environ.get('SCHEDULER_QUEUE_LIMIT', 500))
 
+# The max number of times the scheduler will try to reconnect to 
+# mesos if disconnected.
 SCHEDULER_MAX_RECONNECT = int(os.environ.get('SCHEDULER_MAX_RECONNECT', 3))
 
 # Base URL of vault or DCOS secrets store, or None to disable secrets

--- a/scale/scale/settings.py
+++ b/scale/scale/settings.py
@@ -90,6 +90,8 @@ MESSSAGE_QUEUE_DEPTH_WARN = int(os.environ.get('MESSSAGE_QUEUE_DEPTH_WARN', -1))
 # Queue limit
 SCHEDULER_QUEUE_LIMIT = int(os.environ.get('SCHEDULER_QUEUE_LIMIT', 500))
 
+SCHEDULER_MAX_RECONNECT = int(os.environ.get('SCHEDULER_MAX_RECONNECT', 3))
+
 # Base URL of vault or DCOS secrets store, or None to disable secrets
 SECRETS_URL = None
 # Public token if DCOS secrets store, or privleged token for vault

--- a/scale/scheduler/scale_scheduler.py
+++ b/scale/scheduler/scale_scheduler.py
@@ -155,7 +155,7 @@ class ScaleScheduler(object):
         self._client.on(MesosClient.RESCIND, self.rescind)
         self._client.on(MesosClient.DISCONNECTED, self.disconnected)
         self._client.on(MesosClient.RECONNECTED, self.reconnected)
-        self._client.max_reconnect=3
+        self._client.max_reconnect=settings.SCHEDULER_MAX_RECONNECT
         self._client.connection_timeout=20
 
         self._client.register()


### PR DESCRIPTION
### Checklist

- [x] `manage.py test` passes
- [x] documentation is changed or added

### Affected app(s)

Scale Scheduler

### Description of change

Moved the hard-coded value for max connections in the scheduler to an environment variable.

The hope is that by increasing this number that when a leader election happens that takes an extended amount of time, the framework will not be marked inactive.