### PR TITLE
Verify v7

### DIFF
--- a/scale/data/views.py
+++ b/scale/data/views.py
@@ -508,7 +508,7 @@ class DataSetValidationView(APIView):
         :returns: the HTTP response to send back to the user
         """
 
-        if request.version == 'v6':
+        if request.version == 'v6' or request.version == 'v7':
             return self.post_v6(request)
         else:
             Http404()

--- a/scale/diagnostic/views.py
+++ b/scale/diagnostic/views.py
@@ -330,7 +330,7 @@ class QueueScaleRouletteView(GenericAPIView):
 
         num = rest_util.parse_int(request, 'num')
 
-        if num < 1:
+        if num < 1: 
             raise BadParameter('num must be at least 1')
 
         # TODO: in the future, send command message to do this asynchronously

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -514,9 +514,9 @@ class JobTypesPendingView(ListAPIView):
     def get_serializer_class(self):
         """Returns the appropriate serializer based off the requests version of the REST API. """
 
-        if request.version == 'v6':
+        if self.request.version == 'v6':
             return JobTypePendingStatusSerializerV6
-        elif request.version == 'v7':
+        elif self.request.version == 'v7':
             return JobTypePendingStatusSerializerV6
 
     def list(self, request):
@@ -548,9 +548,9 @@ class JobTypesRunningView(ListAPIView):
     def get_serializer_class(self):
         """Returns the appropriate serializer based off the requests version of the REST API. """
 
-        if request.version == 'v6':
+        if self.request.version == 'v6':
             return JobTypeRunningStatusSerializerV6
-        elif request.version == 'v7':
+        elif self.request.version == 'v7':
             return JobTypeRunningStatusSerializerV6
 
     def list(self, request):
@@ -582,9 +582,9 @@ class JobTypesSystemFailuresView(ListAPIView):
     def get_serializer_class(self):
         """Returns the appropriate serializer based off the requests version of the REST API. """
 
-        if request.version == 'v6':
+        if self.request.version == 'v6':
             return JobTypeFailedStatusSerializerV6
-        elif request.version == 'v7':
+        elif self.request.version == 'v7':
             return JobTypeFailedStatusSerializerV6
 
     def list(self, request):
@@ -616,9 +616,9 @@ class JobTypesStatusView(ListAPIView):
     def get_serializer_class(self):
         """Returns the appropriate serializer based off the requests version of the REST API. """
 
-        if request.version == 'v6':
+        if self.request.version == 'v6':
             return JobTypeStatusSerializerV6
-        elif request.version == 'v7':
+        elif self.request.version == 'v7':
             return JobTypeStatusSerializerV6
 
     def list(self, request):

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -519,8 +519,6 @@ class JobTypesPendingView(ListAPIView):
         elif request.version == 'v7':
             return JobTypePendingStatusSerializerV6
 
-        raise Http404()
-
     def list(self, request):
         """Retrieves the current status of pending job types and returns it in JSON form
 
@@ -554,8 +552,6 @@ class JobTypesRunningView(ListAPIView):
             return JobTypeRunningStatusSerializerV6
         elif request.version == 'v7':
             return JobTypeRunningStatusSerializerV6
-
-        raise Http404()
 
     def list(self, request):
         """Retrieves the current status of running job types and returns it in JSON form
@@ -591,8 +587,6 @@ class JobTypesSystemFailuresView(ListAPIView):
         elif request.version == 'v7':
             return JobTypeFailedStatusSerializerV6
 
-        raise Http404()
-
     def list(self, request):
         """Retrieves the job types that have failed with system errors and returns them in JSON form
 
@@ -626,8 +620,6 @@ class JobTypesStatusView(ListAPIView):
             return JobTypeStatusSerializerV6
         elif request.version == 'v7':
             return JobTypeStatusSerializerV6
-
-        raise Http404()
 
     def list(self, request):
         """Retrieves the list of all job types with status and returns it in JSON form

--- a/scale/job/views.py
+++ b/scale/job/views.py
@@ -55,6 +55,9 @@ class JobTypesView(ListCreateAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
 
         keywords = rest_util.parse_string_list(request, 'keyword', required=False)
         is_active = rest_util.parse_bool(request, 'is_active', required=False)
@@ -229,6 +232,10 @@ class JobTypeVersionsView(ListAPIView):
         :returns: the HTTP response to send back to the user
         """
 
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
+
         is_active = rest_util.parse_bool(request, 'is_active', required=False)
         order = ['-version']
 
@@ -301,6 +308,9 @@ class JobTypeDetailsView(GenericAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
 
         try:
             job_type = JobType.objects.get_details_v6(name=name, version=version)
@@ -324,6 +334,10 @@ class JobTypeDetailsView(GenericAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
 
         auto_update = rest_util.parse_bool(request, 'auto_update', required=False, default_value=True)
         icon_code = rest_util.parse_string(request, 'icon_code', required=False)
@@ -411,6 +425,10 @@ class JobTypeRevisionsView(ListAPIView):
         :returns: the HTTP response to send back to the user
         """
 
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
+
         order = ['-revision_num']
 
         try:
@@ -443,6 +461,10 @@ class JobTypeRevisionDetailsView(GenericAPIView):
         :returns: the HTTP response to send back to the user
         """
 
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
+
         try:
             job_type_rev = JobTypeRevision.objects.get_details_v6(name, version, revision_num)
         except JobType.DoesNotExist:
@@ -468,6 +490,10 @@ class JobTypesValidationView(APIView):
         :returns: the HTTP response to send back to the user
         """
 
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
+
         # Validate the seed manifest and job configuration
         manifest_dict = rest_util.parse_dict(request, 'manifest', required=True)
         configuration_dict = rest_util.parse_dict(request, 'configuration', required=True)
@@ -488,7 +514,12 @@ class JobTypesPendingView(ListAPIView):
     def get_serializer_class(self):
         """Returns the appropriate serializer based off the requests version of the REST API. """
 
-        return JobTypePendingStatusSerializerV6
+        if request.version == 'v6':
+            return JobTypePendingStatusSerializerV6
+        elif request.version == 'v7':
+            return JobTypePendingStatusSerializerV6
+
+        raise Http404()
 
     def list(self, request):
         """Retrieves the current status of pending job types and returns it in JSON form
@@ -498,6 +529,10 @@ class JobTypesPendingView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
 
         # Get all the pending job types with statistics
         pending_status = JobType.objects.get_pending_status()
@@ -515,7 +550,12 @@ class JobTypesRunningView(ListAPIView):
     def get_serializer_class(self):
         """Returns the appropriate serializer based off the requests version of the REST API. """
 
-        return JobTypeRunningStatusSerializerV6
+        if request.version == 'v6':
+            return JobTypeRunningStatusSerializerV6
+        elif request.version == 'v7':
+            return JobTypeRunningStatusSerializerV6
+
+        raise Http404()
 
     def list(self, request):
         """Retrieves the current status of running job types and returns it in JSON form
@@ -525,6 +565,10 @@ class JobTypesRunningView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
 
         # Get all the running job types with statistics
         running_status = JobType.objects.get_running_status()
@@ -542,7 +586,12 @@ class JobTypesSystemFailuresView(ListAPIView):
     def get_serializer_class(self):
         """Returns the appropriate serializer based off the requests version of the REST API. """
 
-        return JobTypeFailedStatusSerializerV6
+        if request.version == 'v6':
+            return JobTypeFailedStatusSerializerV6
+        elif request.version == 'v7':
+            return JobTypeFailedStatusSerializerV6
+
+        raise Http404()
 
     def list(self, request):
         """Retrieves the job types that have failed with system errors and returns them in JSON form
@@ -552,6 +601,10 @@ class JobTypesSystemFailuresView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
 
         # Get all the failed job types with statistics
         failed_status = JobType.objects.get_failed_status()
@@ -569,7 +622,12 @@ class JobTypesStatusView(ListAPIView):
     def get_serializer_class(self):
         """Returns the appropriate serializer based off the requests version of the REST API. """
 
-        return JobTypeStatusSerializerV6
+        if request.version == 'v6':
+            return JobTypeStatusSerializerV6
+        elif request.version == 'v7':
+            return JobTypeStatusSerializerV6
+
+        raise Http404()
 
     def list(self, request):
         """Retrieves the list of all job types with status and returns it in JSON form
@@ -579,6 +637,10 @@ class JobTypesStatusView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
 
         # Get a list of all job type status counts
         is_active = rest_util.parse_bool(request, 'is_active', required=False)
@@ -605,6 +667,10 @@ class JobsView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
 
         started = rest_util.parse_timestamp(request, 'started', required=False)
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
@@ -657,6 +723,10 @@ class JobsView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
 
         job_type_id = rest_util.parse_int(request, 'job_type_id')
         job_data = rest_util.parse_dict(request, 'input', {})
@@ -716,6 +786,10 @@ class CancelJobsView(GenericAPIView):
         :returns: the HTTP response to send back to the user
         """
 
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
+
         started = rest_util.parse_timestamp(request, 'started', required=False)
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended)
@@ -767,6 +841,10 @@ class RequeueJobsView(GenericAPIView):
         :type request: :class:`rest_framework.request.Request`
         :returns: the HTTP response to send back to the user
         """
+
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
 
         started = rest_util.parse_timestamp(request, 'started', required=False)
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
@@ -821,6 +899,10 @@ class JobDetailsView(GenericAPIView):
         :returns: the HTTP response to send back to the user
         """
 
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
+
         try:
             job = Job.objects.get_details(job_id)
         except Job.DoesNotExist:
@@ -845,6 +927,10 @@ class JobInputFilesView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
 
         started = rest_util.parse_timestamp(request, 'started', required=False)
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
@@ -925,6 +1011,10 @@ class JobExecutionDetailsView(RetrieveAPIView):
         :returns: the HTTP response to send back to the user
         """
 
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
+
         try:
             job_exe = JobExecution.objects.get_job_exe_details(job_id=job_id, exe_num=exe_num)
         except JobExecution.DoesNotExist:
@@ -950,6 +1040,10 @@ class JobExecutionSpecificLogView(RetrieveAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+
+        # Check version
+        if request.version != 'v6' and request.version != 'v7':
+            raise Http404()
 
         try:
             job_exe = JobExecution.objects.get_logs(job_exe_id)

--- a/scale/queue/views.py
+++ b/scale/queue/views.py
@@ -26,6 +26,23 @@ class JobLoadView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
+
+        if request.version == 'v6':
+            return self._list_v6(request)
+        elif request.version == 'v7':
+            return self._list_v6(request)
+
+        raise Http404()
+
+    def _list_v6(self, request):
+        """Retrieves the job load for a given time range and returns it in JSON form
+
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+
         started = rest_util.parse_timestamp(request, 'started', default_value=rest_util.get_relative_days(7))
         ended = rest_util.parse_timestamp(request, 'ended', required=False)
         rest_util.check_time_range(started, ended, max_duration=datetime.timedelta(days=31))
@@ -52,8 +69,24 @@ class QueueStatusView(ListAPIView):
             return QueueStatusSerializerV6
         elif self.request.version == 'v7':
             return QueueStatusSerializerV6
-
+    
     def list(self, request):
+        """Retrieves the job load for a given time range and returns it in JSON form
+
+        :param request: the HTTP GET request
+        :type request: :class:`rest_framework.request.Request`
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
+
+        if request.version == 'v6':
+            return self._list_v6(request)
+        elif request.version == 'v7':
+            return self._list_v6(request)
+
+        raise Http404()
+
+    def _list_v6(self, request):
         """Retrieves the current status of the queue and returns it in JSON form
 
         :param request: the HTTP GET request

--- a/scale/recipe/views.py
+++ b/scale/recipe/views.py
@@ -462,8 +462,22 @@ class RecipesView(ListAPIView):
         :rtype: :class:`rest_framework.response.Response`
         :returns: the HTTP response to send back to the user
         """
-        if request.version != 'v6':
-            raise Http404
+
+        if request.version == 'v6':
+            return self._post_v6(request)
+        elif request.version == 'v7':
+            return self._post_v6(request)
+
+        raise Http404()
+
+    def _post_v6(self, request):
+        """Queue a recipe and returns the new job information in JSON form
+
+        :param request: the HTTP POST request
+        :type request: :class:`rest_framework.request.Request`
+        :rtype: :class:`rest_framework.response.Response`
+        :returns: the HTTP response to send back to the user
+        """
 
         recipe_type_id = rest_util.parse_int(request, 'recipe_type_id')
         recipe_data = rest_util.parse_dict(request, 'input', {})

--- a/scale/storage/views.py
+++ b/scale/storage/views.py
@@ -171,7 +171,7 @@ class PurgeSourceFileView(APIView):
         :returns: the HTTP response to send back to the user
         """
 
-        if self.request.version != 'v6':
+        if self.request.version != 'v6' and self.request.version != 'v7':
             content = 'This endpoint is supported with REST API v6+'
             return Response(status=status.HTTP_400_BAD_REQUEST, data=content)
 


### PR DESCRIPTION
### Checklist
- [x] All API endpoints tested (both v6 and v7) 

### Description of Change
Added checks to verify API requests are using v6 or v7. Addresses the [#1884](https://github.com/ngageoint/scale/issues/1884) issue. 