### PR TITLE
Sharedmem skip

### DIFF
--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1173,9 +1173,6 @@ class Job(models.Model):
         if scalar_resources:
             resources.increase_up_to(NodeResources(scalar_resources))
 
-        # We have to ensure shared memory is not a required NodeResource, otherwise scheduling cannot occur
-        resources.remove_resource('sharedmem')
-
         # If no inputMultiplier for Disk we need to at least ensure it exceeds input_file_size
         resources.increase_up_to(NodeResources([Disk(input_file_size)]))
 

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -59,7 +59,8 @@ MIN_DISK = 0.0
 MIN_RESOURCE = {
     'cpus': MIN_CPUS,
     'mem': MIN_MEM,
-    'disk': MIN_DISK
+    'disk': MIN_DISK,
+    'sharedmem': 0.0
 }
 
 INPUT_FILE_BATCH_SIZE = 500  # Maximum batch size for creating JobInputFile models
@@ -1171,6 +1172,11 @@ class Job(models.Model):
 
         if scalar_resources:
             resources.increase_up_to(NodeResources(scalar_resources))
+
+        # Remove sharedmem resource if it has a zero value
+        dict_resources = resources.get_json().get_dict()['resources']
+        if 'sharedmem' in dict_resources and dict_resources['sharedmem'] <= 0:
+            resources.remove_resource('sharedmem')
 
         # If no inputMultiplier for Disk we need to at least ensure it exceeds input_file_size
         resources.increase_up_to(NodeResources([Disk(input_file_size)]))

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1173,7 +1173,7 @@ class Job(models.Model):
         if scalar_resources:
             resources.increase_up_to(NodeResources(scalar_resources))
 
-        # Remove sharedmem resource
+        # We have to ensure shared memory is not a required NodeResource, otherwise scheduling cannot occur
         resources.remove_resource('sharedmem')
 
         # If no inputMultiplier for Disk we need to at least ensure it exceeds input_file_size

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -59,8 +59,7 @@ MIN_DISK = 0.0
 MIN_RESOURCE = {
     'cpus': MIN_CPUS,
     'mem': MIN_MEM,
-    'disk': MIN_DISK,
-    'sharedmem': 0.0
+    'disk': MIN_DISK
 }
 
 INPUT_FILE_BATCH_SIZE = 500  # Maximum batch size for creating JobInputFile models

--- a/scale/job/models.py
+++ b/scale/job/models.py
@@ -1173,10 +1173,8 @@ class Job(models.Model):
         if scalar_resources:
             resources.increase_up_to(NodeResources(scalar_resources))
 
-        # Remove sharedmem resource if it has a zero value
-        dict_resources = resources.get_json().get_dict()['resources']
-        if 'sharedmem' in dict_resources and dict_resources['sharedmem'] <= 0:
-            resources.remove_resource('sharedmem')
+        # Remove sharedmem resource
+        resources.remove_resource('sharedmem')
 
         # If no inputMultiplier for Disk we need to at least ensure it exceeds input_file_size
         resources.increase_up_to(NodeResources([Disk(input_file_size)]))

--- a/scale/scheduler/scheduling/manager.py
+++ b/scale/scheduler/scheduling/manager.py
@@ -367,9 +367,10 @@ class SchedulingManager(object):
             # get resource names offered and compare to job type resources
             for resource in job_exe.required_resources.resources:
                 # skip sharedmem
-                if resource.name.lower() == 'sharedmem':
-                    continue
-                if resource.name not in max_cluster_resources._resources:
+                #if resource.name.lower() == 'sharedmem':
+                    #continue
+
+                if (resource.name not in max_cluster_resources._resources) or resource.name.lower() == 'sharedmem':
                     if jt.name in type_warnings:
                         type_warnings[jt.name]['count'] += 1
                         if resource.name not in type_warnings[jt.name]['warning']:

--- a/scale/scheduler/scheduling/manager.py
+++ b/scale/scheduler/scheduling/manager.py
@@ -366,11 +366,11 @@ class SchedulingManager(object):
             insufficient_resources = []
             # get resource names offered and compare to job type resources
             for resource in job_exe.required_resources.resources:
-                # skip sharedmem
-                #if resource.name.lower() == 'sharedmem':
-                    #continue
-
-                if (resource.name not in max_cluster_resources._resources) or resource.name.lower() == 'sharedmem':
+                # Check for invalid resource or sharedmem
+                if (resource.name not in max_cluster_resources._resources) or (resource.name.lower() == 'sharedmem'):
+                    # Skip sharedmem if its 0
+                    if (resource.name.lower() == 'sharedmem') and (resource.value <= 0):
+                        continue
                     if jt.name in type_warnings:
                         type_warnings[jt.name]['count'] += 1
                         if resource.name not in type_warnings[jt.name]['warning']:


### PR DESCRIPTION
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `manage.py test` passes
- [x] `sharedmem` jobs do not get scheduled and are added to `invalid_resources` list if and only if the `sharedmem` resource is not stripped from the job before scheduling occurs. Otherwise it is scheduled.

#### Description of change
Added a condition for skipping of the the `sharedmem`, where its only removed if the value is 0. Also added a check for `sharedmem` when looking for invalid resources. Addresses issue [#1826](https://github.com/ngageoint/scale/issues/1826)
