### PR TITLE
Fix docs build in Scale 5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ RUN if [ $EPEL_INSTALL -eq 1 ]; then yum install -y epel-release; fi\
          unzip \
          make \
  && pip install --upgrade pip \
- && pip install --upgrade setuptools \
  && yum install -y \
          gcc \
          wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN if [ $EPEL_INSTALL -eq 1 ]; then yum install -y epel-release; fi\
          unzip \
          make \
  && pip install --upgrade pip \
+ && pip install --upgrade setuptools \
  && yum install -y \
          gcc \
          wget \

--- a/scale/pip/docs.txt
+++ b/scale/pip/docs.txt
@@ -6,8 +6,3 @@
 mock>=2.0.0,<2.1.0
 Sphinx>=1.5.3,<1.6.0
 sphinx_rtd_theme>=0.1.9,<1
-
-# Needed for new wiki docs
-mkdocs>0.16.0
-mkdocs-material>=3.0.0
-pymdown-extensions>=6.0


### PR DESCRIPTION
<!--
Thank you for your pull request (PR).  PRs should correlate to an issue that has been created 
with appropriate metadata (assignee(s), label(s), project(s), sprint, etc.).

PR Name format: [GitHub issue #] - [GitHub issue title] 
Example: #1446 - Add contribution guidelines

Note: Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `manage.py test` passes
- [ ] tests are included
- [ ] migrations are included
- [ ] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!-- Please provide a description of the change here. -->

This change allows docs to build properly. Extra requirements were backported to Scale 5.x that aren't compatible with Python 2.7 (not sure how it's working in Scale 7). It seems like Scale 5 docs have been broken since [this commit](https://github.com/ngageoint/scale/commit/cad5f20a6af8a46e7d7ee83b5c689543236548ac#diff-75118d885980acf6bfb5d8ad825827f60e063522e2ffecbef5844e2078719a57).

Confirmed this is working by building a docker image and running it locally, enabling the webserver.